### PR TITLE
AD email lookup for user activity detail (PR A of 4)

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -17,6 +17,21 @@ analytics:
   memory_limit: "512MB"           # DuckDB bellek siniri
   threads: 4                      # DuckDB paralel thread sayisi
 
+active_directory:
+  # Kullanici adindan e-posta ve tam ad cozumleme. Kullanici aktivite
+  # detay sekmesinde gosterilir, bildirim e-postalari icin kullanilir.
+  # enabled=false ise tum AD cagrilari no-op calisir (cache varsa doner).
+  enabled: false
+  server: ""                      # ornek: ldap://dc.firma.local veya ldaps://dc.firma.local:636
+  bind_dn: ""                     # ornek: CN=svc_fileactivity,CN=Users,DC=firma,DC=local
+  bind_password: ""               # Guvenlik: bos birakip AD_BIND_PASSWORD env var kullanin
+  base_dn: ""                     # ornek: DC=firma,DC=local
+  user_filter: "(sAMAccountName={username})"
+  email_attribute: "mail"
+  name_attribute: "displayName"
+  cache_ttl_minutes: 60           # Sonuclar TTL boyunca SQLite'ta cache'lenir
+  timeout_seconds: 5
+
 sources: []
   # Örnek:
   # - name: "Engineering"

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,3 +27,9 @@ reportlab>=4.0.0
 # growth, stats) run through DuckDB via the sqlite_scanner extension.
 # SQLite remains the source of truth; DuckDB only reads.
 duckdb>=1.0.0
+
+# Active Directory lookup (optional): pure-Python LDAP client.
+# When installed and active_directory.enabled=true, dashboard resolves
+# username -> email/display_name for activity detail + notifications.
+# Missing package -> ADLookup.available=False and feature silently disabled.
+ldap3>=2.9.1

--- a/src/dashboard/api.py
+++ b/src/dashboard/api.py
@@ -116,19 +116,27 @@ def _read_version() -> str:
 APP_VERSION = _read_version()
 
 
-def create_app(db, config, analytics=None):
+def create_app(db, config, analytics=None, ad_lookup=None):
     """FastAPI uygulamasini olustur.
 
     analytics: Opsiyonel AnalyticsEngine. Verilmezse config.analytics'e gore
     olusturulur; DuckDB yoksa veya basarisiz olursa `available=False` ile
     doner ve endpoint'ler SQLite fallback'ine duser.
+
+    ad_lookup: Opsiyonel ADLookup. Verilmezse config.active_directory'den
+    olusturulur; ldap3 yoksa veya enabled=false ise available=False ile
+    doner ve endpoint'ler cache degeri / None doner.
     """
     if analytics is None:
         from src.storage.analytics import AnalyticsEngine
         analytics = AnalyticsEngine(db.db_path, config.get("analytics", {}))
+    if ad_lookup is None:
+        from src.user_activity.ad_lookup import ADLookup
+        ad_lookup = ADLookup(db, config)
 
     app = FastAPI(title="FILE ACTIVITY Dashboard", version=APP_VERSION)
     app.state.analytics = analytics
+    app.state.ad_lookup = ad_lookup
 
     static_dir = os.path.join(os.path.dirname(__file__), "static")
     if os.path.exists(static_dir):
@@ -776,7 +784,19 @@ def create_app(db, config, analytics=None):
         # recent_activity - not available from get_user_activity
         recent = []
 
+        # AD lookup: e-posta + display name (yoksa null alanlar)
+        ad_info = ad_lookup.lookup(username) or {
+            "email": None, "display_name": None, "found": False, "source": None
+        }
+
         return {
+            "username": username,
+            "ad": {
+                "email": ad_info.get("email"),
+                "display_name": ad_info.get("display_name"),
+                "found": ad_info.get("found", False),
+                "source": ad_info.get("source"),
+            },
             "summary": {
                 "total_access": total_access,
                 "unique_files": unique_files,
@@ -1569,6 +1589,29 @@ def create_app(db, config, analytics=None):
     async def version():
         """Calisan sürüm (repo kokundeki VERSION dosyasindan)."""
         return {"version": APP_VERSION}
+
+    @app.get("/api/system/ad/status")
+    async def ad_status():
+        """AD/LDAP baglanti durumu + bind testi."""
+        return ad_lookup.health()
+
+    @app.get("/api/users/{username}/ad-info")
+    async def user_ad_info(username: str, refresh: bool = False):
+        """Kullanici adindan e-posta + display name cozumle.
+
+        AD devre disi veya erisilmez ise cache'ten doner; cache yoksa
+        null alanlarla sessizce doner.
+        """
+        info = ad_lookup.lookup(username, force_refresh=refresh)
+        if info is None:
+            return {
+                "username": username,
+                "email": None,
+                "display_name": None,
+                "found": False,
+                "source": None,
+            }
+        return info
 
     def _parse_ver(v: str):
         """Semver-ish karsilastirma icin tuple parse et.

--- a/src/dashboard/static/index.html
+++ b/src/dashboard/static/index.html
@@ -1746,7 +1746,62 @@ function renderHeatmap(data) {
 async function loadUserDetail(username) {
     try {
         const data = await api(`/users/${username}/detail`);
-        alert(JSON.stringify(data.summary, null, 2));
+        const ad = data.ad || {};
+        const s = data.summary || {};
+
+        // AD source etiketi (tooltip icin)
+        const adSourceLabel = {
+            live: 'canli AD sorgusu',
+            cache: 'yerel cache (taze)',
+            'stale-cache': 'yerel cache (eski - AD erisilemedi)',
+        }[ad.source] || 'AD devre disi';
+
+        const adBlock = ad.found || ad.email ? `
+            <div style="background:var(--bg-primary);padding:12px;border-radius:8px;margin-bottom:16px;border-left:3px solid var(--accent)">
+                <div style="font-size:11px;color:var(--text-muted);text-transform:uppercase;letter-spacing:0.5px;margin-bottom:4px">Active Directory</div>
+                ${ad.display_name ? `<div style="font-size:15px;font-weight:600">${ad.display_name}</div>` : ''}
+                ${ad.email ? `<div style="font-size:13px;color:var(--accent)"><a href="mailto:${ad.email}" style="color:inherit">${ad.email}</a></div>` : '<div style="font-size:12px;color:var(--text-muted)">E-posta bulunamadi</div>'}
+                <div style="font-size:10px;color:var(--text-muted);margin-top:4px" title="${adSourceLabel}">Kaynak: ${adSourceLabel}</div>
+            </div>
+        ` : `
+            <div style="background:var(--bg-primary);padding:12px;border-radius:8px;margin-bottom:16px;border-left:3px solid var(--text-muted)">
+                <div style="font-size:11px;color:var(--text-muted);text-transform:uppercase;letter-spacing:0.5px;margin-bottom:4px">Active Directory</div>
+                <div style="font-size:13px;color:var(--text-muted)">AD bilgisi yok</div>
+                <div style="font-size:10px;color:var(--text-muted);margin-top:4px">${adSourceLabel}</div>
+            </div>
+        `;
+
+        const modalId = 'modal-user-detail';
+        const body = `
+            <h3 style="margin:0 0 16px 0">Kullanici Detay: ${username}</h3>
+            ${adBlock}
+            <div class="cards">
+                <div class="card accent"><div class="card-label">Toplam Erisim</div><div class="card-value">${formatNum(s.total_access||0)}</div></div>
+                <div class="card success"><div class="card-label">Benzersiz Dosya</div><div class="card-value">${formatNum(s.unique_files||0)}</div></div>
+                <div class="card purple"><div class="card-label">Aktif Gun</div><div class="card-value">${formatNum(s.active_days||0)}</div></div>
+                <div class="card warning"><div class="card-label">Veri Boyutu</div><div class="card-value" style="font-size:16px">${s.total_data_formatted||'0 B'}</div></div>
+            </div>
+            <div style="display:flex;gap:8px;margin-top:12px;font-size:12px">
+                <div style="flex:1;padding:10px;background:var(--bg-primary);border-radius:6px"><strong>Okuma:</strong> ${formatNum(s.reads||0)}</div>
+                <div style="flex:1;padding:10px;background:var(--bg-primary);border-radius:6px"><strong>Yazma:</strong> ${formatNum(s.writes||0)}</div>
+                <div style="flex:1;padding:10px;background:var(--bg-primary);border-radius:6px"><strong>Silme:</strong> ${formatNum(s.deletes||0)}</div>
+            </div>
+            <div style="text-align:right;margin-top:16px">
+                <button class="btn btn-outline" onclick="closeModal('${modalId}')">Kapat</button>
+            </div>
+        `;
+
+        let modal = document.getElementById(modalId);
+        if (!modal) {
+            modal = document.createElement('div');
+            modal.id = modalId;
+            modal.className = 'modal-overlay';
+            modal.innerHTML = '<div class="modal" style="max-width:700px;width:90%"></div>';
+            modal.onclick = (e) => { if (e.target === modal) closeModal(modalId); };
+            document.body.appendChild(modal);
+        }
+        modal.querySelector('.modal').innerHTML = body;
+        modal.classList.add('active');
     } catch(e) { notify(e.message, 'error'); }
 }
 

--- a/src/user_activity/ad_lookup.py
+++ b/src/user_activity/ad_lookup.py
@@ -1,0 +1,279 @@
+"""Active Directory lookup - kullanici e-posta + display name.
+
+ldap3 ile AD/LDAP'a sorgu atar, kullanici adindan e-posta ve tam adi
+cikarir. Sonuclari SQLite'ta TTL bazli cache'ler; AD indisponible iken
+ya da sorgu timeout olursa eski cache degerini doner.
+
+Konfigurasyon (config.yaml):
+    active_directory:
+      enabled: true
+      server: "ldap://dc.example.com"   # ldaps:// icin port 636 kullanin
+      bind_dn: "CN=svc_fileactivity,CN=Users,DC=example,DC=com"
+      bind_password: ""                  # veya AD_BIND_PASSWORD env var
+      base_dn: "DC=example,DC=com"
+      user_filter: "(sAMAccountName={username})"
+      email_attribute: "mail"
+      name_attribute: "displayName"
+      cache_ttl_minutes: 60
+      timeout_seconds: 5
+
+enabled=false ise modul no-op calisir, lookup() None doner.
+"""
+
+import logging
+import os
+import threading
+from datetime import datetime, timedelta
+from typing import Optional
+
+logger = logging.getLogger("file_activity.ad_lookup")
+
+try:
+    from ldap3 import Server, Connection, SAFE_SYNC, ALL as LDAP3_ALL  # type: ignore
+    _HAVE_LDAP3 = True
+except ImportError:
+    Server = None
+    Connection = None
+    _HAVE_LDAP3 = False
+
+
+class ADLookup:
+    """AD/LDAP uzerinden kullanici bilgisi cozumleyici."""
+
+    def __init__(self, db, config: dict):
+        self.db = db
+        ad_conf = config.get("active_directory", {}) or {}
+        self.enabled = bool(ad_conf.get("enabled", False))
+        self.server = ad_conf.get("server", "").strip()
+        self.bind_dn = ad_conf.get("bind_dn", "").strip()
+        # Sifre oncelik: env var > config
+        self.bind_password = (
+            os.environ.get("AD_BIND_PASSWORD")
+            or ad_conf.get("bind_password", "")
+        )
+        self.base_dn = ad_conf.get("base_dn", "").strip()
+        self.user_filter = ad_conf.get("user_filter", "(sAMAccountName={username})")
+        self.email_attr = ad_conf.get("email_attribute", "mail")
+        self.name_attr = ad_conf.get("name_attribute", "displayName")
+        self.cache_ttl = timedelta(minutes=int(ad_conf.get("cache_ttl_minutes", 60)))
+        self.timeout = int(ad_conf.get("timeout_seconds", 5))
+        self._lock = threading.Lock()
+        self._ensure_cache_table()
+
+        self._init_error: Optional[str] = None
+        if not _HAVE_LDAP3:
+            self._init_error = "ldap3 paketi yuklenmemis"
+        elif not self.enabled:
+            self._init_error = "config.active_directory.enabled=false"
+        elif not self.server or not self.base_dn:
+            self._init_error = "server veya base_dn eksik"
+
+        if self._init_error:
+            logger.info("ADLookup devre disi: %s", self._init_error)
+
+    @property
+    def available(self) -> bool:
+        return self._init_error is None
+
+    def _ensure_cache_table(self):
+        """SQLite'ta ad_user_cache tablosunu olustur."""
+        with self.db.get_cursor() as cur:
+            cur.execute("""
+                CREATE TABLE IF NOT EXISTS ad_user_cache (
+                    username TEXT PRIMARY KEY,
+                    email TEXT,
+                    display_name TEXT,
+                    found INTEGER NOT NULL DEFAULT 0,
+                    looked_up_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+                )
+            """)
+
+    def _normalize_username(self, username: str) -> str:
+        """DOMAIN\\user veya user@domain formatlarindan sadece sam'i cikar."""
+        if not username:
+            return ""
+        if "\\" in username:
+            username = username.split("\\", 1)[1]
+        if "@" in username:
+            username = username.split("@", 1)[0]
+        return username.strip().lower()
+
+    def _get_cached(self, username: str) -> Optional[dict]:
+        with self.db.get_cursor() as cur:
+            cur.execute(
+                "SELECT email, display_name, found, looked_up_at "
+                "FROM ad_user_cache WHERE username = ?",
+                (username,),
+            )
+            row = cur.fetchone()
+        if not row:
+            return None
+        try:
+            ts = datetime.strptime(row["looked_up_at"], "%Y-%m-%d %H:%M:%S")
+        except (ValueError, TypeError):
+            ts = None
+        return {
+            "email": row["email"],
+            "display_name": row["display_name"],
+            "found": bool(row["found"]),
+            "looked_up_at": ts,
+            "stale": ts is None or (datetime.now() - ts) > self.cache_ttl,
+        }
+
+    def _set_cache(self, username: str, email: Optional[str],
+                    display_name: Optional[str], found: bool):
+        now = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+        with self.db.get_cursor() as cur:
+            cur.execute(
+                """
+                INSERT INTO ad_user_cache (username, email, display_name, found, looked_up_at)
+                VALUES (?, ?, ?, ?, ?)
+                ON CONFLICT(username) DO UPDATE SET
+                    email = excluded.email,
+                    display_name = excluded.display_name,
+                    found = excluded.found,
+                    looked_up_at = excluded.looked_up_at
+                """,
+                (username, email, display_name, 1 if found else 0, now),
+            )
+
+    def _query_ad(self, username: str) -> Optional[dict]:
+        """AD'ye canli sorgu. Basarisiz olursa None."""
+        if not self.available:
+            return None
+        try:
+            server = Server(self.server, get_info=LDAP3_ALL, connect_timeout=self.timeout)
+            conn = Connection(
+                server,
+                user=self.bind_dn,
+                password=self.bind_password,
+                client_strategy=SAFE_SYNC,
+                auto_bind=True,
+                receive_timeout=self.timeout,
+            )
+            search_filter = self.user_filter.format(
+                username=self._escape_ldap(username)
+            )
+            status, result, response, _req = conn.search(
+                search_base=self.base_dn,
+                search_filter=search_filter,
+                attributes=[self.email_attr, self.name_attr],
+            )
+            try:
+                conn.unbind()
+            except Exception:
+                pass
+            if not status or not response:
+                return {"email": None, "display_name": None, "found": False}
+            entry = response[0].get("attributes") or {}
+            email = entry.get(self.email_attr)
+            name = entry.get(self.name_attr)
+            if isinstance(email, list):
+                email = email[0] if email else None
+            if isinstance(name, list):
+                name = name[0] if name else None
+            return {"email": email, "display_name": name, "found": bool(email or name)}
+        except Exception as e:
+            logger.warning("AD sorgusu basarisiz (%s): %s", username, e)
+            return None
+
+    @staticmethod
+    def _escape_ldap(value: str) -> str:
+        """LDAP filter injection koruma."""
+        if not value:
+            return ""
+        out = []
+        for ch in value:
+            if ch in ("*", "(", ")", "\\", "\0"):
+                out.append(f"\\{ord(ch):02x}")
+            else:
+                out.append(ch)
+        return "".join(out)
+
+    def lookup(self, username: str, force_refresh: bool = False) -> Optional[dict]:
+        """Kullanici icin e-posta + display name doner.
+
+        Sonuc: {"username", "email", "display_name", "found", "source"}
+        source: "cache" | "live" | "stale-cache" | None (AD devre disi)
+        """
+        uname = self._normalize_username(username)
+        if not uname:
+            return None
+
+        with self._lock:
+            cached = self._get_cached(uname)
+
+            if cached and not force_refresh and not cached["stale"]:
+                return {
+                    "username": uname,
+                    "email": cached["email"],
+                    "display_name": cached["display_name"],
+                    "found": cached["found"],
+                    "source": "cache",
+                }
+
+            if not self.available:
+                # AD devre disi; cache varsa onu don, yoksa None
+                if cached:
+                    return {
+                        "username": uname,
+                        "email": cached["email"],
+                        "display_name": cached["display_name"],
+                        "found": cached["found"],
+                        "source": "stale-cache",
+                    }
+                return None
+
+            live = self._query_ad(uname)
+            if live is None:
+                # AD erisilmez, eski cache varsa onu don
+                if cached:
+                    return {
+                        "username": uname,
+                        "email": cached["email"],
+                        "display_name": cached["display_name"],
+                        "found": cached["found"],
+                        "source": "stale-cache",
+                    }
+                return None
+
+            self._set_cache(uname, live["email"], live["display_name"], live["found"])
+            return {
+                "username": uname,
+                "email": live["email"],
+                "display_name": live["display_name"],
+                "found": live["found"],
+                "source": "live",
+            }
+
+    def health(self) -> dict:
+        info = {
+            "enabled": self.enabled,
+            "ldap3_installed": _HAVE_LDAP3,
+            "available": self.available,
+            "server": self.server or None,
+            "base_dn": self.base_dn or None,
+        }
+        if self._init_error:
+            info["init_error"] = self._init_error
+        # Canli test: bind dene
+        if self.available:
+            try:
+                server = Server(self.server, connect_timeout=self.timeout)
+                conn = Connection(
+                    server,
+                    user=self.bind_dn,
+                    password=self.bind_password,
+                    client_strategy=SAFE_SYNC,
+                    auto_bind=True,
+                    receive_timeout=self.timeout,
+                )
+                info["bind_ok"] = True
+                try:
+                    conn.unbind()
+                except Exception:
+                    pass
+            except Exception as e:
+                info["bind_ok"] = False
+                info["bind_error"] = str(e)
+        return info


### PR DESCRIPTION
## Summary

Part A of the user-notification feature set. Resolves a username (from file ownership or event log) to email + display name by querying AD/LDAP, with a TTL-cached SQLite backing store. Feeds the user activity detail modal now; later PRs (B/C/D) will reuse `ADLookup.lookup()` for notification e-mails.

## What's included

### New module `src/user_activity/ad_lookup.py`
- `ADLookup(db, config)` reads `config.active_directory`. If `ldap3` is not installed, `enabled=false`, or `server`/`base_dn` are empty, `available=False` and lookups transparently fall back to cache (or `None`) — nothing breaks when AD is not configured.
- **Username normalization**: `DOMAIN\user` and `user@domain` collapse to the sAMAccountName portion and lowercased before lookup, so both Windows Event Log format and email-style identifiers resolve consistently.
- **LDAP filter injection guard**: parens, asterisks, backslashes, and NULs hex-escaped (`\28`, `\29`, `\2a`, `\5c`, `\00`) before building the search filter.
- **Password handling**: read from `AD_BIND_PASSWORD` env var if set, otherwise from config. Env var is the recommended deployment form (documented).
- **Cache table** `ad_user_cache` auto-created on init; TTL default 60 min. Stale cache is still returned when AD becomes unreachable so UI doesn't flicker.
- **Health endpoint** does a live bind test so operators can verify the service account.

### API wiring
- `create_app(db, config, analytics=None, ad_lookup=None)` — builds from config when omitted.
- `GET /api/system/ad/status` — health + bind probe.
- `GET /api/users/{username}/ad-info?refresh={bool}` — direct lookup.
- `GET /api/users/{username}/detail` enriched with `ad: {email, display_name, found, source}`.

### Dashboard UI
- `loadUserDetail` now opens a proper modal (was `alert(JSON)`). Shows display name, clickable `mailto:` link, activity cards, and a source hint (live vs cache vs AD-disabled).

### Config + deps
- `config.yaml`: new `active_directory` section, `enabled: false` by default so existing installs see no change until flipped on.
- `requirements.txt`: `ldap3>=2.9.1`, optional.

## Test plan
- [x] Without `ldap3`: module inits cleanly, `available=False`, `init_error` reports cause
- [x] Username normalization: `DOMAIN\user`, `user@domain.com`, `User` all → `user`
- [x] LDAP escape: `x)(cn=*` → `x\29\28cn=\2a`
- [x] With `ldap3` 2.9.1 installed: health probe returns structured info
- [ ] Real AD: configure server, verify bind + search against a real account
- [ ] Cache TTL: first call `live`, second call `cache`, after 60min `live` again
- [ ] AD outage simulation: cache miss → returns `None`; cache hit → returns `stale-cache`

## Notes
- Part of a 4-PR series: **A (this)** AD lookup → **B** efficiency score + non-compliance report → **C** SMTP email with admin CC → **D** scheduled notifications via APScheduler. Each PR is independently deployable; later PRs compose on earlier ones.
- Storing plaintext AD password in `config.yaml` is supported but not recommended. The Windows Credential Manager / env var approach should be used in production.