### PR TITLE
Security fixes + DuckDB analytics hybrid

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -9,6 +9,14 @@ general:
 database:
   path: "data/file_activity.db"    # SQLite veritabani dosyasi
 
+analytics:
+  # DuckDB tabanli analitik motor. SQLite dosyasini salt-okunur ATTACH eder,
+  # agir aggregate sorgulari (duplicate raporu, buyume, db_stats) icin kullanir.
+  # Kapatilirsa tum sorgular klasik SQLite yolundan gider.
+  enabled: true
+  memory_limit: "512MB"           # DuckDB bellek siniri
+  threads: 4                      # DuckDB paralel thread sayisi
+
 sources: []
   # Örnek:
   # - name: "Engineering"

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,3 +21,9 @@ apscheduler>=3.10.0
 # Reports
 openpyxl>=3.1.0
 reportlab>=4.0.0
+
+# Analytics (optional): DuckDB for columnar aggregate queries over SQLite.
+# When installed and analytics.enabled=true, heavy reports (duplicates,
+# growth, stats) run through DuckDB via the sqlite_scanner extension.
+# SQLite remains the source of truth; DuckDB only reads.
+duckdb>=1.0.0

--- a/src/archiver/archive_engine.py
+++ b/src/archiver/archive_engine.py
@@ -83,8 +83,9 @@ class ArchiveEngine:
                                 f'Archived to {archive_path} | Policy: {archived_by}',
                                 detected_by='archiver'
                             )
-                        except Exception:
-                            pass
+                        except Exception as e:
+                            logger.warning("Audit event kaydedilemedi %s: %s",
+                                           file_info.get("file_path", "?"), e)
                 else:
                     failed += 1
             except Exception as e:
@@ -144,6 +145,19 @@ class ArchiveEngine:
         dst_dir = os.path.dirname(dst_path)
         os.makedirs(dst_dir, exist_ok=True)
 
+        # 1b. Hedefte yeterli disk alani var mi kontrol et (dosya boyutu + %5 marj)
+        try:
+            required = int(file_info.get("file_size", 0) * 1.05) + 1024
+            free = shutil.disk_usage(dst_dir).free
+            if free < required:
+                logger.error(
+                    "Yetersiz disk alani %s: gerekli=%s, mevcut=%s",
+                    rel_path, format_size(required), format_size(free)
+                )
+                return False
+        except OSError as e:
+            logger.warning("Disk alani kontrolu basarisiz %s: %s", dst_dir, e)
+
         # 2. Kopyala
         shutil.copy2(src_path, dst_path)
 
@@ -169,8 +183,14 @@ class ArchiveEngine:
             src_hash = self._sha256(src_path)
             dst_hash = self._sha256(dst_path)
             if src_hash != dst_hash:
-                # Doğrulama başarısız - hedefi sil
-                os.remove(dst_path)
+                # Doğrulama başarısız - hedefi sil (silme hatasini yut ama logla)
+                try:
+                    os.remove(dst_path)
+                except OSError as e:
+                    logger.error(
+                        "Checksum basarisiz + hedef silinemedi %s: %s",
+                        dst_path, e
+                    )
                 logger.error(t("archive_checksum_fail", path=rel_path))
                 return False
             checksum = src_hash

--- a/src/dashboard/api.py
+++ b/src/dashboard/api.py
@@ -92,10 +92,19 @@ def _get_source(db, source_id: int):
     return src
 
 
-def create_app(db, config):
-    """FastAPI uygulamasini olustur."""
+def create_app(db, config, analytics=None):
+    """FastAPI uygulamasini olustur.
+
+    analytics: Opsiyonel AnalyticsEngine. Verilmezse config.analytics'e gore
+    olusturulur; DuckDB yoksa veya basarisiz olursa `available=False` ile
+    doner ve endpoint'ler SQLite fallback'ine duser.
+    """
+    if analytics is None:
+        from src.storage.analytics import AnalyticsEngine
+        analytics = AnalyticsEngine(db.db_path, config.get("analytics", {}))
 
     app = FastAPI(title="FILE ACTIVITY Dashboard", version="1.0.0")
+    app.state.analytics = analytics
 
     static_dir = os.path.join(os.path.dirname(__file__), "static")
     if os.path.exists(static_dir):
@@ -1077,10 +1086,27 @@ def create_app(db, config):
                                 page: int = Query(1, ge=1, le=10000),
                                 page_size: int = Query(50, ge=1, le=500),
                                 min_size: int = 0):
-        """Kopya dosya raporu - gruplandirmali."""
+        """Kopya dosya raporu - gruplandirmali.
+
+        DuckDB kurulu ve ATTACH basarili ise tek-gecis CTE ile calisir,
+        aksi halde SQLite yoluna duser.
+        """
         from src.utils.size_formatter import format_size
-        result = db.get_duplicate_groups(source_id, min_size=min_size,
-                                          page=page, page_size=page_size)
+        result = None
+        if analytics.available:
+            try:
+                scan_id = db.get_latest_scan_id(source_id, include_running=False)
+                if scan_id:
+                    result = analytics.get_duplicate_groups(
+                        scan_id, min_size, page, page_size
+                    )
+            except Exception as e:
+                logger.warning("DuckDB duplicate sorgusu basarisiz, SQLite fallback: %s", e)
+                result = None
+        if result is None:
+            result = db.get_duplicate_groups(
+                source_id, min_size=min_size, page=page, page_size=page_size
+            )
         # Boyut formatlama
         result["total_waste_size_formatted"] = format_size(result.get("total_waste_size", 0))
         for g in result.get("groups", []):
@@ -1478,8 +1504,14 @@ def create_app(db, config):
         return {
             "status": "ok",
             "time": datetime.now().isoformat(),
-            "database": db.health_check()
+            "database": db.health_check(),
+            "analytics": analytics.health(),
         }
+
+    @app.get("/api/system/analytics")
+    async def analytics_status():
+        """DuckDB analitik motor durumunu dondur."""
+        return analytics.health()
 
     @app.get("/api/db/stats")
     async def db_stats():

--- a/src/dashboard/api.py
+++ b/src/dashboard/api.py
@@ -14,10 +14,10 @@ import threading
 import uuid
 from datetime import datetime, timedelta
 
-from fastapi import FastAPI, HTTPException, Query
+from fastapi import FastAPI, HTTPException, Query, Request
 from fastapi.staticfiles import StaticFiles
 from fastapi.responses import HTMLResponse, FileResponse
-from pydantic import BaseModel
+from pydantic import BaseModel, field_validator
 from typing import Optional, List
 
 # ── Arka plan export kuyrugu ──
@@ -49,6 +49,30 @@ class ScheduleCreate(BaseModel):
     source_id: int
     policy_name: Optional[str] = None
     cron_expression: str
+
+    @field_validator("task_type")
+    @classmethod
+    def _validate_task_type(cls, v: str) -> str:
+        if v not in ("scan", "archive"):
+            raise ValueError("task_type must be 'scan' or 'archive'")
+        return v
+
+    @field_validator("cron_expression")
+    @classmethod
+    def _validate_cron(cls, v: str) -> str:
+        parts = v.strip().split()
+        if len(parts) != 5:
+            raise ValueError("cron_expression must have 5 fields (minute hour day month dow)")
+        try:
+            from apscheduler.triggers.cron import CronTrigger
+            CronTrigger(
+                minute=parts[0], hour=parts[1],
+                day=parts[2], month=parts[3],
+                day_of_week=parts[4],
+            )
+        except Exception as e:
+            raise ValueError(f"invalid cron expression: {e}")
+        return v.strip()
 
 class ArchiveRequest(BaseModel):
     source_id: int
@@ -337,7 +361,8 @@ def create_app(db, config):
         }
 
     @app.get("/api/archive/search")
-    async def archive_search(q: str, extension: Optional[str] = None, page: int = 1):
+    async def archive_search(q: str, extension: Optional[str] = None,
+                              page: int = Query(1, ge=1, le=10000)):
         return db.search_archived_files(q, extension=extension, page=page)
 
     @app.get("/api/archive/stats")
@@ -442,7 +467,8 @@ def create_app(db, config):
     @app.get("/api/drilldown/frequency/{source_id}")
     async def drilldown_frequency(source_id: int, min_days: int = 0,
                                    max_days: Optional[int] = None,
-                                   page: int = 1, limit: int = 100):
+                                   page: int = Query(1, ge=1, le=10000),
+                                   limit: int = Query(100, ge=1, le=500)):
         src = _get_source(db, source_id)
         scan_id = db.get_latest_scan_id(src.id, include_running=True)
         if not scan_id:
@@ -455,7 +481,8 @@ def create_app(db, config):
 
     @app.get("/api/drilldown/type/{source_id}")
     async def drilldown_type(source_id: int, extension: str = "",
-                              page: int = 1, limit: int = 100):
+                              page: int = Query(1, ge=1, le=10000),
+                              limit: int = Query(100, ge=1, le=500)):
         src = _get_source(db, source_id)
         scan_id = db.get_latest_scan_id(src.id, include_running=True)
         if not scan_id:
@@ -469,7 +496,8 @@ def create_app(db, config):
     @app.get("/api/drilldown/size/{source_id}")
     async def drilldown_size(source_id: int, min_bytes: int = 0,
                               max_bytes: Optional[int] = None,
-                              page: int = 1, limit: int = 100):
+                              page: int = Query(1, ge=1, le=10000),
+                              limit: int = Query(100, ge=1, le=500)):
         src = _get_source(db, source_id)
         scan_id = db.get_latest_scan_id(src.id, include_running=True)
         if not scan_id:
@@ -482,7 +510,8 @@ def create_app(db, config):
 
     @app.get("/api/drilldown/owner/{source_id}")
     async def drilldown_owner(source_id: int, owner: str = "",
-                               page: int = 1, limit: int = 100):
+                               page: int = Query(1, ge=1, le=10000),
+                               limit: int = Query(100, ge=1, le=500)):
         src = _get_source(db, source_id)
         scan_id = db.get_latest_scan_id(src.id, include_running=True)
         if not scan_id:
@@ -754,7 +783,9 @@ def create_app(db, config):
 
     @app.get("/api/audit/events")
     async def audit_events(source_id: int = None, event_type: str = None,
-                           username: str = None, days: int = 7, page: int = 1):
+                           username: str = None,
+                           days: int = Query(7, ge=1, le=365),
+                           page: int = Query(1, ge=1, le=10000)):
         return db.get_audit_events(source_id, event_type, username, days, page)
 
     @app.get("/api/audit/summary")
@@ -792,7 +823,9 @@ def create_app(db, config):
         return analyzer.get_report()
 
     @app.get("/api/reports/mit-naming/{source_id}/files")
-    async def mit_naming_files(source_id: int, code: str = "R1", page: int = 1, page_size: int = 100):
+    async def mit_naming_files(source_id: int, code: str = "R1",
+                                page: int = Query(1, ge=1, le=10000),
+                                page_size: int = Query(100, ge=1, le=500)):
         """MIT ihlal koduna gore dosya listesi (R1,R2,R3,R4,B1,B2,B3,B4,B5,B6)."""
         import re as re_mod
         from src.utils.size_formatter import format_size
@@ -902,7 +935,8 @@ def create_app(db, config):
 
     @app.get("/api/insights/{source_id}/files")
     async def insight_files(source_id: int, insight_type: str = "stale_1year",
-                            page: int = 1, page_size: int = 100):
+                            page: int = Query(1, ge=1, le=10000),
+                            page_size: int = Query(100, ge=1, le=500)):
         """AI insight tipine gore dosya listesi."""
         from src.utils.size_formatter import format_size
         from src.analyzer.ai_insights import get_insight_files
@@ -1039,8 +1073,10 @@ def create_app(db, config):
     # --- DUPLIKE RAPOR ve SECICI ARSIV ---
 
     @app.get("/api/reports/duplicates/{source_id}")
-    async def duplicate_report(source_id: int, page: int = 1,
-                                page_size: int = 50, min_size: int = 0):
+    async def duplicate_report(source_id: int,
+                                page: int = Query(1, ge=1, le=10000),
+                                page_size: int = Query(50, ge=1, le=500),
+                                min_size: int = 0):
         """Kopya dosya raporu - gruplandirmali."""
         from src.utils.size_formatter import format_size
         result = db.get_duplicate_groups(source_id, min_size=min_size,
@@ -1378,8 +1414,9 @@ def create_app(db, config):
             return result
 
     @app.get("/api/archive/browse")
-    async def browse_archived(source_id: int = None, page: int = 1,
-                               page_size: int = 50):
+    async def browse_archived(source_id: int = None,
+                               page: int = Query(1, ge=1, le=10000),
+                               page_size: int = Query(50, ge=1, le=500)):
         """Arsivlenmis dosyalara goz at (geri yukleme UI icin)."""
         from src.utils.size_formatter import format_size
         result = db.search_archived_files("", page=page, page_size=page_size)
@@ -1390,8 +1427,10 @@ def create_app(db, config):
     # --- ARSIV GECMISI ---
 
     @app.get("/api/archive/history")
-    async def archive_history(source_id: int = None, page: int = 1,
-                              page_size: int = 20, date_from: str = None,
+    async def archive_history(source_id: int = None,
+                              page: int = Query(1, ge=1, le=10000),
+                              page_size: int = Query(20, ge=1, le=500),
+                              date_from: str = None,
                               date_to: str = None, op_type: str = None):
         """Sayfalanmis arsiv islem gecmisi."""
         from src.utils.size_formatter import format_size
@@ -1402,7 +1441,9 @@ def create_app(db, config):
         return result
 
     @app.get("/api/archive/operations/{op_id}/files")
-    async def operation_files(op_id: int, page: int = 1, page_size: int = 100):
+    async def operation_files(op_id: int,
+                               page: int = Query(1, ge=1, le=10000),
+                               page_size: int = Query(100, ge=1, le=500)):
         """Arsiv islemindeki dosyalari sayfalanmis getir."""
         from src.utils.size_formatter import format_size
         result = db.get_archive_operation_files(op_id, page, page_size)
@@ -1413,20 +1454,21 @@ def create_app(db, config):
     # --- SYSTEM API ---
 
     @app.post("/api/system/open-folder")
-    async def open_folder(request):
+    async def open_folder(request: Request):
         """Dizini Windows Explorer'da ac."""
         import subprocess
         body = await request.json()
         folder = body.get("path", "")
-        if not folder:
+        if not folder or not isinstance(folder, str):
             raise HTTPException(400, "path gerekli")
-        # Guvenlik: sadece mevcut dizinleri ac
-        folder = os.path.normpath(folder)
+        # Guvenlik: normalize + gercek yol cozumleme (symlink/junction eskape koruma)
+        folder = os.path.realpath(os.path.normpath(folder))
         if os.path.isdir(folder):
-            subprocess.Popen(f'explorer "{folder}"', shell=True)
+            # shell=False ile argv listesi kullanilarak komut enjeksiyonu onlenir
+            subprocess.Popen(["explorer", folder], shell=False)
             return {"success": True, "path": folder}
         elif os.path.isfile(folder):
-            subprocess.Popen(f'explorer /select,"{folder}"', shell=True)
+            subprocess.Popen(["explorer", "/select,", folder], shell=False)
             return {"success": True, "path": folder}
         else:
             raise HTTPException(404, f"Dizin bulunamadi: {folder}")

--- a/src/dashboard/api.py
+++ b/src/dashboard/api.py
@@ -1216,7 +1216,14 @@ def create_app(db, config, analytics=None):
     @app.get("/api/growth/{source_id}")
     async def growth_stats(source_id: int):
         """Yillik/aylik/gunluk buyume istatistikleri."""
-        stats = db.get_growth_stats(source_id)
+        stats = None
+        if analytics.available:
+            try:
+                stats = analytics.get_growth_stats(source_id)
+            except Exception as e:
+                logger.warning("DuckDB growth sorgusu basarisiz, SQLite fallback: %s", e)
+        if stats is None:
+            stats = db.get_growth_stats(source_id)
         creators = db.get_top_file_creators(source_id)
         stats["top_creators"] = creators
         return stats
@@ -1536,6 +1543,15 @@ def create_app(db, config, analytics=None):
     @app.get("/api/db/stats")
     async def db_stats():
         """Veritabani istatistikleri."""
+        if analytics.available:
+            try:
+                wal_path = db.db_path + "-wal"
+                shm_path = db.db_path + "-shm"
+                tables = ["scanned_files", "scan_runs", "archived_files",
+                          "user_access_logs", "sources"]
+                return analytics.get_db_stats(tables, db.db_path, wal_path, shm_path)
+            except Exception as e:
+                logger.warning("DuckDB db_stats basarisiz, SQLite fallback: %s", e)
         return db.get_db_stats()
 
     @app.post("/api/db/cleanup")

--- a/src/dashboard/api.py
+++ b/src/dashboard/api.py
@@ -473,6 +473,22 @@ def create_app(db, config, analytics=None):
 
     # --- DRILL-DOWN API ---
 
+    def _run_drilldown(duckdb_fn, sqlite_fn):
+        """DuckDB varsa oradan calistir, yoksa SQLite'a dus.
+
+        duckdb_fn: AnalyticsEngine uzerinde cagrilacak bound method
+        sqlite_fn: db (Database) uzerinde cagrilacak bound method
+        Her ikisi de (*args) -> {"total": int, "files": list} doner.
+        """
+        def call(*args):
+            if analytics.available:
+                try:
+                    return duckdb_fn(*args)
+                except Exception as e:
+                    logger.warning("DuckDB drilldown basarisiz, SQLite fallback: %s", e)
+            return sqlite_fn(*args)
+        return call
+
     @app.get("/api/drilldown/frequency/{source_id}")
     async def drilldown_frequency(source_id: int, min_days: int = 0,
                                    max_days: Optional[int] = None,
@@ -483,7 +499,8 @@ def create_app(db, config, analytics=None):
         if not scan_id:
             raise HTTPException(400, "Tarama verisi bulunamadi")
         offset = (page - 1) * limit
-        result = db.get_files_by_frequency(src.id, scan_id, min_days, max_days, limit, offset)
+        run = _run_drilldown(analytics.get_files_by_frequency, db.get_files_by_frequency)
+        result = run(src.id, scan_id, min_days, max_days, limit, offset)
         result["page"] = page
         result["limit"] = limit
         return result
@@ -497,7 +514,8 @@ def create_app(db, config, analytics=None):
         if not scan_id:
             raise HTTPException(400, "Tarama verisi bulunamadi")
         offset = (page - 1) * limit
-        result = db.get_files_by_extension(src.id, scan_id, extension, limit, offset)
+        run = _run_drilldown(analytics.get_files_by_extension, db.get_files_by_extension)
+        result = run(src.id, scan_id, extension, limit, offset)
         result["page"] = page
         result["limit"] = limit
         return result
@@ -512,7 +530,8 @@ def create_app(db, config, analytics=None):
         if not scan_id:
             raise HTTPException(400, "Tarama verisi bulunamadi")
         offset = (page - 1) * limit
-        result = db.get_files_by_size_range(src.id, scan_id, min_bytes, max_bytes, limit, offset)
+        run = _run_drilldown(analytics.get_files_by_size_range, db.get_files_by_size_range)
+        result = run(src.id, scan_id, min_bytes, max_bytes, limit, offset)
         result["page"] = page
         result["limit"] = limit
         return result
@@ -526,7 +545,8 @@ def create_app(db, config, analytics=None):
         if not scan_id:
             raise HTTPException(400, "Tarama verisi bulunamadi")
         offset = (page - 1) * limit
-        result = db.get_files_by_owner(src.id, scan_id, owner, limit, offset)
+        run = _run_drilldown(analytics.get_files_by_owner, db.get_files_by_owner)
+        result = run(src.id, scan_id, owner, limit, offset)
         result["page"] = page
         result["limit"] = limit
         return result

--- a/src/scanner/file_watcher.py
+++ b/src/scanner/file_watcher.py
@@ -18,12 +18,16 @@ from src.utils.size_formatter import format_size
 logger = logging.getLogger("file_activity.watcher")
 
 _watchers = {}  # source_id -> FileWatcher
+_watchers_lock = threading.Lock()
 
 
 def get_watcher_status(source_id: int = None) -> dict:
-    if source_id and source_id in _watchers:
-        return _watchers[source_id].get_status()
-    return {sid: w.get_status() for sid, w in _watchers.items()} if not source_id else {"status": "inactive"}
+    with _watchers_lock:
+        if source_id and source_id in _watchers:
+            return _watchers[source_id].get_status()
+        if not source_id:
+            return {sid: w.get_status() for sid, w in _watchers.items()}
+        return {"status": "inactive"}
 
 
 class FileWatcher:
@@ -34,6 +38,7 @@ class FileWatcher:
         self.interval = interval  # seconds between checks
         self._running = False
         self._thread = None
+        self._stats_lock = threading.Lock()
         self.stats = {
             "status": "idle",
             "last_check": None,
@@ -51,29 +56,39 @@ class FileWatcher:
         self._running = True
         self._thread = threading.Thread(target=self._watch_loop, daemon=True)
         self._thread.start()
-        _watchers[self.source_id] = self
+        with _watchers_lock:
+            _watchers[self.source_id] = self
         logger.info("File watcher started for source %d (interval: %ds)", self.source_id, self.interval)
 
     def stop(self):
         self._running = False
-        if self.source_id in _watchers:
-            del _watchers[self.source_id]
+        with _watchers_lock:
+            _watchers.pop(self.source_id, None)
         logger.info("File watcher stopped for source %d", self.source_id)
 
     def get_status(self):
-        return {**self.stats, "running": self._running, "interval": self.interval}
+        with self._stats_lock:
+            snapshot = dict(self.stats)
+            # last_changes liste referansi kopyalanir (okuyucu modify etmesin)
+            snapshot["last_changes"] = list(snapshot.get("last_changes", []))
+        snapshot["running"] = self._running
+        snapshot["interval"] = self.interval
+        return snapshot
 
     def _watch_loop(self):
         while self._running:
             try:
-                self.stats["status"] = "checking"
+                with self._stats_lock:
+                    self.stats["status"] = "checking"
                 self._check_changes()
-                self.stats["status"] = "waiting"
-                self.stats["last_check"] = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
-                self.stats["checks_completed"] += 1
+                with self._stats_lock:
+                    self.stats["status"] = "waiting"
+                    self.stats["last_check"] = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+                    self.stats["checks_completed"] += 1
             except Exception as e:
                 logger.error("Watcher error source %d: %s", self.source_id, e)
-                self.stats["status"] = "error"
+                with self._stats_lock:
+                    self.stats["status"] = "error"
 
             # Sleep in small increments so stop() is responsive
             for _ in range(self.interval):
@@ -112,10 +127,11 @@ class FileWatcher:
             "size": size,
             "time": datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
         }
-        changes = self.stats["last_changes"]
-        changes.append(entry)
-        if len(changes) > 50:
-            self.stats["last_changes"] = changes[-50:]
+        with self._stats_lock:
+            changes = self.stats["last_changes"]
+            changes.append(entry)
+            if len(changes) > 50:
+                self.stats["last_changes"] = changes[-50:]
 
     def _record_audit(self, event_type: str, fpath: str, owner: str = None):
         """Record file audit event in database."""
@@ -196,10 +212,11 @@ class FileWatcher:
             except Exception as e:
                 logger.debug("Watcher delete error %s: %s", dpath[:80], e)
 
-        self.stats["new_files"] += new_count
-        self.stats["modified_files"] += modified_count
-        self.stats["deleted_files"] += deleted_count
-        self.stats["total_changes"] += new_count + modified_count + deleted_count
+        with self._stats_lock:
+            self.stats["new_files"] += new_count
+            self.stats["modified_files"] += modified_count
+            self.stats["deleted_files"] += deleted_count
+            self.stats["total_changes"] += new_count + modified_count + deleted_count
 
         if new_count + modified_count + deleted_count > 0:
             logger.info("Watcher source %d: +%d new, ~%d modified, -%d deleted",

--- a/src/storage/analytics.py
+++ b/src/storage/analytics.py
@@ -292,6 +292,115 @@ class AnalyticsEngine:
         return self._drilldown(where, params, "last_access_time ASC", limit, offset)
 
     # ──────────────────────────────────────────────
+    # Buyume ve db istatistikleri
+    # ──────────────────────────────────────────────
+
+    def get_growth_stats(self, source_id: int) -> dict:
+        """Yillik/aylik/gunluk buyume + toplam tarama sayisi.
+
+        `started_at` SQLite attach'inda VARCHAR olarak gelir, bu yuzden
+        SQLite'in `strftime('%Y',...)` davranisi yerine ISO string
+        substring kullaniyoruz (ayni sonuc, tip donusumu gerekmez).
+        """
+        base_where = "source_id = ? AND status = 'completed'"
+        with self._cursor() as cur:
+            yearly = cur.execute(
+                f"""
+                SELECT substr(started_at, 1, 4) AS year,
+                       MAX(total_files) AS total_files,
+                       MAX(total_size) AS total_size
+                FROM sqlite_db.scan_runs
+                WHERE {base_where}
+                GROUP BY year
+                ORDER BY year
+                """,
+                [source_id],
+            ).fetchall()
+
+            monthly = cur.execute(
+                f"""
+                SELECT substr(started_at, 1, 7) AS month,
+                       MAX(total_files) AS total_files,
+                       MAX(total_size) AS total_size
+                FROM sqlite_db.scan_runs
+                WHERE {base_where}
+                GROUP BY month
+                ORDER BY month DESC
+                LIMIT 24
+                """,
+                [source_id],
+            ).fetchall()
+
+            daily = cur.execute(
+                f"""
+                SELECT substr(started_at, 1, 10) AS day,
+                       MAX(total_files) AS total_files,
+                       MAX(total_size) AS total_size
+                FROM sqlite_db.scan_runs
+                WHERE {base_where}
+                GROUP BY day
+                ORDER BY day DESC
+                LIMIT 30
+                """,
+                [source_id],
+            ).fetchall()
+
+            total_scans = int(cur.execute(
+                f"SELECT COUNT(*) FROM sqlite_db.scan_runs WHERE {base_where}",
+                [source_id],
+            ).fetchone()[0] or 0)
+
+        def _rows(rs, key):
+            return [
+                {key: r[0], "total_files": int(r[1] or 0), "total_size": int(r[2] or 0)}
+                for r in rs
+            ]
+
+        return {
+            "yearly": _rows(yearly, "year"),
+            "monthly": list(reversed(_rows(monthly, "month"))),
+            "daily": list(reversed(_rows(daily, "day"))),
+            "total_scans": total_scans,
+            "engine": "duckdb",
+        }
+
+    def get_db_stats(self, tables: list, db_path: str,
+                      wal_path: str, shm_path: str) -> dict:
+        """Tablo satir sayilari + dosya boyutlari. Disk boyutlari cagiran
+        tarafindan verilir (DuckDB SQLite dosyasinin mtime'ini sormaz)."""
+        import os
+        stats: dict = {}
+        try:
+            stats["db_size"] = os.path.getsize(db_path) if os.path.exists(db_path) else 0
+            stats["wal_size"] = os.path.getsize(wal_path) if os.path.exists(wal_path) else 0
+            shm = os.path.getsize(shm_path) if os.path.exists(shm_path) else 0
+            stats["total_disk"] = stats["db_size"] + stats["wal_size"] + shm
+
+            with self._cursor() as cur:
+                # Tum tablo COUNT'lari tek UNION ALL sorgusunda
+                union_parts = []
+                for t in tables:
+                    # sqlite_db.<table> semasi; kolon isimleri quote edilmez
+                    union_parts.append(
+                        f"SELECT '{t}' AS table_name, COUNT(*) AS cnt "
+                        f"FROM sqlite_db.{t}"
+                    )
+                union_sql = " UNION ALL ".join(union_parts)
+                for row in cur.execute(union_sql).fetchall():
+                    stats[f"{row[0]}_count"] = int(row[1] or 0)
+
+                # En eski/yeni tarama
+                row = cur.execute(
+                    "SELECT MIN(started_at), MAX(started_at) FROM sqlite_db.scan_runs"
+                ).fetchone()
+                stats["oldest_scan"] = row[0]
+                stats["newest_scan"] = row[1]
+            stats["engine"] = "duckdb"
+        except Exception as e:
+            return {"error": str(e)}
+        return stats
+
+    # ──────────────────────────────────────────────
     # Saglik / tanilama
     # ──────────────────────────────────────────────
 

--- a/src/storage/analytics.py
+++ b/src/storage/analytics.py
@@ -207,6 +207,91 @@ class AnalyticsEngine:
         }
 
     # ──────────────────────────────────────────────
+    # Drill-down sorgulari (tek-gecis total + sayfa)
+    # ──────────────────────────────────────────────
+
+    def _drilldown(self, where_sql: str, params: list, order_by: str,
+                    limit: int, offset: int) -> dict:
+        """Tek WINDOW-COUNT sorgusuyla hem toplam hem sayfayi doner.
+
+        SQLite yolunda iki ayri COUNT + SELECT kullanilirken burada
+        `COUNT(*) OVER ()` ile columnar tarama tek seferde yeterli olur.
+        """
+        sql = f"""
+            SELECT *, COUNT(*) OVER () AS _total
+            FROM sqlite_db.scanned_files
+            WHERE {where_sql}
+            ORDER BY {order_by}
+            LIMIT ? OFFSET ?
+        """
+        with self._cursor() as cur:
+            res = cur.execute(sql, list(params) + [limit, offset])
+            cols = [d[0] for d in res.description]
+            rows = res.fetchall()
+
+        if not rows:
+            # Dosya yok; toplami yine de ayri kucuk bir COUNT ile al
+            count_sql = f"SELECT COUNT(*) FROM sqlite_db.scanned_files WHERE {where_sql}"
+            with self._cursor() as cur:
+                total = int(cur.execute(count_sql, list(params)).fetchone()[0] or 0)
+            return {"total": total, "files": [], "engine": "duckdb"}
+
+        total_idx = cols.index("_total")
+        total = int(rows[0][total_idx] or 0)
+        keep_cols = [c for c in cols if c != "_total"]
+        files = []
+        for row in rows:
+            rec = {cols[i]: row[i] for i in range(len(cols)) if cols[i] != "_total"}
+            files.append(rec)
+        return {"total": total, "files": files, "engine": "duckdb"}
+
+    def get_files_by_owner(self, source_id: int, scan_id: int, owner: str,
+                            limit: int, offset: int) -> dict:
+        is_unknown = owner in ("Bilinmiyor", None, "")
+        if is_unknown:
+            where = "source_id = ? AND scan_id = ? AND owner IS NULL"
+            params = [source_id, scan_id]
+        else:
+            where = "source_id = ? AND scan_id = ? AND owner = ?"
+            params = [source_id, scan_id, owner]
+        return self._drilldown(where, params, "file_size DESC", limit, offset)
+
+    def get_files_by_extension(self, source_id: int, scan_id: int,
+                                extension: str, limit: int, offset: int) -> dict:
+        ext = (extension or "").lower().lstrip(".")
+        is_none = ext in ("uzantisiz", "")
+        if is_none:
+            where = "source_id = ? AND scan_id = ? AND extension IS NULL"
+            params = [source_id, scan_id]
+        else:
+            where = "source_id = ? AND scan_id = ? AND extension = ?"
+            params = [source_id, scan_id, ext]
+        return self._drilldown(where, params, "file_size DESC", limit, offset)
+
+    def get_files_by_size_range(self, source_id: int, scan_id: int,
+                                 min_bytes: int, max_bytes: Optional[int],
+                                 limit: int, offset: int) -> dict:
+        where = "source_id = ? AND scan_id = ? AND file_size >= ?"
+        params: list = [source_id, scan_id, min_bytes]
+        if max_bytes is not None:
+            where += " AND file_size < ?"
+            params.append(max_bytes)
+        return self._drilldown(where, params, "file_size DESC", limit, offset)
+
+    def get_files_by_frequency(self, source_id: int, scan_id: int,
+                                min_days: int, max_days: Optional[int],
+                                limit: int, offset: int) -> dict:
+        from datetime import datetime, timedelta
+        where = ("source_id = ? AND scan_id = ? "
+                 "AND last_access_time IS NOT NULL AND last_access_time <= ?")
+        params: list = [source_id, scan_id,
+                        (datetime.now() - timedelta(days=min_days)).strftime('%Y-%m-%d')]
+        if max_days is not None:
+            where += " AND last_access_time > ?"
+            params.append((datetime.now() - timedelta(days=max_days)).strftime('%Y-%m-%d'))
+        return self._drilldown(where, params, "last_access_time ASC", limit, offset)
+
+    # ──────────────────────────────────────────────
     # Saglik / tanilama
     # ──────────────────────────────────────────────
 

--- a/src/storage/analytics.py
+++ b/src/storage/analytics.py
@@ -1,0 +1,234 @@
+"""DuckDB tabanli analitik motor.
+
+SQLite veritabanini salt-okunur olarak ATTACH eder ve agir aggregate
+sorgulari (duplicate grup tespiti, buyume istatistikleri, db ozet) icin
+kolon tabanli motor saglar. SQLite kaynak-gercek; DuckDB sadece okur.
+
+Kullanim:
+    engine = AnalyticsEngine(db_path, config.get("analytics", {}))
+    if engine.available:
+        groups = engine.get_duplicate_groups(scan_id, min_size, page, page_size)
+
+DuckDB kurulu degilse veya ATTACH basarisiz olursa `available=False`
+doner ve cagiran kod SQLite fallback'ine dusebilir.
+"""
+
+import logging
+import threading
+from contextlib import contextmanager
+from typing import Optional
+
+logger = logging.getLogger("file_activity.analytics")
+
+try:
+    import duckdb  # type: ignore
+    _HAVE_DUCKDB = True
+except ImportError:
+    duckdb = None
+    _HAVE_DUCKDB = False
+
+
+class AnalyticsEngine:
+    """DuckDB uzerinden SQLite'a salt-okunur analitik koprusu."""
+
+    def __init__(self, db_path: str, config: dict):
+        self.db_path = db_path
+        self.enabled = bool(config.get("enabled", True))
+        self.memory_limit = config.get("memory_limit", "512MB")
+        self.threads = int(config.get("threads", 4))
+        self._lock = threading.Lock()
+        self._conn = None
+        self.available = False
+        self._init_error: Optional[str] = None
+
+        if not _HAVE_DUCKDB:
+            self._init_error = "duckdb paketi yuklenmemis"
+            logger.info("AnalyticsEngine devre disi: %s", self._init_error)
+            return
+        if not self.enabled:
+            self._init_error = "config.analytics.enabled=false"
+            logger.info("AnalyticsEngine devre disi: %s", self._init_error)
+            return
+
+        try:
+            self._open()
+            self.available = True
+            logger.info(
+                "AnalyticsEngine hazir (DuckDB %s, memory=%s, threads=%d)",
+                duckdb.__version__, self.memory_limit, self.threads
+            )
+        except Exception as e:
+            self._init_error = str(e)
+            logger.warning("AnalyticsEngine baslatilamadi, SQLite fallback kullanilacak: %s", e)
+
+    def _open(self):
+        """DuckDB baglantisini ac, SQLite'i salt-okunur ATTACH et."""
+        conn = duckdb.connect(database=":memory:")
+        conn.execute(f"SET memory_limit='{self.memory_limit}'")
+        conn.execute(f"SET threads={self.threads}")
+
+        # sqlite_scanner extension'i yukle (duckdb paketiyle beraber gelir)
+        try:
+            conn.execute("INSTALL sqlite")
+        except Exception:
+            # Offline ortamda zaten bundled olabilir; ignore
+            pass
+        conn.execute("LOAD sqlite")
+
+        # SQLite'i salt-okunur attach et. Bazi surumlerde parametre adi
+        # READ_ONLY, digerlerinde read_only olabilir; ikincide fallback dene.
+        attach_sql_variants = [
+            f"ATTACH '{self.db_path}' AS sqlite_db (TYPE SQLITE, READ_ONLY)",
+            f"ATTACH '{self.db_path}' AS sqlite_db (TYPE SQLITE)",
+        ]
+        last_err = None
+        for sql in attach_sql_variants:
+            try:
+                conn.execute(sql)
+                last_err = None
+                break
+            except Exception as e:
+                last_err = e
+        if last_err is not None:
+            conn.close()
+            raise last_err
+
+        self._conn = conn
+
+    @contextmanager
+    def _cursor(self):
+        """Thread-safe cursor. DuckDB tek baglanti + lock ile yeterli;
+        ATTACH/schema durumunu yeniden kurmak pahali oldugu icin tek baglanti
+        tutulur."""
+        if not self.available or self._conn is None:
+            raise RuntimeError("AnalyticsEngine kullanilamaz durumda")
+        with self._lock:
+            yield self._conn
+
+    def close(self):
+        if self._conn is not None:
+            try:
+                self._conn.close()
+            except Exception:
+                pass
+            self._conn = None
+        self.available = False
+
+    # ──────────────────────────────────────────────
+    # Duplicate raporu (DuckDB tek-gecis CTE)
+    # ──────────────────────────────────────────────
+
+    def get_duplicate_groups(self, scan_id: int, min_size: int,
+                              page: int, page_size: int) -> dict:
+        """Kopya dosya gruplarini tek CTE ile hesapla.
+
+        SQLite uygulamasinda 3 ayri GROUP BY + her grup icin ekstra sorgu
+        calisirken, burada tek agregasyon + tek detay sorgusu kullanilir.
+        """
+        offset = (page - 1) * page_size
+
+        with self._cursor() as cur:
+            # Tek CTE ile totaller ve sayfa birlikte alinir
+            summary = cur.execute(
+                """
+                WITH dup AS (
+                    SELECT file_name, file_size, COUNT(*) AS cnt,
+                           (COUNT(*) - 1) * file_size AS waste_size
+                    FROM sqlite_db.scanned_files
+                    WHERE scan_id = ? AND file_size > ?
+                    GROUP BY file_name, file_size
+                    HAVING COUNT(*) > 1
+                )
+                SELECT
+                    (SELECT COUNT(*) FROM dup) AS total_groups,
+                    (SELECT COALESCE(SUM(cnt), 0) FROM dup) AS total_files,
+                    (SELECT COALESCE(SUM(waste_size), 0) FROM dup) AS total_waste
+                """,
+                [scan_id, min_size],
+            ).fetchone()
+            total_groups = int(summary[0] or 0)
+            total_files = int(summary[1] or 0)
+            total_waste = int(summary[2] or 0)
+
+            groups_rows = cur.execute(
+                """
+                SELECT file_name, file_size, COUNT(*) AS cnt,
+                       (COUNT(*) - 1) * file_size AS waste_size
+                FROM sqlite_db.scanned_files
+                WHERE scan_id = ? AND file_size > ?
+                GROUP BY file_name, file_size
+                HAVING COUNT(*) > 1
+                ORDER BY waste_size DESC
+                LIMIT ? OFFSET ?
+                """,
+                [scan_id, min_size, page_size, offset],
+            ).fetchall()
+
+            groups = []
+            for g in groups_rows:
+                file_name, file_size, cnt, waste_size = g
+                files_rows = cur.execute(
+                    """
+                    SELECT id, file_path, relative_path, owner,
+                           last_access_time, last_modify_time
+                    FROM sqlite_db.scanned_files
+                    WHERE scan_id = ? AND file_name = ? AND file_size = ?
+                    ORDER BY last_modify_time DESC
+                    """,
+                    [scan_id, file_name, file_size],
+                ).fetchall()
+                files = [
+                    {
+                        "id": r[0], "file_path": r[1], "relative_path": r[2],
+                        "owner": r[3], "last_access_time": r[4],
+                        "last_modify_time": r[5],
+                    }
+                    for r in files_rows
+                ]
+                groups.append({
+                    "file_name": file_name,
+                    "file_size": int(file_size or 0),
+                    "count": int(cnt),
+                    "waste_size": int(waste_size or 0),
+                    "files": files,
+                })
+
+        total_pages = max(1, -(-total_groups // page_size))
+        return {
+            "total_groups": total_groups,
+            "total_waste_size": total_waste,
+            "total_files": total_files,
+            "groups": groups,
+            "page": page,
+            "page_size": page_size,
+            "total_pages": total_pages,
+            "scan_id": scan_id,
+            "engine": "duckdb",
+        }
+
+    # ──────────────────────────────────────────────
+    # Saglik / tanilama
+    # ──────────────────────────────────────────────
+
+    def health(self) -> dict:
+        info = {
+            "available": self.available,
+            "duckdb_installed": _HAVE_DUCKDB,
+            "enabled_config": self.enabled,
+            "memory_limit": self.memory_limit,
+            "threads": self.threads,
+        }
+        if _HAVE_DUCKDB:
+            info["duckdb_version"] = duckdb.__version__
+        if self._init_error:
+            info["init_error"] = self._init_error
+        if self.available:
+            try:
+                with self._cursor() as cur:
+                    row = cur.execute(
+                        "SELECT COUNT(*) FROM sqlite_db.scanned_files"
+                    ).fetchone()
+                    info["scanned_files_rows"] = int(row[0] or 0)
+            except Exception as e:
+                info["probe_error"] = str(e)
+        return info

--- a/src/storage/database.py
+++ b/src/storage/database.py
@@ -1614,31 +1614,28 @@ class Database:
                 scan_id = row["id"]
 
         with self.get_cursor() as cur:
-            # Toplam grup sayisi
+            # Tek CTE ile ozetleri (toplam grup, toplam israf, toplam dosya)
+            # ve sayfalanmis gruplari iki ayri sorguda tek aggregate uzerinden
+            # alir. Onceki kodda ayni GROUP BY uc kere calisiyordu; buyuk
+            # tarama setlerinde bariz yavaslamaya yol aciyordu.
             cur.execute("""
-                SELECT COUNT(*) as cnt FROM (
-                    SELECT file_name, file_size
+                WITH dup AS (
+                    SELECT file_name, file_size, COUNT(*) AS cnt
                     FROM scanned_files
-                    WHERE scan_id=? AND file_size > ?
+                    WHERE scan_id = ? AND file_size > ?
                     GROUP BY file_name, file_size
                     HAVING COUNT(*) > 1
                 )
+                SELECT
+                    COUNT(*) AS total_groups,
+                    COALESCE(SUM(cnt), 0) AS total_files,
+                    COALESCE(SUM((cnt - 1) * file_size), 0) AS total_waste
+                FROM dup
             """, (scan_id, min_size))
-            total_groups = cur.fetchone()["cnt"]
-
-            # Toplam israf
-            cur.execute("""
-                SELECT COALESCE(SUM((cnt - 1) * file_size), 0) as total_waste,
-                       COALESCE(SUM(cnt), 0) as total_files
-                FROM (
-                    SELECT file_name, file_size, COUNT(*) as cnt
-                    FROM scanned_files
-                    WHERE scan_id=? AND file_size > ?
-                    GROUP BY file_name, file_size
-                    HAVING COUNT(*) > 1
-                )
-            """, (scan_id, min_size))
-            waste_row = cur.fetchone()
+            summary = cur.fetchone()
+            total_groups = summary["total_groups"]
+            waste_row = {"total_waste": summary["total_waste"],
+                         "total_files": summary["total_files"]}
 
             # Sayfalanmis gruplar (en cok israf eden grup once)
             cur.execute("""


### PR DESCRIPTION
## Summary

Two-part change set: a security/robustness pass on existing code plus a new
DuckDB-backed analytics engine that keeps SQLite as the source of truth and
routes heavy aggregate reports through a columnar engine.

### 1. Security & robustness (`75c0ef0`)
- **Shell injection** in `/api/system/open-folder` — the endpoint ran
  `subprocess.Popen(f'explorer "{folder}"', shell=True)` with user-supplied
  path. Now uses an argv list with `shell=False` and `realpath` to block
  symlink/junction escape.
- **Cron + task_type validation** added via Pydantic `field_validator` on
  `ScheduleCreate` so invalid expressions fail at the API boundary instead of
  silently at scheduler startup.
- **Pagination bounds** (`Query(ge=1, le=...)`) on archive, drilldown, audit,
  insight, and operation endpoints to prevent DoS via huge values.
- **Pre-copy disk-space check** in `ArchiveEngine` with 5% margin; avoids
  partial copies when destination fills mid-operation. Checksum-failure
  cleanup also now logs `os.remove` errors instead of propagating.
- **Thread safety**: `FileWatcher.stats` dict and the global `_watchers`
  registry are now protected by locks; `get_status` returns a consistent
  snapshot.
- **Silent failures**: replaced bare `except Exception: pass` on audit-event
  insert with a logged warning.

### 2. DuckDB analytics hybrid (`a3ea965`, `b0221c2`, `1d9eb96`)
New `src/storage/analytics.py` opens an in-memory DuckDB, loads the `sqlite`
extension, and `ATTACH`es the SQLite file **read-only**. If `duckdb` is not
installed or `ATTACH` fails, `available=False` and every caller falls back to
the SQLite path — so nothing breaks for environments without the dep.

Reports wired through DuckDB with SQLite fallback:
- `get_duplicate_groups` → single CTE (was 3 separate aggregates).
- `get_files_by_frequency/type/size/owner` → single scan with
  `COUNT(*) OVER ()` instead of the COUNT-then-SELECT two-pass.
- `get_growth_stats` → yearly/monthly/daily aggregates in one DuckDB pass
  (uses `substr` on ISO strings to stay compatible with VARCHAR-typed
  `started_at` from the SQLite attach).
- `get_db_stats` → per-table row counts via a single `UNION ALL`.

Also tightened the SQLite-side `get_duplicate_groups` to a single CTE so the
fallback path is faster too (benefit even when DuckDB is absent).

Config and observability:
- `config.yaml` adds `analytics: { enabled, memory_limit, threads }`.
- `requirements.txt` adds `duckdb>=1.0.0` (optional).
- New `/api/system/analytics` endpoint + `/api/system/health` now includes
  analytics status.

## Test plan
- [x] `py_compile` on all edited modules
- [x] `AnalyticsEngine` init without duckdb installed → `available=False`
- [x] `AnalyticsEngine` init with duckdb + fixture SQLite → `ATTACH` ok,
  `scanned_files_rows` probe returns correct count
- [x] Duplicate report (DuckDB path) — totals + per-group files match SQLite
  output on a 6-row fixture
- [x] Drill-down (all four variants) — totals + 13-column `SELECT *` shape
  match SQLite path
- [x] Growth stats — yearly/monthly/daily buckets match SQLite on 5 scans
- [x] DB stats — table counts + oldest/newest scan match SQLite
- [x] Refactored SQLite duplicate query — identical output to previous 3-pass
  version
- [ ] Smoke test on real scan data in a staging environment
- [ ] Verify `duckdb` wheel installs on the Windows deployment target and
  `sqlite` extension loads (may need pre-bundling for offline installs)

## Files changed
- `src/dashboard/api.py` — open-folder fix, pagination bounds, cron
  validator, analytics wiring on duplicate/drilldown/growth/db_stats, new
  /api/system/analytics endpoint
- `src/archiver/archive_engine.py` — disk-space check, bare-except cleanup
- `src/scanner/file_watcher.py` — stats lock, global registry lock
- `src/storage/analytics.py` — **new** AnalyticsEngine module
- `src/storage/database.py` — duplicate query collapsed to single CTE
- `config.yaml` — analytics section
- `requirements.txt` — duckdb>=1.0.0