### PR TITLE
Make TLS 1.2 assignment part of the canonical install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,13 +18,18 @@ Enterprise file share analysis tool that detects risky/stale/duplicate files, ar
 
 ```powershell
 # PowerShell (Run as Admin):
-powershell -ExecutionPolicy Bypass -Command "irm https://raw.githubusercontent.com/deepdarbe/FILE_ACTIVITY/master/deploy/setup-source.ps1 | iex"
+powershell -ExecutionPolicy Bypass -Command "[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; irm https://raw.githubusercontent.com/deepdarbe/FILE_ACTIVITY/master/deploy/setup-source.ps1 | iex"
 ```
 
-Installs to `C:\FileActivity\`, creates a Python venv, installs all
-dependencies (including DuckDB analytics), configures firewall, and offers to
-start the dashboard. Re-run the same command any time to update — data,
-logs, reports, and `config.yaml` are preserved.
+The leading TLS 1.2 assignment is required on Windows Server 2012/2016 where
+PowerShell 5.1 still defaults to TLS 1.0/1.1 (GitHub rejects both since 2018).
+Harmless on newer systems — keep it as the canonical form.
+
+Installs to `C:\FileActivity\`, auto-installs Python 3.11 if missing, creates a
+Python venv, installs all dependencies (including DuckDB analytics),
+configures firewall, and offers to start the dashboard. Re-run the same
+command any time to update — data, logs, reports, and `config.yaml` are
+preserved.
 
 To update later: `C:\FileActivity\update.cmd`
 

--- a/deploy/setup-source.ps1
+++ b/deploy/setup-source.ps1
@@ -10,7 +10,12 @@
     EXE release'i GEREKTIRMEZ. Tek gereksinim: hedef sunucuda Python 3.10+
 
     Kullanim (Yonetici PowerShell):
-    powershell -ExecutionPolicy Bypass -Command "irm https://raw.githubusercontent.com/deepdarbe/FILE_ACTIVITY/master/deploy/setup-source.ps1 | iex"
+    powershell -ExecutionPolicy Bypass -Command "[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; irm https://raw.githubusercontent.com/deepdarbe/FILE_ACTIVITY/master/deploy/setup-source.ps1 | iex"
+
+    Bastaki TLS 1.2 atamasi, eski PowerShell 5.1 (Windows Server 2012/2016)
+    varsayili TLS 1.0/1.1 kullandigi icin GitHub'a HTTPS isteginin calismasini
+    garanti eder. Daha yeni sistemlerde zararsiz, guvenli tarafta kalmak icin
+    kanonik komut olarak onerilir.
 
     Ayni komut guncelleme icin de kullanilabilir: mevcut data\, config\,
     logs\ ve reports\ dizinleri korunur, sadece kaynak kod yenilenir.
@@ -270,10 +275,11 @@ pause
 Set-Content "$InstallDir\start_dashboard.cmd" $dashCmd
 
 # Update launcher: ayni script'i tekrar cagirir (guncelleme)
+# Eski PowerShell'lerde TLS 1.2'yi onceden set etmek zorunlu (irm basarisiz olmasin)
 $updateCmd = @"
 @echo off
 echo FILE ACTIVITY guncelleniyor (master branch)...
-powershell -ExecutionPolicy Bypass -Command "irm https://raw.githubusercontent.com/$RepoOwner/$RepoName/$Branch/deploy/setup-source.ps1 | iex"
+powershell -ExecutionPolicy Bypass -Command "[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; irm https://raw.githubusercontent.com/$RepoOwner/$RepoName/$Branch/deploy/setup-source.ps1 | iex"
 "@
 Set-Content "$InstallDir\update.cmd" $updateCmd
 


### PR DESCRIPTION
## Summary

On Windows Server 2012 R2 and 2016, PowerShell 5.1 still defaults to TLS 1.0/1.1. GitHub deprecated those in 2018, so the one-liner's `irm` against `raw.githubusercontent.com` fails with `Could not create SSL/TLS secure channel` before it even downloads the script. The script already forces TLS 1.2 internally, but that runs after irm, which is too late.

Prepending `[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12;` before `irm` fixes this. It's harmless on newer PowerShell where TLS 1.2 is already the default, so this becomes the canonical form.

### Canonical install command

```powershell
powershell -ExecutionPolicy Bypass -Command "[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; irm https://raw.githubusercontent.com/deepdarbe/FILE_ACTIVITY/master/deploy/setup-source.ps1 | iex"
```

### Changes
- `README.md` Quick Setup: updated one-liner, added note explaining the TLS prefix
- `deploy/setup-source.ps1` docstring: mirrored the canonical form
- `update.cmd` generator: emits the TLS-forced command so in-place updates via `C:\FileActivity\update.cmd` also work on older Server SKUs

### Verified
Reported by user: original `irm ...` failed with SSL/TLS error on one server, the TLS-prefixed form succeeded.