### PR TITLE
Add GitHub infrastructure: CI, release automation, templates, policies

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,70 @@
+name: Bug report
+description: Report a reproducible bug in FILE ACTIVITY
+title: "[Bug] "
+labels: [bug]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting! Please fill in the fields below so we can reproduce quickly.
+  - type: textarea
+    id: description
+    attributes:
+      label: What happened?
+      description: A clear description of the bug and what you expected instead.
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      placeholder: |
+        1. Run `fa source add -n SRV01 -p \\server\share ...`
+        2. Run `fa scan -s SRV01`
+        3. Open dashboard, click ...
+        4. See error ...
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: Version or commit SHA
+      description: "Output of `fa version` or `git rev-parse HEAD`"
+      placeholder: "v1.7.0 or 100d95b"
+    validations:
+      required: true
+  - type: dropdown
+    id: install
+    attributes:
+      label: Install method
+      options:
+        - One-command (setup-source.ps1)
+        - EXE release (setup.ps1 / install.bat)
+        - Manual source clone
+        - Windows Service
+    validations:
+      required: true
+  - type: input
+    id: os
+    attributes:
+      label: Operating system
+      placeholder: "Windows Server 2019 / Windows 11 22H2"
+    validations:
+      required: true
+  - type: input
+    id: python
+    attributes:
+      label: Python version (if source install)
+      placeholder: "3.11.9"
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs
+      description: "From `C:\\FileActivity\\logs\\file_activity.log` or dashboard error output. Strip any UNC paths / share names if sensitive."
+      render: text
+  - type: textarea
+    id: config
+    attributes:
+      label: Relevant config (optional)
+      description: "Scrubbed snippet from config.yaml — no credentials."
+      render: yaml

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/deepdarbe/FILE_ACTIVITY/security/advisories/new
+    about: Please report security issues privately via Security Advisories, not public issues.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,40 @@
+name: Feature request
+description: Propose a new feature or improvement
+title: "[Feat] "
+labels: [enhancement]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem / use case
+      description: What problem does this solve, or what workflow is awkward today?
+    validations:
+      required: true
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+      description: A rough sketch of how the feature should behave. Concrete beats abstract.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other approaches you've thought about and why this one is preferred.
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area of the codebase
+      options:
+        - Scanner (file_scanner, file_watcher, win_attributes)
+        - Archiver (archive_engine, restore_engine, archive_policy)
+        - Analyzer / reports
+        - Dashboard UI or API
+        - Storage (database / analytics)
+        - Scheduler
+        - Windows Service / deployment
+        - CLI
+        - Other / cross-cutting
+    validations:
+      required: true

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,35 @@
+version: 2
+updates:
+  # Python requirements.txt: haftalik guncelleme taramasi
+  - package-ecosystem: pip
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "04:00"
+      timezone: Europe/Istanbul
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+      - python
+    commit-message:
+      prefix: deps
+      include: scope
+    groups:
+      # Hep birlikte gidenler icin tek PR (patch upgrade gruplamasi)
+      patch-updates:
+        update-types:
+          - patch
+
+  # GitHub Actions workflow versiyonlari
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly
+    open-pull-requests-limit: 3
+    labels:
+      - dependencies
+      - ci
+    commit-message:
+      prefix: ci
+      include: scope

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,22 @@
+## Summary
+
+<!-- What changed and why. 1-3 sentences focused on intent, not mechanics. -->
+
+## Test plan
+
+<!-- How did you verify this works? Check boxes for anything done, leave unchecked for known gaps. -->
+
+- [ ] Syntax / compile passes locally
+- [ ] Relevant endpoint / CLI command exercised
+- [ ] Dashboard loads if UI touched
+- [ ] Regression: adjacent feature still works
+
+## Notes
+
+<!--
+Optional. Examples:
+- Known follow-ups (link to an issue if you'll file one)
+- Breaking changes for existing installations
+- Why a simpler alternative was rejected
+- Screenshots for UI changes
+-->

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,86 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  syntax:
+    name: Python syntax check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+
+      - name: py_compile across src/ and entry points
+        run: |
+          python -m compileall -q src/ main.py dev_server.py
+
+      - name: Import-level smoke test for cross-platform modules
+        run: |
+          # AnalyticsEngine and Database models import cleanly on Linux
+          # (no pywin32 required). Scanner/archiver import pywin32 and are
+          # skipped here; they run in the release workflow on windows-latest.
+          python -m pip install --upgrade pip --quiet
+          python -m pip install duckdb pydantic --quiet
+          python - <<'PY'
+          import sys
+          sys.path.insert(0, '.')
+          from src.storage.analytics import AnalyticsEngine
+          from src.storage.models import Source, ScannedFile, ArchivedFile
+          engine = AnalyticsEngine("/tmp/nonexistent.db", {"enabled": True})
+          print(f"AnalyticsEngine available={engine.available} (expected: may be False without attached DB)")
+          PY
+
+  lint:
+    name: Ruff lint (non-blocking)
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install ruff
+        run: python -m pip install ruff --quiet
+
+      - name: Run ruff (report only)
+        run: ruff check src/ main.py dev_server.py --output-format=github || true
+
+  powershell-syntax:
+    name: PowerShell syntax check
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Parse deploy/*.ps1
+        shell: pwsh
+        run: |
+          $errors = 0
+          Get-ChildItem deploy\*.ps1 | ForEach-Object {
+            $tokens = $null
+            $parseErrors = $null
+            [System.Management.Automation.Language.Parser]::ParseFile(
+              $_.FullName, [ref]$tokens, [ref]$parseErrors
+            ) | Out-Null
+            if ($parseErrors.Count -gt 0) {
+              Write-Host "::error file=$($_.FullName)::Parse errors in $($_.Name)"
+              $parseErrors | ForEach-Object { Write-Host "  $_" }
+              $errors += $parseErrors.Count
+            } else {
+              Write-Host "[OK] $($_.Name)"
+            }
+          }
+          if ($errors -gt 0) { exit 1 }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,83 @@
+name: Release
+
+# Tetikleyici: v*.*.* sekilinde semver tag push'u
+# Ornek: git tag v1.7.0 && git push --tags
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+permissions:
+  contents: write
+
+jobs:
+  build-windows:
+    name: Build Windows EXE + package
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install pyinstaller
+          python -m pip install -r requirements.txt
+
+      - name: Build EXE via file_activity.spec
+        run: |
+          python -m PyInstaller file_activity.spec --noconfirm --log-level WARN
+
+      - name: Assemble deploy package
+        shell: pwsh
+        run: |
+          $DIST = "dist\FileActivity"
+          $PKG  = "dist\FileActivity-Package"
+          if (-not (Test-Path $DIST)) {
+            throw "PyInstaller output not found at $DIST"
+          }
+          New-Item -ItemType Directory -Force -Path `
+            "$PKG\bin","$PKG\config","$PKG\scripts","$PKG\logs","$PKG\reports" | Out-Null
+          Copy-Item "$DIST\*" "$PKG\bin\" -Recurse -Force
+          Copy-Item "config.yaml"                 "$PKG\config\config.yaml"         -Force
+          Copy-Item "scripts\init_db.py"          "$PKG\scripts\"                   -Force
+          Copy-Item "deploy\install.bat"          "$PKG\install.bat"                -Force
+          Copy-Item "deploy\uninstall.bat"        "$PKG\uninstall.bat"              -Force
+          Copy-Item "deploy\service_install.bat"  "$PKG\service_install.bat"        -Force
+
+      - name: Smoke test the built EXE
+        shell: pwsh
+        run: |
+          $exe = "dist\FileActivity-Package\bin\FileActivity.exe"
+          if (-not (Test-Path $exe)) { throw "EXE not produced at $exe" }
+          # Basit dogrulama: --help exit code 0 dondurmeli
+          & $exe --help
+          if ($LASTEXITCODE -ne 0) { throw "EXE --help exited $LASTEXITCODE" }
+
+      - name: Create FileActivity-Deploy.zip
+        shell: pwsh
+        run: |
+          Compress-Archive -Path "dist\FileActivity-Package\*" `
+                           -DestinationPath "dist\FileActivity-Deploy.zip" `
+                           -Force
+          $size = [math]::Round((Get-Item "dist\FileActivity-Deploy.zip").Length / 1MB, 1)
+          Write-Host "Package size: $size MB"
+
+      - name: Upload as workflow artifact (retain for 30 days)
+        uses: actions/upload-artifact@v4
+        with:
+          name: FileActivity-Deploy
+          path: dist/FileActivity-Deploy.zip
+          retention-days: 30
+
+      - name: Create GitHub Release with asset
+        uses: softprops/action-gh-release@v2
+        with:
+          files: dist/FileActivity-Deploy.zip
+          generate_release_notes: true
+          draft: false
+          prerelease: ${{ contains(github.ref_name, '-') }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,95 @@
+# Contributing
+
+Short guide for making changes to FILE ACTIVITY.
+
+## Development setup
+
+Full integration requires Windows 10/11 or Windows Server 2016+ because the
+scanner and archiver modules use `pywin32` APIs (`win32security`,
+`win32api`, etc.). Linux works for most of the code except those modules.
+
+```powershell
+git clone https://github.com/deepdarbe/FILE_ACTIVITY.git
+cd FILE_ACTIVITY
+python -m venv .venv
+.venv\Scripts\activate
+pip install -r requirements.txt
+python main.py dashboard
+```
+
+Dashboard: http://localhost:8085
+
+On Linux (for docs / analytics / db layer work):
+
+```bash
+python3 -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt  # pywin32 will be skipped via environment markers
+python -m compileall -q src/ main.py
+```
+
+## Branch naming
+
+- `feat/<short-desc>` — new features
+- `fix/<short-desc>` — bug fixes
+- `chore/<short-desc>` — maintenance (deps, CI, docs)
+- `claude/<short-desc>` — branches produced by Claude Code sessions
+
+## Commit messages
+
+- Subject ≤ 72 chars, imperative mood ("Add X", not "Added X")
+- Blank line, then body explaining **why**, not **what**
+- Reference issues like `Closes #42` in the body when relevant
+
+Example:
+
+```
+Fix pip SSL failure behind corporate TLS-inspection proxies
+
+Customer install on an AD-joined Windows Server failed at pip install
+with SSL CERTIFICATE_VERIFY_FAILED. The corporate proxy MITMs HTTPS...
+```
+
+## Pull requests
+
+1. Branch off `master`
+2. Open PR against `master` — fill in the template (Summary + Test plan)
+3. Wait for CI green (syntax + PowerShell parse)
+4. Merge with a merge commit (not squash) to preserve logical units
+
+## Code style
+
+- Stdlib preferred — don't pull in a dep for trivial helpers
+- Match the style of the file you're editing; there's no strict formatter
+- Type hints welcome on new code, not mandatory for existing code
+- Comments explain **why** non-obvious decisions were made; skip obvious
+  **what** (that's what identifiers are for)
+- No dead code. No `TODO: ...` for planned work — file an issue instead.
+
+## Storage layer
+
+- SQLite is the source of truth (`src/storage/database.py`)
+- DuckDB (`src/storage/analytics.py`) is an optional read-only layer for
+  heavy aggregates. Every caller must have a SQLite fallback.
+- When you add a new analytical query, write it first in SQLite, then
+  optionally add a DuckDB fast-path.
+
+## Testing
+
+No automated test suite yet. For now:
+
+- `python -m compileall -q src/ main.py` passes
+- Manual smoke: scan → dashboard → drill-down → archive → restore
+- If you touch `src/storage/analytics.py`, verify duplicate / drill-down /
+  growth against a small in-memory SQLite fixture (pattern in the commit
+  history on PRs #1, #2)
+
+## Release process
+
+1. Merge changes to `master`
+2. Tag a semver release: `git tag v1.x.y && git push --tags`
+3. GitHub Actions (`.github/workflows/release.yml`) builds the EXE on
+   `windows-latest`, creates the release, and attaches
+   `FileActivity-Deploy.zip`
+4. Existing installs pick up the new release via `setup.ps1` or via
+   `C:\FileActivity\update.cmd` (source installs)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,54 @@
+# Security Policy
+
+## Supported versions
+
+Only the latest release on `master` is supported. Security fixes are applied
+forward — we do not backport to older tags.
+
+## Reporting a vulnerability
+
+**Please do not open a public issue for security vulnerabilities.**
+
+Preferred channel:
+
+- Private GitHub Security Advisory:
+  https://github.com/deepdarbe/FILE_ACTIVITY/security/advisories/new
+
+Include in the report:
+
+- Impact and severity assessment (what an attacker can do)
+- Steps to reproduce or a minimal PoC
+- Affected versions / commit SHAs
+- Any proposed mitigation
+
+## Response timeline
+
+- **Acknowledgement**: within 3 business days
+- **Initial status update**: within 7 days
+- **Public disclosure**: coordinated with you after a fix is released
+
+## Scope
+
+In scope:
+
+- Command / shell injection in API endpoints or CLI
+- Path traversal in archive / restore / export endpoints
+- SSRF in any HTTP caller
+- Archive integrity issues (silent data corruption, checksum bypass)
+- Authentication / authorization flaws (when auth is added)
+- Dependency vulnerabilities in pinned packages
+
+Out of scope:
+
+- Theoretical vulnerabilities without a working PoC
+- Upstream CVEs in third-party dependencies already tracked by Dependabot
+- Self-XSS requiring the victim to paste attacker-supplied input
+- Attacks requiring physical access to the Windows host
+- Attacks against shares the tool is configured to scan (those are the
+  domain of the underlying Windows ACL / SMB configuration)
+
+## Safe harbor
+
+Good-faith security research is welcome. If you follow the policy above
+(private disclosure, no data exfiltration, no disruption of others'
+deployments), we will not pursue any legal action.

--- a/file_activity.spec
+++ b/file_activity.spec
@@ -11,10 +11,18 @@ ROOT = os.path.abspath('.')
 sys.path.insert(0, ROOT)
 
 # Use PyInstaller's collect helpers
-from PyInstaller.utils.hooks import collect_submodules, collect_data_files
+from PyInstaller.utils.hooks import collect_submodules, collect_data_files, collect_dynamic_libs
 
 # Collect ALL submodules from src package
 src_imports = collect_submodules('src')
+
+# DuckDB C extension libraries (duckdb.dll) must be bundled
+duckdb_binaries = []
+try:
+    duckdb_binaries = collect_dynamic_libs('duckdb')
+    print(f"[SPEC] DuckDB binaries: {len(duckdb_binaries)}")
+except Exception as e:
+    print(f"[SPEC] DuckDB binary collection skipped: {e}")
 print(f"[SPEC] Collected {len(src_imports)} src submodules:")
 for m in sorted(src_imports):
     print(f"  {m}")
@@ -57,11 +65,13 @@ print(f"[SPEC] Data files: {len(data_files)}")
 a = Analysis(
     ['main.py'],
     pathex=[ROOT],
-    binaries=[],
+    binaries=duckdb_binaries,
     datas=data_files,
     hiddenimports=src_imports + [
         # SQLite (built-in, but ensure it's bundled)
         'sqlite3',
+        # DuckDB analytics engine (optional, SQLite fallback if absent)
+        'duckdb',
         # Win32 (pywin32 hidden modules)
         'win32timezone',
         'win32api',


### PR DESCRIPTION
## Summary

Repo had no `.github/` directory — no CI, no automated release build, no issue or PR templates, no dependency automation. This adds the full set so `git push --tags` produces a release automatically, customers/contributors get structured templates, and dependencies stay fresh.

## What's included

### Workflows

| File | Triggers | What it does |
|---|---|---|
| `.github/workflows/ci.yml` | push to `master`, all PRs | py_compile over `src/`, `main.py`, `dev_server.py`; non-blocking ruff lint; PowerShell parse check over `deploy/*.ps1` on windows-latest |
| `.github/workflows/release.yml` | `v*.*.*` tag push | Builds EXE on windows-latest, assembles deploy package, smoke-tests `EXE --help`, creates GitHub Release with auto-generated notes, attaches `FileActivity-Deploy.zip` |

### Templates
- `.github/pull_request_template.md` — Summary / Test plan / Notes
- `.github/ISSUE_TEMPLATE/bug_report.yml` — structured bug form (version, install method, OS, Python, logs, config)
- `.github/ISSUE_TEMPLATE/feature_request.yml` — problem / solution / alternatives with codebase-area dropdown
- `.github/ISSUE_TEMPLATE/config.yml` — disables blank issues, routes security reports to Security Advisories

### Automation
- `.github/dependabot.yml` — weekly pip scan (patch updates grouped), monthly github-actions scan

### Policies
- `SECURITY.md` — private disclosure via GitHub Security Advisories, response SLAs, scope, safe-harbor
- `CONTRIBUTING.md` — dev setup, branch/commit style, PR flow, storage-layer rules (SQLite + optional DuckDB), release process

### PyInstaller spec update
`file_activity.spec` now adds `duckdb` to `hiddenimports` and bundles its C extension libraries via `collect_dynamic_libs('duckdb')`. Without this the release workflow would produce an EXE that crashes at first `AnalyticsEngine` import.

## How the release flow works after merge

```powershell
# Tag a new release — that's it:
git tag v1.7.0
git push --tags
```

Then GitHub Actions:
1. Checks out `master`, installs Python 3.11 + PyInstaller + requirements.txt
2. Builds EXE via `file_activity.spec`
3. Assembles `dist/FileActivity-Package/` (bin + config + scripts + install.bat)
4. Runs `EXE --help` as a smoke test
5. Creates a GitHub Release with auto-generated notes (from merged PRs)
6. Attaches `FileActivity-Deploy.zip`

Customer installs via `deploy/setup.ps1` (EXE path) or `deploy/setup-source.ps1` (source path) then continue to work.

## Test plan
- [x] All new files parse (YAML, Markdown, Python spec)
- [ ] CI workflow runs green on this PR (first validation of its own workflow file)
- [ ] Release workflow dry-run: manually trigger on a test tag, confirm EXE builds and release is created — **action required by maintainer after merge, first real run will be the first release**
- [ ] Dependabot files its first PR within a week of merge
- [ ] Issue templates render correctly on GitHub (verify via New Issue)
- [ ] Security Advisory link resolves

## Notes
- Release workflow uses `softprops/action-gh-release@v2` and `actions/upload-artifact@v4` — both maintained, stable.
- CI's ruff lint is `continue-on-error: true` so it reports without blocking; tighten after a cleanup pass.
- Once this PR lands, the canonical way to publish a new version is simply tag push; no manual build or upload needed.