### PR TITLE
Fix AttributeError in optimize_database/cleanup_old_scans (closes #13)

### DIFF
--- a/src/storage/database.py
+++ b/src/storage/database.py
@@ -1795,7 +1795,7 @@ class Database:
                         deleted_runs += cur.rowcount
             return {"deleted_runs": deleted_runs, "deleted_files": deleted_files}
         except Exception as e:
-            self.logger.error(f"Cleanup error: {e}")
+            logger.error(f"Cleanup error: {e}")
             return {"error": str(e)}
 
     def optimize_database(self) -> dict:
@@ -1833,7 +1833,7 @@ class Database:
                 "wal_cleared": wal_size_before,
             }
         except Exception as e:
-            self.logger.error(f"Optimize error: {e}")
+            logger.error(f"Optimize error: {e}")
             return {"error": str(e)}
 
     def get_db_stats(self) -> dict:


### PR DESCRIPTION
## Summary

Fixes #13. `Database.optimize_database()` and `Database.cleanup_old_scans()` both called `self.logger.error(...)` from their except handlers, but `Database` has no `self.logger` attribute — the module uses a module-level `logger = logging.getLogger("file_activity.database")`.

When VACUUM or the cleanup SQL raised (WAL locked, other cursor open, etc.), the except block raised `AttributeError: 'Database' object has no attribute 'logger'`, which masked the original error and made the endpoint return 500 instead of the structured `{"error": str(e)}` shape.

**User-visible effect**: the "Optimize Et" and "Eski Taramalari Temizle" buttons on the Kaynaklar / Veritabani Bakimi card silently fail.

## Change

Two single-line fixes in `src/storage/database.py`:
- Line 1798: `self.logger.error(...)` → `logger.error(...)` in `cleanup_old_scans`
- Line 1836: `self.logger.error(...)` → `logger.error(...)` in `optimize_database`

The module-level `logger` is already correctly namespaced at `file_activity.database`.

## Test plan
- [x] `grep -n 'self\.logger' src/storage/database.py` returns empty
- [x] `py_compile` passes
- [ ] Click "Optimize Et" on a real install — VACUUM + ANALYZE + checkpoint runs, notify shows before/after sizes
- [ ] Click "Eski Taramalari Temizle" — cleanup count returned, no 500

## Notes
Closes #13.