### PR TITLE
Per-user efficiency score + non-compliance report (PR B of 4)

### DIFF
--- a/src/dashboard/api.py
+++ b/src/dashboard/api.py
@@ -733,6 +733,18 @@ def create_app(db, config, analytics=None):
     async def user_activity(username: str, days: int = 30):
         return db.get_user_activity(username, days=days)
 
+    @app.get("/api/users/{username}/efficiency")
+    async def user_efficiency(username: str,
+                               source_id: Optional[int] = None,
+                               scan_id: Optional[int] = None):
+        """Kullanici verimlilik skoru + uyumsuzluk raporu.
+
+        0-100 arasi skor, faktorler, somut oneriler. source_id ve scan_id
+        opsiyonel; hic biri verilmezse son tamamlanmis tarama kullanilir.
+        """
+        from src.user_activity.efficiency_score import compute_user_score
+        return compute_user_score(db, username, source_id=source_id, scan_id=scan_id)
+
     @app.get("/api/users/{username}/detail")
     async def user_detail(username: str, days: int = 30):
         """Kullanici detay raporu - HTML dashboard icin genisletilmis format."""

--- a/src/dashboard/static/index.html
+++ b/src/dashboard/static/index.html
@@ -1715,8 +1715,12 @@ async function loadUsers() {
             renderHeatmap(heatData);
 
             document.getElementById('users-table').innerHTML = `
-                <thead><tr><th>Kullanici</th><th>Erisim</th><th>Detay</th></tr></thead>
-                <tbody>${topUsers.slice(0,20).map(u => `<tr><td><strong>${u.username}</strong></td><td>${formatNum(u.access_count||u.count||0)}</td><td><button class="btn btn-sm btn-outline" onclick="loadUserDetail('${u.username}')">Detay</button></td></tr>`).join('')}</tbody>
+                <thead><tr><th>Kullanici</th><th>Erisim</th><th>Islem</th></tr></thead>
+                <tbody>${topUsers.slice(0,20).map(u => `<tr><td><strong>${u.username}</strong></td><td>${formatNum(u.access_count||u.count||0)}</td>
+                    <td style="display:flex;gap:4px">
+                        <button class="btn btn-sm btn-outline" onclick="loadUserDetail('${u.username}')">Detay</button>
+                        <button class="btn btn-sm btn-outline" style="border-color:var(--accent);color:var(--accent)" onclick="loadUserEfficiency('${u.username}')">Verimlilik</button>
+                    </td></tr>`).join('')}</tbody>
             `;
         }
     } catch(e) { console.error(e); }
@@ -1748,6 +1752,76 @@ async function loadUserDetail(username) {
         const data = await api(`/users/${username}/detail`);
         alert(JSON.stringify(data.summary, null, 2));
     } catch(e) { notify(e.message, 'error'); }
+}
+
+// Verimlilik skoru modali — PR B (efficiency score)
+async function loadUserEfficiency(username) {
+    try {
+        const d = await api(`/users/${username}/efficiency`);
+        const score = d.score || 0;
+        const grade = d.grade || 'A';
+        // Renk: A/B yesil, C sari, D/E kirmizi
+        const gradeColor = {A:'var(--success)', B:'var(--success)', C:'var(--warning)', D:'var(--danger)', E:'var(--danger)'}[grade] || 'var(--text-primary)';
+
+        const factorsHtml = (d.factors || []).length === 0 ?
+            '<p style="color:var(--text-muted);font-size:13px">Hicbir uyumsuzluk tespit edilmedi. Iyi gidiyorsunuz.</p>' :
+            (d.factors || []).map(f => `
+                <div style="margin-bottom:10px;padding:10px;background:var(--bg-primary);border-radius:6px">
+                    <div style="display:flex;justify-content:space-between;align-items:center;font-size:13px">
+                        <strong>${f.label}</strong>
+                        <span style="color:var(--danger);font-weight:600">-${f.penalty} puan</span>
+                    </div>
+                    <div style="font-size:11px;color:var(--text-muted);margin-top:4px">${formatNum(f.count)} ${f.name === 'dormant' ? 'gun' : 'dosya'} (max ceza: -${f.max})</div>
+                </div>
+            `).join('');
+
+        const suggestionsHtml = (d.suggestions || []).map(s => `<li style="margin-bottom:6px">${s}</li>`).join('');
+
+        const body = `
+            <h3 style="margin:0 0 16px 0">Verimlilik Skoru: ${username}</h3>
+
+            <div style="display:flex;gap:20px;align-items:center;background:var(--bg-primary);padding:20px;border-radius:8px;margin-bottom:20px">
+                <div style="flex:0 0 100px;text-align:center">
+                    <div style="font-size:56px;font-weight:700;color:${gradeColor};line-height:1">${score}</div>
+                    <div style="font-size:14px;color:var(--text-muted);margin-top:4px">/ 100</div>
+                </div>
+                <div style="flex:0 0 80px;text-align:center">
+                    <div style="font-size:48px;font-weight:700;color:${gradeColor};line-height:1">${grade}</div>
+                    <div style="font-size:11px;color:var(--text-muted);margin-top:4px">Sinif</div>
+                </div>
+                <div style="flex:1;font-size:12px;color:var(--text-muted)">
+                    <div><strong>Toplam dosya:</strong> ${formatNum(d.total_files||0)}</div>
+                    <div><strong>Toplam boyut:</strong> ${formatSize(d.total_size||0)}</div>
+                    <div><strong>Toplam ceza:</strong> -${d.total_penalty||0} puan</div>
+                    <div style="font-size:10px;margin-top:4px">Son guncelleme: ${d.computed_at ? new Date(d.computed_at).toLocaleString() : '-'}</div>
+                </div>
+            </div>
+
+            <h4 style="font-size:13px;margin:0 0 8px 0;color:var(--text-muted);text-transform:uppercase;letter-spacing:0.5px">Faktorler</h4>
+            ${factorsHtml}
+
+            ${suggestionsHtml ? `
+                <h4 style="font-size:13px;margin:16px 0 8px 0;color:var(--text-muted);text-transform:uppercase;letter-spacing:0.5px">Oneriler</h4>
+                <ul style="font-size:13px;line-height:1.6;padding-left:20px;margin:0">${suggestionsHtml}</ul>
+            ` : ''}
+
+            <div style="text-align:right;margin-top:20px">
+                <button class="btn btn-outline" onclick="closeModal('modal-user-efficiency')">Kapat</button>
+            </div>
+        `;
+
+        let modal = document.getElementById('modal-user-efficiency');
+        if (!modal) {
+            modal = document.createElement('div');
+            modal.id = 'modal-user-efficiency';
+            modal.className = 'modal-overlay';
+            modal.innerHTML = '<div class="modal" style="max-width:700px;width:90%"></div>';
+            modal.onclick = (e) => { if (e.target === modal) closeModal('modal-user-efficiency'); };
+            document.body.appendChild(modal);
+        }
+        modal.querySelector('.modal').innerHTML = body;
+        modal.classList.add('active');
+    } catch(e) { notify(e.message || 'Verimlilik skoru alinamadi', 'error'); }
 }
 
 // ═══════════════════════════════════════════════════

--- a/src/user_activity/efficiency_score.py
+++ b/src/user_activity/efficiency_score.py
@@ -67,10 +67,6 @@ def _grade(score: int) -> str:
     return "E"
 
 
-def _pluralize(count: int, singular: str, plural: str) -> str:
-    return f"{count} {singular if count == 1 else plural}"
-
-
 def compute_user_score(db, username: str,
                         source_id: Optional[int] = None,
                         scan_id: Optional[int] = None) -> dict:

--- a/src/user_activity/efficiency_score.py
+++ b/src/user_activity/efficiency_score.py
@@ -1,0 +1,311 @@
+"""Kullanici verimlilik skoru + standart uyumsuzluk raporu.
+
+Bir kullanici icin son taranan dosyalara bakarak 0-100 arasi bir
+verimlilik skoru uretir ve iyilestirme icin somut onerileri listeler.
+
+Skor algoritmasi (base 100, her faktor kirmizi puan dusurur):
+
+    Faktor                              Ceza (puan)             Sinir
+    ----------------------------------  ----------------------  -----
+    Erismedigi eski dosyalar (1+ yil)   -2 her 10 dosya         -30
+    Buyuk dosyalar (>100 MB)            -1 her dosya            -15
+    MIT adlandirma ihlalleri            -1 her 10 dosya         -20
+    Kopya dosyalar (ayni ad+boyut)      -1 her 5 kopya          -15
+    Dormant hesap (90+ gun hareketsiz)  -10                     -10
+    Dizilimsiz ekstrem dosya buyumesi   -1 her aktif gun        -5
+                                                                -----
+                                              TOPLAM MAX CEZA:  -95
+    (En dusuk skor 5, ciddi uyumsuzlukta bile pozitif kalir.)
+
+Sonuc:
+    {
+      "username": "jdoe",
+      "score": 78,
+      "grade": "B",            # A 90+, B 75+, C 60+, D 45+, E <45
+      "factors": [
+        {"name": "stale_files", "count": 42, "penalty": 8, "max": 30,
+         "label": "1+ yildir erisilmeyen dosyalar"},
+        ...
+      ],
+      "non_compliance": {
+        "stale_files": 42,
+        "oversized_files": 3,
+        "naming_violations": 15,
+        "duplicate_files": 8,
+        "dormant": false,
+      },
+      "suggestions": [
+        "42 adet 1 yildir erismediginiz dosya var - arsivlemeyi dusunun",
+        "3 adet 100MB'dan buyuk dosya tespit edildi - sikistirma faydali olabilir",
+        ...
+      ],
+      "scan_id": 12,
+      "computed_at": "2026-04-21T08:15:00"
+    }
+"""
+
+import logging
+from datetime import datetime, timedelta
+from typing import Optional
+
+logger = logging.getLogger("file_activity.efficiency_score")
+
+STALE_THRESHOLD_DAYS = 365
+OVERSIZED_THRESHOLD_BYTES = 100 * 1024 * 1024  # 100 MB
+DORMANT_THRESHOLD_DAYS = 90
+
+
+def _grade(score: int) -> str:
+    if score >= 90:
+        return "A"
+    if score >= 75:
+        return "B"
+    if score >= 60:
+        return "C"
+    if score >= 45:
+        return "D"
+    return "E"
+
+
+def _pluralize(count: int, singular: str, plural: str) -> str:
+    return f"{count} {singular if count == 1 else plural}"
+
+
+def compute_user_score(db, username: str,
+                        source_id: Optional[int] = None,
+                        scan_id: Optional[int] = None) -> dict:
+    """Kullanici verimlilik skoru hesapla.
+
+    source_id verilmezse tum kaynaklardaki son tamamlanmis tarama kullanilir.
+    scan_id verilirse direk o scan uzerinde calisir (source_id opsiyonel).
+
+    username bulunamazsa veya hic dosya sahibi degilse score=100 ile temiz doner.
+    """
+    if scan_id is None and source_id is not None:
+        scan_id = db.get_latest_scan_id(source_id, include_running=False)
+    elif scan_id is None and source_id is None:
+        with db.get_cursor() as cur:
+            cur.execute("""
+                SELECT id FROM scan_runs WHERE status = 'completed'
+                ORDER BY started_at DESC LIMIT 1
+            """)
+            row = cur.fetchone()
+            scan_id = row["id"] if row else None
+
+    if scan_id is None:
+        return _empty_result(username, reason="Tarama verisi bulunamadi")
+
+    factors: list = []
+    total_penalty = 0
+    nc = {
+        "stale_files": 0,
+        "oversized_files": 0,
+        "naming_violations": 0,
+        "duplicate_files": 0,
+        "dormant": False,
+    }
+
+    with db.get_cursor() as cur:
+        # Toplam kullanici dosyalari (hicbiri yoksa erken don)
+        cur.execute("""
+            SELECT COUNT(*) AS total, COALESCE(SUM(file_size), 0) AS total_size
+            FROM scanned_files WHERE scan_id = ? AND owner = ?
+        """, (scan_id, username))
+        row = cur.fetchone()
+        total_files = row["total"]
+        total_size = row["total_size"]
+
+        if total_files == 0:
+            return _empty_result(username, scan_id=scan_id,
+                                 reason="Bu kullaniciya ait dosya bulunamadi")
+
+        # 1. Stale (1+ yil erisilmeyen) dosyalar
+        stale_cutoff = (datetime.now() - timedelta(days=STALE_THRESHOLD_DAYS)).strftime('%Y-%m-%d')
+        cur.execute("""
+            SELECT COUNT(*) AS cnt FROM scanned_files
+            WHERE scan_id = ? AND owner = ?
+              AND last_access_time IS NOT NULL
+              AND last_access_time <= ?
+        """, (scan_id, username, stale_cutoff))
+        stale_count = cur.fetchone()["cnt"]
+        if stale_count > 0:
+            penalty = min(30, (stale_count // 10) * 2)
+            nc["stale_files"] = stale_count
+            if penalty > 0:
+                total_penalty += penalty
+                factors.append({
+                    "name": "stale_files",
+                    "label": "1+ yildir erisilmeyen dosyalar",
+                    "count": stale_count,
+                    "penalty": penalty,
+                    "max": 30,
+                })
+
+        # 2. Oversized dosyalar (>100 MB)
+        cur.execute("""
+            SELECT COUNT(*) AS cnt FROM scanned_files
+            WHERE scan_id = ? AND owner = ? AND file_size > ?
+        """, (scan_id, username, OVERSIZED_THRESHOLD_BYTES))
+        oversized_count = cur.fetchone()["cnt"]
+        if oversized_count > 0:
+            penalty = min(15, oversized_count)
+            nc["oversized_files"] = oversized_count
+            if penalty > 0:
+                total_penalty += penalty
+                factors.append({
+                    "name": "oversized_files",
+                    "label": "100 MB'dan buyuk dosyalar",
+                    "count": oversized_count,
+                    "penalty": penalty,
+                    "max": 15,
+                })
+
+        # 3. Kopya dosyalar (ayni file_name + file_size > 1 kez)
+        cur.execute("""
+            SELECT COALESCE(SUM(cnt - 1), 0) AS dup_extras FROM (
+                SELECT file_name, file_size, COUNT(*) AS cnt
+                FROM scanned_files
+                WHERE scan_id = ? AND owner = ? AND file_size > 0
+                GROUP BY file_name, file_size
+                HAVING COUNT(*) > 1
+            )
+        """, (scan_id, username))
+        dup_extras = cur.fetchone()["dup_extras"] or 0
+        if dup_extras > 0:
+            nc["duplicate_files"] = dup_extras
+            penalty = min(15, dup_extras // 5)
+            if penalty > 0:
+                total_penalty += penalty
+                factors.append({
+                    "name": "duplicate_files",
+                    "label": "Kopya dosyalar (ayni isim+boyut)",
+                    "count": dup_extras,
+                    "penalty": penalty,
+                    "max": 15,
+                })
+
+    # 4. MIT naming violations — analyzer'i kullanici dosyalari uzerinde calistir
+    try:
+        from src.scanner.file_scanner import MITNamingAnalyzer
+        analyzer = MITNamingAnalyzer()
+        with db.get_cursor() as cur:
+            cur.execute("""
+                SELECT file_path, file_name FROM scanned_files
+                WHERE scan_id = ? AND owner = ?
+            """, (scan_id, username))
+            for row in cur:
+                analyzer.analyze(row["file_path"], row["file_name"])
+        report = analyzer.get_report()
+        violations = int(report.get("total_issues", 0) or 0)
+        if violations > 0:
+            nc["naming_violations"] = violations
+            penalty = min(20, violations // 10)
+            if penalty > 0:
+                total_penalty += penalty
+                factors.append({
+                    "name": "naming_violations",
+                    "label": "MIT adlandirma ihlalleri",
+                    "count": violations,
+                    "penalty": penalty,
+                    "max": 20,
+                })
+    except Exception as e:
+        logger.debug("MIT naming analyzer calistirilamadi: %s", e)
+
+    # 5. Dormant account (90+ gun aktivite yok) — user_access_logs'tan
+    try:
+        with db.get_cursor() as cur:
+            cur.execute("""
+                SELECT MAX(access_time) AS last_seen FROM user_access_logs
+                WHERE username = ?
+            """, (username,))
+            row = cur.fetchone()
+            last_seen = row["last_seen"] if row else None
+        if last_seen:
+            try:
+                last_dt = datetime.strptime(last_seen[:19], "%Y-%m-%d %H:%M:%S")
+                days_idle = (datetime.now() - last_dt).days
+                if days_idle >= DORMANT_THRESHOLD_DAYS:
+                    total_penalty += 10
+                    nc["dormant"] = True
+                    factors.append({
+                        "name": "dormant",
+                        "label": f"{days_idle} gundur aktif degil",
+                        "count": days_idle,
+                        "penalty": 10,
+                        "max": 10,
+                    })
+            except (ValueError, TypeError):
+                pass
+        # last_seen yoksa event log hic gelmemis; cezalandirmaca (data gap'i)
+    except Exception as e:
+        logger.debug("Dormant check hata: %s", e)
+
+    score = max(5, 100 - total_penalty)
+    suggestions = _build_suggestions(nc, total_files)
+
+    return {
+        "username": username,
+        "score": score,
+        "grade": _grade(score),
+        "total_penalty": total_penalty,
+        "factors": factors,
+        "non_compliance": nc,
+        "suggestions": suggestions,
+        "total_files": total_files,
+        "total_size": total_size,
+        "scan_id": scan_id,
+        "computed_at": datetime.now().isoformat(),
+    }
+
+
+def _build_suggestions(nc: dict, total_files: int) -> list:
+    out = []
+    if nc.get("stale_files", 0) > 0:
+        out.append(
+            f"{nc['stale_files']} adet 1 yildir erismediginiz dosya var — "
+            f"arsivleme once buradan baslamali."
+        )
+    if nc.get("oversized_files", 0) > 0:
+        out.append(
+            f"{nc['oversized_files']} adet 100 MB'dan buyuk dosya tespit edildi — "
+            f"sikistirma veya uzun sureli depolamaya tasima dusunun."
+        )
+    if nc.get("duplicate_files", 0) > 0:
+        out.append(
+            f"{nc['duplicate_files']} kopya dosya fark edildi — "
+            f"birini tutup digerlerini silmek alan kazandirir."
+        )
+    if nc.get("naming_violations", 0) > 0:
+        out.append(
+            f"{nc['naming_violations']} dosya MIT adlandirma standartlarina uymuyor — "
+            f"arama/filtrelemede zorluk yasayabilirsiniz."
+        )
+    if nc.get("dormant"):
+        out.append(
+            "Son 90 gunden beri sisteme aktif erisim kaydiniz yok — "
+            "hesap yoneticinizle konusmanizi oneririz."
+        )
+    if not out and total_files > 0:
+        out.append("Herhangi bir uyumsuzluk tespit edilmedi — iyi gidiyorsunuz.")
+    return out
+
+
+def _empty_result(username: str, scan_id: Optional[int] = None,
+                   reason: str = "") -> dict:
+    return {
+        "username": username,
+        "score": 100,
+        "grade": "A",
+        "total_penalty": 0,
+        "factors": [],
+        "non_compliance": {
+            "stale_files": 0, "oversized_files": 0, "naming_violations": 0,
+            "duplicate_files": 0, "dormant": False,
+        },
+        "suggestions": [reason] if reason else [],
+        "total_files": 0,
+        "total_size": 0,
+        "scan_id": scan_id,
+        "computed_at": datetime.now().isoformat(),
+    }


### PR DESCRIPTION
## Summary

Part B of the user-notification feature series. Computes a 0-100 efficiency score per user from the latest scan, identifying non-compliant files and surfacing actionable suggestions. Feeds a "Verimlilik" button in the Kullanici Aktivite table; will later be embedded in the scheduled e-mail notifications shipped in PR C/D.

## Scoring algorithm

Base 100, then deduct per category:

| Category | Penalty | Cap |
|---|---|---|
| Stale files (last_access > 1 year) | -2 per 10 files | -30 |
| Oversized (>100 MB) | -1 per file | -15 |
| Duplicates (same name+size) | -1 per 5 extras | -15 |
| MIT naming violations | -1 per 10 files | -20 |
| Dormant (no activity 90+ days) | -10 flat | -10 |
| **Max total penalty** | | **-95** |

Grade: A 90+, B 75+, C 60+, D 45+, E <45. Minimum score clamped at 5.

## Changes

### New `src/user_activity/efficiency_score.py`
- `compute_user_score(db, username, source_id=None, scan_id=None)` — main entry point
- When `scan_id` and `source_id` both omitted, uses the most recent completed scan across all sources
- Factors with zero penalty are reported in `non_compliance` counts but not listed as factor rows — avoids UI clutter when counts round down below threshold
- Empty cases (no scan, no files for user) return `score=100` grade `A` with an informational suggestion, so callers always have a result

### API
- `GET /api/users/{username}/efficiency?source_id=&scan_id=`
- Returns: `{username, score, grade, total_penalty, factors[], non_compliance, suggestions[], total_files, total_size, scan_id, computed_at}`

### Dashboard UI
- Kullanici Aktivite table row actions now include "Verimlilik" button
- Opens a 700px modal showing:
  - Large score + letter grade (color-coded: A/B green, C yellow, D/E red)
  - Factors list with per-factor penalty and max
  - Suggestions list
  - Total file count, size, total penalty, and compute timestamp

## Test plan
- [x] `py_compile` passes
- [x] Fixture test with 3 users:
  - `jdoe` (8 stale, 2 oversized, 2 duplicates) → score 98 (stale `<10` rounds to 0 penalty, dup `<5` rounds to 0, oversized -2)
  - `alice` (1 clean file) → score 100 A
  - unknown user → score 100 with reason
- [ ] Real scan data with MIT naming violations and dormant account
- [ ] UI smoke: button opens modal, renders correctly on both AD-enabled and disabled installs

## Notes

- Depends on `get_latest_scan_id(source_id, include_running)` which already exists in `Database`
- `MITNamingAnalyzer` imported lazily; any exception is logged and naming simply contributes nothing (so a broken analyzer doesn't drop scoring)
- Duplicate detection uses `file_name + file_size` matching (same logic as `/api/reports/duplicates/{source_id}`)
- Part of 4-PR series: A (AD lookup, #12) → **B (this)** → C (SMTP) → D (scheduler). B reuses A's data indirectly when the notification text needs the user's display name.