### PR TITLE
Lower watcher default poll interval to 60s + make it configurable (re #14)

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -24,6 +24,12 @@ sources: []
   #   archive_dest: "D:\\Archive\\engineering"
   #   enabled: true
 
+watcher:
+  # Dosya degisikligi izleme (polling-based). Yeni/degisen/silinen dosyalar
+  # bu aralikta scan_runs tablosuna yansir. Cok dusuk degerler FS'i yorar,
+  # cok yuksek degerler degisikliklerin gorunmesini geciktirir.
+  poll_interval_seconds: 60   # varsayilan 60 sn, minimum 10 sn (API zorlar)
+
 scanner:
   max_workers: 4              # paralel dizin tarayıcı sayısı
   batch_size: 1000            # DB batch insert boyutu

--- a/src/dashboard/api.py
+++ b/src/dashboard/api.py
@@ -812,12 +812,21 @@ def create_app(db, config, analytics=None):
     # --- FILE WATCHER API ---
 
     @app.post("/api/watcher/{source_id}/start")
-    async def start_watcher(source_id: int, interval: int = 300):
-        from src.scanner.file_watcher import FileWatcher, get_watcher_status
+    async def start_watcher(source_id: int,
+                             interval: Optional[int] = Query(
+                                 default=None, ge=10, le=3600,
+                                 description="Polling araligi (saniye). "
+                                             "Bos birakilirsa config.watcher.poll_interval_seconds "
+                                             "veya 60 saniye kullanilir."
+                             )):
+        from src.scanner.file_watcher import FileWatcher, DEFAULT_POLL_INTERVAL
         src = _get_source(db, source_id)
+        if interval is None:
+            interval = int(config.get("watcher", {}).get("poll_interval_seconds",
+                                                          DEFAULT_POLL_INTERVAL))
         watcher = FileWatcher(db, src.id, src.unc_path, interval)
         watcher.start()
-        return {"status": "started", "interval": interval}
+        return {"status": "started", "interval": watcher.interval}
 
     @app.post("/api/watcher/{source_id}/stop")
     async def stop_watcher(source_id: int):

--- a/src/scanner/file_watcher.py
+++ b/src/scanner/file_watcher.py
@@ -30,12 +30,18 @@ def get_watcher_status(source_id: int = None) -> dict:
         return {"status": "inactive"}
 
 
+DEFAULT_POLL_INTERVAL = 60  # Polling aralığı — config.yaml ile override edilebilir
+MIN_POLL_INTERVAL = 10      # Daha düşük değerler DoS etkisi yaratır, reddedilir
+
+
 class FileWatcher:
-    def __init__(self, db: Database, source_id: int, path: str, interval: int = 300):
+    def __init__(self, db: Database, source_id: int, path: str,
+                 interval: int = DEFAULT_POLL_INTERVAL):
         self.db = db
         self.source_id = source_id
         self.path = path
-        self.interval = interval  # seconds between checks
+        # Minimum sinir uygula — cok dusuk degerler FS'i sarsitir
+        self.interval = max(MIN_POLL_INTERVAL, interval)
         self._running = False
         self._thread = None
         self._stats_lock = threading.Lock()


### PR DESCRIPTION
## Summary

Partial fix for #14. Customer reported file changes don't appear in the dashboard in real time — root cause was `FileWatcher` defaulted to a 300-second (5 minute) polling interval, hardcoded in `__init__`. Lowers the default to **60 seconds** and makes it configurable.

## Changes

### `src/scanner/file_watcher.py`
- `DEFAULT_POLL_INTERVAL = 60` (was 300, hardcoded)
- `MIN_POLL_INTERVAL = 10` enforced in `__init__` — lower values DoS the FS
- `self.interval = max(MIN_POLL_INTERVAL, interval)` so even a direct call with `interval=0` gets clamped

### `src/dashboard/api.py`
- `POST /api/watcher/{source_id}/start`: `interval` param is now `Query(ge=10, le=3600)` and **optional**. When omitted, reads `config.watcher.poll_interval_seconds`, falling back to 60.
- Response now reports `watcher.interval` (the clamped value actually used), not the raw query param.

### `config.yaml`
- New `watcher:` section with `poll_interval_seconds: 60` and a comment explaining the tradeoff.

## What this doesn't fix

This is a polling-based watcher — truly sub-second real-time change notification needs `watchdog` + `ReadDirectoryChangesW`. That's a larger change (new dep, event-driven rewrite) and stays in the #14 backlog for a follow-up PR.

## Test plan
- [x] `py_compile` passes
- [x] New default is 60s, visible in the response after start
- [ ] On customer install: start watcher, drop a file in the share, verify it appears within 60-70 seconds
- [ ] `interval=5` rejected (< 10 min)
- [ ] `interval=5000` rejected (> 3600 max)
- [ ] `interval` omitted → uses config value

## Notes
Related to #14.