### PR TITLE
Fix misleading placeholder in Veritabani Bakimi card

### DIFF
--- a/src/dashboard/static/index.html
+++ b/src/dashboard/static/index.html
@@ -368,7 +368,7 @@ label { font-size: 12px; color: var(--text-muted); margin-bottom: 6px; display: 
     <div style="margin-top:24px;padding:20px;background:var(--bg-card);border-radius:12px;border:1px solid var(--border)">
         <h3 style="font-size:15px;margin-bottom:16px;color:var(--text-primary)">Veritabani Bakimi</h3>
         <div style="display:flex;gap:12px;flex-wrap:wrap;align-items:center">
-            <div id="db-stats-info" style="flex:1;min-width:200px;font-size:12px;color:var(--text-secondary)">Yukle butonuna tiklayin...</div>
+            <div id="db-stats-info" style="flex:1;min-width:200px;font-size:12px;color:var(--text-secondary)">Istatistikler icin butona tiklayin...</div>
             <button class="btn btn-outline" onclick="loadDbStats()" style="font-size:12px">Istatistikler</button>
             <button class="btn btn-outline" onclick="cleanupOldScans()" style="font-size:12px;border-color:var(--warning);color:var(--warning)">Eski Taramalari Temizle</button>
             <button class="btn btn-outline" onclick="optimizeDb()" style="font-size:12px;border-color:var(--info);color:var(--info)">Optimize Et</button>


### PR DESCRIPTION
## Summary

Screenshot from customer showed the "Veritabani Bakimi" card on Kaynaklar page with the message "Yukle butonuna tiklayin..." — but there is no "Yukle" button. The three buttons in that card are **Istatistikler**, **Eski Taramalari Temizle**, and **Optimize Et**. The placeholder was evidently left over from an earlier iteration where the statistics button was labeled "Yukle".

## Change

`src/dashboard/static/index.html:371`
- Before: `Yukle butonuna tiklayin...`
- After: `Istatistikler icin butona tiklayin...`

Points the user at the actual button they should click.

## Test plan
- [x] Placeholder text now matches the adjacent button label
- [ ] Visually verify on running dashboard

## Notes
This also aligns with the dashboard user flow: clicking `Istatistikler` triggers `loadDbStats()` which replaces the placeholder with real values.