### PR TITLE
Fix pip SSL failure behind corporate TLS-inspection proxies

### DIFF
--- a/deploy/setup-source.ps1
+++ b/deploy/setup-source.ps1
@@ -217,8 +217,25 @@ if (-not (Test-Path $venvPy)) {
     Write-Host "  [OK] Mevcut venv kullaniliyor" -ForegroundColor Green
 }
 
-& $venvPy -m pip install --upgrade pip --quiet
-& $venvPy -m pip install -r "$InstallDir\requirements.txt" --quiet --upgrade
+# Kurumsal TLS inspection proxy'leri icin pip'e pypi host'larini guvenilir olarak
+# isaretle. Ayrica venv icine pip.ini yaz: sonraki manuel pip kullanimlari da
+# (update.cmd dahil) bu ayarlari otomatik alir.
+$pipIni = @"
+[global]
+trusted-host = pypi.org
+               files.pythonhosted.org
+               pypi.python.org
+"@
+Set-Content "$venvPath\pip.ini" $pipIni -Encoding ASCII
+
+$pipTrust = @(
+    "--trusted-host", "pypi.org",
+    "--trusted-host", "files.pythonhosted.org",
+    "--trusted-host", "pypi.python.org"
+)
+
+& $venvPy -m pip install --upgrade pip --quiet @pipTrust
+& $venvPy -m pip install -r "$InstallDir\requirements.txt" --quiet --upgrade @pipTrust
 if ($LASTEXITCODE -ne 0) {
     Write-Host "  [HATA] pip install basarisiz" -ForegroundColor Red
     Write-Host "         Asagidaki komutla elle kontrol edin:" -ForegroundColor Yellow


### PR DESCRIPTION
## Summary

Customer install on an AD-joined Windows Server reached pip install but failed with `SSL: CERTIFICATE_VERIFY_FAILED`. The corporate proxy performs TLS inspection: Windows certificate store trusts the corporate root CA (which is why the Python installer download worked), but pip bundles its own `certifi` CA list which does not.

### Fix

Pass `--trusted-host` for the three pypi hosts to every pip invocation so pip skips SSL verification for those hosts specifically. This is the pragmatic solution for TLS-inspected corporate networks where the interception is already policy.

Also write a `pip.ini` into the venv root with the same trusted-host list so future manual pip usage and `update.cmd` re-runs work without passing flags.

### Changes to `deploy/setup-source.ps1`

- `$pipTrust` array with `--trusted-host pypi.org files.pythonhosted.org pypi.python.org`
- Flags passed to both `pip install --upgrade pip` and `pip install -r requirements.txt`
- `pip.ini` written to `$venvPath\pip.ini` with `[global] trusted-host = ...` for persistence

### Not a replacement for CA configuration

A cleaner corporate fix would be importing the corporate root CA into Python's `certifi` bundle or using `--use-feature=truststore` (Windows cert store). Both require more setup and `truststore` is pip 22.2+. For the one-command installer use case, `--trusted-host` is simpler and works everywhere.

## Test plan
- [x] On a TLS-inspected corporate network: pip install succeeds (this is the reported failure)
- [ ] On an open network: pip install still succeeds (trusted-host is no-op when SSL already verifies)
- [ ] Re-run installer: pip.ini persists, no extra flags needed for subsequent manual pip usage
- [ ] `fa.cmd` and `start_dashboard.cmd` still work after install completes