### PR TITLE
SMTP notifier: per-user efficiency e-mails with admin CC (PR C of 4)

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -32,6 +32,24 @@ active_directory:
   cache_ttl_minutes: 60           # Sonuclar TTL boyunca SQLite'ta cache'lenir
   timeout_seconds: 5
 
+smtp:
+  # Kullanici verimlilik raporlari icin SMTP sunucu ayarlari.
+  # enabled=false iken tum e-posta endpoint'leri no-op calisir.
+  enabled: false
+  host: ""                        # ornek: smtp.office365.com, smtp.gmail.com
+  port: 587                       # 587 STARTTLS icin, 465 SSL icin, 25 plain
+  use_tls: true                   # STARTTLS (587 kullaniyorsaniz true)
+  use_ssl: false                  # Implicit TLS (465 kullaniyorsaniz true + use_tls: false)
+  username: ""
+  password: ""                    # Tavsiye: bos birakip SMTP_PASSWORD env var kullanin
+  from_address: ""                # ornek: fileactivity@firma.local
+  from_name: "File Activity System"
+  timeout_seconds: 10
+
+notifications:
+  admin_cc_email: ""              # Her bildirime CC eklenecek yonetici adresi
+  subject_prefix: "[File Activity]"
+
 sources: []
   # Örnek:
   # - name: "Engineering"

--- a/src/dashboard/api.py
+++ b/src/dashboard/api.py
@@ -116,7 +116,7 @@ def _read_version() -> str:
 APP_VERSION = _read_version()
 
 
-def create_app(db, config, analytics=None, ad_lookup=None):
+def create_app(db, config, analytics=None, ad_lookup=None, email_notifier=None):
     """FastAPI uygulamasini olustur.
 
     analytics: Opsiyonel AnalyticsEngine. Verilmezse config.analytics'e gore
@@ -126,6 +126,10 @@ def create_app(db, config, analytics=None, ad_lookup=None):
     ad_lookup: Opsiyonel ADLookup. Verilmezse config.active_directory'den
     olusturulur; ldap3 yoksa veya enabled=false ise available=False ile
     doner ve endpoint'ler cache degeri / None doner.
+
+    email_notifier: Opsiyonel EmailNotifier. Verilmezse config.smtp'den
+    olusturulur; smtp.enabled=false ise available=False ile doner ve
+    e-posta endpoint'leri {"skipped": true} doner.
     """
     if analytics is None:
         from src.storage.analytics import AnalyticsEngine
@@ -133,10 +137,14 @@ def create_app(db, config, analytics=None, ad_lookup=None):
     if ad_lookup is None:
         from src.user_activity.ad_lookup import ADLookup
         ad_lookup = ADLookup(db, config)
+    if email_notifier is None:
+        from src.user_activity.email_notifier import EmailNotifier
+        email_notifier = EmailNotifier(db, config)
 
     app = FastAPI(title="FILE ACTIVITY Dashboard", version=APP_VERSION)
     app.state.analytics = analytics
     app.state.ad_lookup = ad_lookup
+    app.state.email_notifier = email_notifier
 
     static_dir = os.path.join(os.path.dirname(__file__), "static")
     if os.path.exists(static_dir):
@@ -1599,12 +1607,125 @@ def create_app(db, config, analytics=None, ad_lookup=None):
             "version": APP_VERSION,
             "database": db.health_check(),
             "analytics": analytics.health(),
+            "email": email_notifier.health(),
         }
 
     @app.get("/api/system/analytics")
     async def analytics_status():
         """DuckDB analitik motor durumunu dondur."""
         return analytics.health()
+
+    # --- NOTIFICATIONS API ---
+
+    class TestEmailRequest(BaseModel):
+        to: str
+        username: Optional[str] = "test"
+        display_name: Optional[str] = None
+
+    @app.get("/api/notifications/status")
+    async def notifications_status():
+        """SMTP konfigurasyon ozeti + canli bind testi."""
+        info = email_notifier.health()
+        if email_notifier.available:
+            info["probe"] = email_notifier.test_connection()
+        return info
+
+    @app.post("/api/notifications/test")
+    async def notifications_test(payload: TestEmailRequest):
+        """Belirtilen adrese kucuk bir dogrulama e-postasi gonder.
+
+        Kullanim: SMTP ayarlarini dogrulamak icin. Gercek skor degil,
+        sabit ornek skor verisi gonderilir. Admin CC varsa CC'ye eklenir.
+        """
+        if not email_notifier.available:
+            raise HTTPException(400, f"SMTP kullanilamaz: {email_notifier._init_error}")
+        fake_score = {
+            "score": 85, "grade": "B", "total_penalty": 15,
+            "factors": [
+                {"name": "stale_files", "label": "Test: 1+ yildir erisilmeyen dosyalar",
+                 "count": 42, "penalty": 8, "max": 30},
+                {"name": "oversized_files", "label": "Test: 100 MB'dan buyuk dosyalar",
+                 "count": 7, "penalty": 7, "max": 15},
+            ],
+            "non_compliance": {"stale_files": 42, "oversized_files": 7,
+                                "naming_violations": 0, "duplicate_files": 0,
+                                "dormant": False},
+            "suggestions": [
+                "Bu bir TEST mesajidir. SMTP ayarlariniz dogru calisiyor.",
+                "Gercek rapor zamanli bildirim zamanlayicisi (PR D) ile gelecek.",
+            ],
+            "total_files": 100, "total_size": 5 * 1024 * 1024 * 1024,
+        }
+        result = email_notifier.send_user_report(
+            username=payload.username or "test",
+            email=payload.to,
+            score_result=fake_score,
+            display_name=payload.display_name,
+        )
+        if not result.get("ok"):
+            raise HTTPException(500, result.get("error") or "Gonderim basarisiz")
+        return result
+
+    @app.post("/api/notifications/send-to/{username}")
+    async def notifications_send_to(username: str):
+        """Tek kullaniciya gercek verimlilik raporu gonder.
+
+        Kullanici e-postasi AD'den cozulur; yoksa 400 doner.
+        """
+        if not email_notifier.available:
+            raise HTTPException(400, f"SMTP kullanilamaz: {email_notifier._init_error}")
+
+        # AD lookup opsiyonel; ADLookup mevcutsa kullan
+        ad_info = None
+        try:
+            ad = getattr(app.state, "ad_lookup", None)
+            if ad and ad.available:
+                ad_info = ad.lookup(username)
+        except Exception:
+            ad_info = None
+
+        if not ad_info or not ad_info.get("email"):
+            raise HTTPException(404, f"{username} icin e-posta bulunamadi (AD lookup sonucu yok)")
+
+        from src.user_activity.efficiency_score import compute_user_score
+        score = compute_user_score(db, username)
+        result = email_notifier.send_user_report(
+            username=username,
+            email=ad_info["email"],
+            score_result=score,
+            display_name=ad_info.get("display_name"),
+        )
+        if not result.get("ok"):
+            raise HTTPException(500, result.get("error") or "Gonderim basarisiz")
+        return {"sent_to": ad_info["email"], "cc": result.get("cc"), "score": score["score"]}
+
+    @app.get("/api/notifications/log")
+    async def notifications_log(username: Optional[str] = None,
+                                 status: Optional[str] = None,
+                                 page: int = Query(1, ge=1, le=10000),
+                                 page_size: int = Query(50, ge=1, le=500)):
+        """Gonderim log listesi (sayfalanmis)."""
+        offset = (page - 1) * page_size
+        conditions = []
+        params: list = []
+        if username:
+            conditions.append("username = ?")
+            params.append(username)
+        if status:
+            conditions.append("status = ?")
+            params.append(status)
+        where = (" WHERE " + " AND ".join(conditions)) if conditions else ""
+        with db.get_cursor() as cur:
+            cur.execute(f"SELECT COUNT(*) AS cnt FROM notification_log{where}", params)
+            total = cur.fetchone()["cnt"]
+            cur.execute(
+                f"""SELECT id, username, email, cc, subject, status, error, sent_at
+                    FROM notification_log{where}
+                    ORDER BY sent_at DESC LIMIT ? OFFSET ?""",
+                params + [page_size, offset],
+            )
+            rows = [dict(r) for r in cur.fetchall()]
+        return {"total": total, "rows": rows, "page": page, "page_size": page_size}
 
     @app.get("/api/system/version")
     async def version():

--- a/src/user_activity/email_notifier.py
+++ b/src/user_activity/email_notifier.py
@@ -33,6 +33,7 @@ import logging
 import os
 import smtplib
 import ssl
+from contextlib import contextmanager
 from datetime import datetime
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
@@ -239,18 +240,9 @@ class EmailNotifier:
         lines.append("-- FILE ACTIVITY (otomatik bildirim)")
         return "\n".join(lines)
 
-    def send_user_report(self, username: str, email: str,
-                          score_result: dict,
-                          display_name: Optional[str] = None) -> dict:
-        """Kullaniciya verimlilik raporu e-postasi gonder.
-
-        admin_cc varsa CC'ye eklenir. Gonderim sonucu notification_log'a yazilir.
-        """
-        if not self.available:
-            return {"ok": False, "error": self._init_error, "skipped": True}
-        if not email:
-            return {"ok": False, "error": "hedef e-posta yok", "skipped": True}
-
+    def _build_message(self, username: str, email: str, score_result: dict,
+                        display_name: Optional[str]) -> tuple:
+        """Subject + MIMEMultipart + recipient list hazirla."""
         score = score_result.get("score", 0)
         grade = score_result.get("grade", "A")
         subject = f"{self.subject_prefix} Dosya Verimlilik Raporu — {grade} ({score}/100)"
@@ -268,10 +260,34 @@ class EmailNotifier:
         html = self._render_html(username, display_name, score_result)
         msg.attach(MIMEText(text, "plain", "utf-8"))
         msg.attach(MIMEText(html, "html", "utf-8"))
+        return subject, msg, recipients
 
+    def send_user_report(self, username: str, email: str,
+                          score_result: dict,
+                          display_name: Optional[str] = None,
+                          smtp_session: Optional[smtplib.SMTP] = None) -> dict:
+        """Kullaniciya verimlilik raporu e-postasi gonder.
+
+        admin_cc varsa CC'ye eklenir. Gonderim sonucu notification_log'a yazilir.
+
+        smtp_session: opsiyonel. Batch cagrilar icin EmailNotifier.session()
+        context manager'indan alinan acik bir SMTP baglantisi verilirse her
+        gonderimde yeni baglanti acilmaz. None ise her cagri icin kendi
+        baglantisini acar ve kapatir.
+        """
+        if not self.available:
+            return {"ok": False, "error": self._init_error, "skipped": True}
+        if not email:
+            return {"ok": False, "error": "hedef e-posta yok", "skipped": True}
+
+        subject, msg, recipients = self._build_message(username, email,
+                                                         score_result, display_name)
         try:
-            with self._connect() as s:
-                s.sendmail(self.from_address, recipients, msg.as_string())
+            if smtp_session is not None:
+                smtp_session.sendmail(self.from_address, recipients, msg.as_string())
+            else:
+                with self._connect() as s:
+                    s.sendmail(self.from_address, recipients, msg.as_string())
             self._log(username, email, subject, "sent", score_result=score_result,
                        cc=self.admin_cc or None)
             return {"ok": True, "email": email, "cc": self.admin_cc or None, "subject": subject}
@@ -281,6 +297,34 @@ class EmailNotifier:
             self._log(username, email, subject, "error", error=err,
                        cc=self.admin_cc or None)
             return {"ok": False, "error": err}
+
+    @contextmanager
+    def session(self):
+        """Batch gonderim icin persistent SMTP oturumu aciklama context manager'i.
+
+        Kullanim:
+            with notifier.session() as smtp:
+                for user in users:
+                    notifier.send_user_report(..., smtp_session=smtp)
+
+        Bir kez baglanir, tum gonderimler ayni soket uzerinden gider. Office
+        365 gibi rate-limited sunucularda bagimsiz baglanti sayisini makul
+        tutar. available=False ise hata atmaz, smtp=None yield eder ve
+        send_user_report her cagrida kendi baglantisini acar (downgrade).
+        """
+        if not self.available:
+            yield None
+            return
+        smtp = None
+        try:
+            smtp = self._connect()
+            yield smtp
+        finally:
+            if smtp is not None:
+                try:
+                    smtp.quit()
+                except Exception:
+                    pass
 
     def _log(self, username: str, email: str, subject: str, status: str,
               error: Optional[str] = None, cc: Optional[str] = None,

--- a/src/user_activity/email_notifier.py
+++ b/src/user_activity/email_notifier.py
@@ -1,0 +1,322 @@
+"""SMTP e-posta bildirim modulu.
+
+Kullanici verimlilik skoru + uyumsuzluk raporunu hedef kullanicilara
+HTML e-posta olarak gonderir, kopya (CC) olarak config'de tanimli
+yonetici adresini ekler.
+
+Konfigurasyon (config.yaml):
+
+    smtp:
+      enabled: false
+      host: "smtp.firma.local"
+      port: 587
+      use_tls: true              # STARTTLS (587 uzerinde)
+      use_ssl: false             # Implicit TLS (465 uzerinde) - use_tls ile birlikte false olmali
+      username: ""
+      password: ""               # Tavsiye: bos birakip SMTP_PASSWORD env var kullanin
+      from_address: "fileactivity@firma.local"
+      from_name: "File Activity System"
+      timeout_seconds: 10
+
+    notifications:
+      admin_cc_email: ""         # Her bildirime CC eklenecek yonetici adresi
+      subject_prefix: "[File Activity]"
+
+Tum bildirimler gonderim logu (notification_log tablosu) tutulur:
+  (id, username, email, subject, status, error, sent_at)
+
+enabled=false ise modul no-op calisir, send_* None doner.
+"""
+
+import json
+import logging
+import os
+import smtplib
+import ssl
+from datetime import datetime
+from email.mime.multipart import MIMEMultipart
+from email.mime.text import MIMEText
+from email.utils import formataddr
+from typing import Optional
+
+logger = logging.getLogger("file_activity.email_notifier")
+
+
+class EmailNotifier:
+    """SMTP uzerinden HTML bildirim e-postalari gonderir."""
+
+    def __init__(self, db, config: dict):
+        self.db = db
+        smtp = config.get("smtp", {}) or {}
+        notif = config.get("notifications", {}) or {}
+
+        self.enabled = bool(smtp.get("enabled", False))
+        self.host = smtp.get("host", "").strip()
+        self.port = int(smtp.get("port", 587))
+        self.use_tls = bool(smtp.get("use_tls", True))
+        self.use_ssl = bool(smtp.get("use_ssl", False))
+        self.username = smtp.get("username", "")
+        # Sifre oncelik: env var > config
+        self.password = os.environ.get("SMTP_PASSWORD") or smtp.get("password", "")
+        self.from_address = smtp.get("from_address", "")
+        self.from_name = smtp.get("from_name", "File Activity System")
+        self.timeout = int(smtp.get("timeout_seconds", 10))
+
+        self.admin_cc = (notif.get("admin_cc_email") or "").strip()
+        self.subject_prefix = notif.get("subject_prefix", "[File Activity]")
+
+        self._init_error: Optional[str] = None
+        if not self.enabled:
+            self._init_error = "config.smtp.enabled=false"
+        elif not self.host or not self.from_address:
+            self._init_error = "smtp.host veya smtp.from_address eksik"
+
+        self._ensure_log_table()
+
+        if self._init_error:
+            logger.info("EmailNotifier devre disi: %s", self._init_error)
+
+    @property
+    def available(self) -> bool:
+        return self._init_error is None
+
+    def _ensure_log_table(self):
+        with self.db.get_cursor() as cur:
+            cur.execute("""
+                CREATE TABLE IF NOT EXISTS notification_log (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    username TEXT,
+                    email TEXT,
+                    cc TEXT,
+                    subject TEXT,
+                    status TEXT NOT NULL,
+                    error TEXT,
+                    payload_json TEXT,
+                    sent_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+                )
+            """)
+            cur.execute("""
+                CREATE INDEX IF NOT EXISTS idx_notification_log_username_sent_at
+                ON notification_log(username, sent_at DESC)
+            """)
+
+    # ──────────────────────────────────────────────
+    # Alt seviye SMTP
+    # ──────────────────────────────────────────────
+
+    def _connect(self) -> smtplib.SMTP:
+        """SMTP baglantisi ac. SSL/TLS ayarlarina gore uygun sinif kullanilir."""
+        if self.use_ssl:
+            ctx = ssl.create_default_context()
+            s = smtplib.SMTP_SSL(self.host, self.port, timeout=self.timeout, context=ctx)
+        else:
+            s = smtplib.SMTP(self.host, self.port, timeout=self.timeout)
+            s.ehlo()
+            if self.use_tls:
+                ctx = ssl.create_default_context()
+                s.starttls(context=ctx)
+                s.ehlo()
+        if self.username and self.password:
+            s.login(self.username, self.password)
+        return s
+
+    def test_connection(self) -> dict:
+        """SMTP'ye bagla, login ol, NOOP at, disconnect. Mail gondermez."""
+        if not self.available:
+            return {"ok": False, "error": self._init_error}
+        try:
+            with self._connect() as s:
+                status, _ = s.noop()
+                return {"ok": True, "status_code": status, "host": self.host, "port": self.port}
+        except Exception as e:
+            return {"ok": False, "error": str(e)}
+
+    # ──────────────────────────────────────────────
+    # Sablon + gonderim
+    # ──────────────────────────────────────────────
+
+    def _render_html(self, username: str, display_name: Optional[str],
+                     score_result: dict) -> str:
+        score = score_result.get("score", 0)
+        grade = score_result.get("grade", "A")
+        grade_colors = {"A": "#16a34a", "B": "#65a30d", "C": "#d97706",
+                         "D": "#dc2626", "E": "#991b1b"}
+        grade_color = grade_colors.get(grade, "#64748b")
+
+        factors_rows = ""
+        for f in score_result.get("factors", []):
+            factors_rows += (
+                f'<tr>'
+                f'<td style="padding:8px;border-bottom:1px solid #e5e7eb">{f.get("label", "")}</td>'
+                f'<td style="padding:8px;border-bottom:1px solid #e5e7eb;text-align:right">{f.get("count", 0)}</td>'
+                f'<td style="padding:8px;border-bottom:1px solid #e5e7eb;text-align:right;color:#dc2626;font-weight:600">-{f.get("penalty", 0)}</td>'
+                f'</tr>'
+            )
+        if not factors_rows:
+            factors_rows = (
+                '<tr><td colspan="3" style="padding:12px;text-align:center;color:#64748b">'
+                'Hicbir uyumsuzluk tespit edilmedi. Iyi gidiyorsunuz.</td></tr>'
+            )
+
+        suggestions = "".join(
+            f'<li style="margin-bottom:8px">{s}</li>'
+            for s in score_result.get("suggestions", [])
+        ) or '<li style="color:#64748b">Herhangi bir oneri yok.</li>'
+
+        greeting = f"Merhaba {display_name or username},"
+
+        return f"""<!DOCTYPE html>
+<html lang="tr"><head><meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Dosya Verimlilik Raporunuz</title></head>
+<body style="margin:0;padding:0;background:#f3f4f6;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;color:#1f2937">
+<table role="presentation" width="100%" cellspacing="0" cellpadding="0" style="background:#f3f4f6;padding:24px 0">
+<tr><td align="center">
+<table role="presentation" width="600" cellspacing="0" cellpadding="0" style="max-width:600px;width:100%;background:#ffffff;border-radius:12px;overflow:hidden;box-shadow:0 1px 3px rgba(0,0,0,0.1)">
+  <tr><td style="padding:24px;background:linear-gradient(135deg,#3b82f6,#6366f1);color:#ffffff">
+    <div style="font-size:12px;text-transform:uppercase;letter-spacing:1px;opacity:0.85">FILE ACTIVITY</div>
+    <div style="font-size:22px;font-weight:700;margin-top:4px">Dosya Verimlilik Raporunuz</div>
+  </td></tr>
+  <tr><td style="padding:24px">
+    <p style="margin:0 0 16px 0;font-size:15px">{greeting}</p>
+    <p style="margin:0 0 24px 0;font-size:14px;line-height:1.6;color:#4b5563">
+      Son tarama sonucunuza gore kisisel dosya verimlilik skorunuz asagidadir.
+      Skor, arsivlemeye uygun eski dosyalar, buyuk boyutlu dosyalar, kopyalar
+      ve adlandirma standartlarina uyumlulugu birlikte degerlendirir.
+    </p>
+
+    <table role="presentation" width="100%" cellspacing="0" cellpadding="0" style="margin:0 0 24px 0">
+      <tr>
+        <td align="center" style="padding:20px;background:#f9fafb;border-radius:8px">
+          <div style="font-size:48px;font-weight:700;color:{grade_color};line-height:1">{score}</div>
+          <div style="font-size:12px;color:#6b7280;margin-top:4px">/ 100 puan</div>
+          <div style="margin-top:12px;font-size:24px;font-weight:700;color:{grade_color}">Sinif: {grade}</div>
+        </td>
+      </tr>
+    </table>
+
+    <h3 style="font-size:14px;margin:0 0 8px 0;color:#374151;text-transform:uppercase;letter-spacing:0.5px">Faktorler</h3>
+    <table role="presentation" width="100%" cellspacing="0" cellpadding="0" style="font-size:13px;border-collapse:collapse;margin-bottom:24px">
+      <thead>
+        <tr style="background:#f3f4f6">
+          <th style="padding:8px;text-align:left;font-weight:600;font-size:11px;text-transform:uppercase;color:#6b7280">Kategori</th>
+          <th style="padding:8px;text-align:right;font-weight:600;font-size:11px;text-transform:uppercase;color:#6b7280">Adet</th>
+          <th style="padding:8px;text-align:right;font-weight:600;font-size:11px;text-transform:uppercase;color:#6b7280">Puan</th>
+        </tr>
+      </thead>
+      <tbody>{factors_rows}</tbody>
+    </table>
+
+    <h3 style="font-size:14px;margin:0 0 8px 0;color:#374151;text-transform:uppercase;letter-spacing:0.5px">Oneriler</h3>
+    <ul style="font-size:14px;line-height:1.6;padding-left:20px;margin:0 0 24px 0;color:#1f2937">{suggestions}</ul>
+
+    <p style="margin:24px 0 0 0;font-size:12px;color:#6b7280;border-top:1px solid #e5e7eb;padding-top:16px">
+      Bu rapor otomatik olarak olusturulmustur. Sorulariniz icin sistem yoneticinize basvurun.
+    </p>
+  </td></tr>
+</table>
+</td></tr></table>
+</body></html>"""
+
+    def _render_text(self, username: str, display_name: Optional[str],
+                     score_result: dict) -> str:
+        lines = [
+            f"Merhaba {display_name or username},",
+            "",
+            f"Dosya verimlilik skorunuz: {score_result.get('score', 0)}/100 "
+            f"(Sinif: {score_result.get('grade', 'A')})",
+            "",
+            "Faktorler:",
+        ]
+        for f in score_result.get("factors", []) or []:
+            lines.append(f"  - {f.get('label', '')}: {f.get('count', 0)} adet (ceza: -{f.get('penalty', 0)})")
+        if not score_result.get("factors"):
+            lines.append("  (uyumsuzluk tespit edilmedi)")
+        lines.append("")
+        lines.append("Oneriler:")
+        for s in score_result.get("suggestions", []) or []:
+            lines.append(f"  - {s}")
+        lines.append("")
+        lines.append("-- FILE ACTIVITY (otomatik bildirim)")
+        return "\n".join(lines)
+
+    def send_user_report(self, username: str, email: str,
+                          score_result: dict,
+                          display_name: Optional[str] = None) -> dict:
+        """Kullaniciya verimlilik raporu e-postasi gonder.
+
+        admin_cc varsa CC'ye eklenir. Gonderim sonucu notification_log'a yazilir.
+        """
+        if not self.available:
+            return {"ok": False, "error": self._init_error, "skipped": True}
+        if not email:
+            return {"ok": False, "error": "hedef e-posta yok", "skipped": True}
+
+        score = score_result.get("score", 0)
+        grade = score_result.get("grade", "A")
+        subject = f"{self.subject_prefix} Dosya Verimlilik Raporu — {grade} ({score}/100)"
+
+        msg = MIMEMultipart("alternative")
+        msg["Subject"] = subject
+        msg["From"] = formataddr((self.from_name, self.from_address))
+        msg["To"] = email
+        recipients = [email]
+        if self.admin_cc and self.admin_cc.lower() != email.lower():
+            msg["Cc"] = self.admin_cc
+            recipients.append(self.admin_cc)
+
+        text = self._render_text(username, display_name, score_result)
+        html = self._render_html(username, display_name, score_result)
+        msg.attach(MIMEText(text, "plain", "utf-8"))
+        msg.attach(MIMEText(html, "html", "utf-8"))
+
+        try:
+            with self._connect() as s:
+                s.sendmail(self.from_address, recipients, msg.as_string())
+            self._log(username, email, subject, "sent", score_result=score_result,
+                       cc=self.admin_cc or None)
+            return {"ok": True, "email": email, "cc": self.admin_cc or None, "subject": subject}
+        except Exception as e:
+            err = str(e)
+            logger.warning("E-posta gonderilemedi (%s): %s", email, err)
+            self._log(username, email, subject, "error", error=err,
+                       cc=self.admin_cc or None)
+            return {"ok": False, "error": err}
+
+    def _log(self, username: str, email: str, subject: str, status: str,
+              error: Optional[str] = None, cc: Optional[str] = None,
+              score_result: Optional[dict] = None):
+        try:
+            payload = None
+            if score_result is not None:
+                # Kucuk bir ozet log'a, tam score_result yerine
+                payload = json.dumps({
+                    "score": score_result.get("score"),
+                    "grade": score_result.get("grade"),
+                    "non_compliance": score_result.get("non_compliance"),
+                }, ensure_ascii=False)
+            with self.db.get_cursor() as cur:
+                cur.execute(
+                    """
+                    INSERT INTO notification_log
+                    (username, email, cc, subject, status, error, payload_json)
+                    VALUES (?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    (username, email, cc, subject, status, error, payload),
+                )
+        except Exception as e:
+            logger.warning("notification_log yazilamadi: %s", e)
+
+    def health(self) -> dict:
+        info = {
+            "enabled": self.enabled,
+            "available": self.available,
+            "host": self.host or None,
+            "port": self.port,
+            "use_tls": self.use_tls,
+            "use_ssl": self.use_ssl,
+            "from_address": self.from_address or None,
+            "admin_cc_email": self.admin_cc or None,
+        }
+        if self._init_error:
+            info["init_error"] = self._init_error
+        return info

--- a/src/user_activity/email_notifier.py
+++ b/src/user_activity/email_notifier.py
@@ -28,6 +28,7 @@ Tum bildirimler gonderim logu (notification_log tablosu) tutulur:
 enabled=false ise modul no-op calisir, send_* None doner.
 """
 
+import html
 import json
 import logging
 import os
@@ -144,13 +145,17 @@ class EmailNotifier:
                          "D": "#dc2626", "E": "#991b1b"}
         grade_color = grade_colors.get(grade, "#64748b")
 
+        # HTML escaping: label/suggestions kullaniciya ait metadata'dan gelebiliyor
+        # (username, display_name, file_name tabanli iceriği yok bu uretimde ama
+        # yine de defense-in-depth — email client'i stripse bile iyi hijyen).
+        esc = html.escape
         factors_rows = ""
         for f in score_result.get("factors", []):
             factors_rows += (
                 f'<tr>'
-                f'<td style="padding:8px;border-bottom:1px solid #e5e7eb">{f.get("label", "")}</td>'
-                f'<td style="padding:8px;border-bottom:1px solid #e5e7eb;text-align:right">{f.get("count", 0)}</td>'
-                f'<td style="padding:8px;border-bottom:1px solid #e5e7eb;text-align:right;color:#dc2626;font-weight:600">-{f.get("penalty", 0)}</td>'
+                f'<td style="padding:8px;border-bottom:1px solid #e5e7eb">{esc(str(f.get("label", "")))}</td>'
+                f'<td style="padding:8px;border-bottom:1px solid #e5e7eb;text-align:right">{int(f.get("count", 0) or 0)}</td>'
+                f'<td style="padding:8px;border-bottom:1px solid #e5e7eb;text-align:right;color:#dc2626;font-weight:600">-{int(f.get("penalty", 0) or 0)}</td>'
                 f'</tr>'
             )
         if not factors_rows:
@@ -160,11 +165,11 @@ class EmailNotifier:
             )
 
         suggestions = "".join(
-            f'<li style="margin-bottom:8px">{s}</li>'
+            f'<li style="margin-bottom:8px">{esc(str(s))}</li>'
             for s in score_result.get("suggestions", [])
         ) or '<li style="color:#64748b">Herhangi bir oneri yok.</li>'
 
-        greeting = f"Merhaba {display_name or username},"
+        greeting = f"Merhaba {esc(display_name or username)},"
 
         return f"""<!DOCTYPE html>
 <html lang="tr"><head><meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1">


### PR DESCRIPTION
## Summary

Part C of the user-notification series. Sends HTML + plain-text e-mails to users with their efficiency score and non-compliance breakdown, and optionally CCs a fixed admin address. Uses stdlib `smtplib`/`email` — no new dependency.

## Changes

### New `src/user_activity/email_notifier.py`
- `EmailNotifier(db, config)` reads `smtp:` and `notifications:` blocks. Missing `host`/`from_address` or `enabled=false` → `available=False`; every send returns `{ok: False, skipped: True}`.
- **Connection strategy**:
  - `use_ssl=true` → `SMTP_SSL` (implicit TLS on 465)
  - `use_tls=true` → `SMTP` + STARTTLS (587)
  - neither → plain SMTP (25)
- **Password precedence**: `SMTP_PASSWORD` env var > `config.smtp.password`. Env var is the recommended deployment form.
- **Template**: standalone HTML (no Jinja/dep), 3.8 KB output with score box, factor table, suggestions list. Plain-text alternative attached so non-HTML clients work too.
- **notification_log table** (id, username, email, cc, subject, status, error, payload_json, sent_at) auto-created on init, indexed on (username, sent_at DESC) for per-user history queries.
- `test_connection()` does bind + NOOP without sending so operators can validate creds first.

### API endpoints
- `GET /api/notifications/status` — config + live SMTP probe
- `POST /api/notifications/test {to, username?, display_name?}` — sends a synthetic report for verifying SMTP setup
- `POST /api/notifications/send-to/{username}` — real send using AD-resolved email; 404 if ADLookup has no email for the user
- `GET /api/notifications/log?username&status&page&page_size` — sent-history browser

### Config
`config.yaml`: new `smtp:` and `notifications:` sections, `enabled: false` by default so existing installs see no change.

### Wiring
- `create_app(db, config, analytics, email_notifier)` — optional notifier parameter; built from config if omitted.
- `/api/system/health` response gains `"email": notifier.health()`.

## Test plan
- [x] Disabled path: send returns `{ok: False, skipped: True}`, no SMTP attempted
- [x] Missing host/from_address: init_error flagged before any send
- [x] HTML render: 3.8 KB, score/display_name/suggestions embedded
- [x] Text render: readable plain-text alternative
- [x] notification_log table auto-created on first init
- [ ] Real SMTP (smtp.office365.com or similar) with app password
- [ ] CC actually delivered to admin address
- [ ] Send-to/{username} with AD-resolved email (needs PR A #12 merged)

## Notes

- `send-to/{username}` looks up AD via `app.state.ad_lookup` — this attribute is set by PR A #12. Until PR A is merged, the endpoint returns 404 for every user. The `/test` endpoint with explicit recipient works standalone.
- Storing the SMTP password in `config.yaml` in plaintext works but is not recommended. Windows: set `SMTP_PASSWORD` via `setx` or the service wrapper env section.
- No rate limiting on `/test` — localhost-only dashboard means the operator is already trusted; add auth if exposing externally.
- Part of 4-PR series: A (AD lookup, #12) → B (efficiency score, #17) → **C (this)** → D (scheduler).