### PR TITLE
Schedule notify_users via APScheduler (PR D of 4, closes the series)

### DIFF
--- a/src/dashboard/api.py
+++ b/src/dashboard/api.py
@@ -53,8 +53,8 @@ class ScheduleCreate(BaseModel):
     @field_validator("task_type")
     @classmethod
     def _validate_task_type(cls, v: str) -> str:
-        if v not in ("scan", "archive"):
-            raise ValueError("task_type must be 'scan' or 'archive'")
+        if v not in ("scan", "archive", "notify_users"):
+            raise ValueError("task_type must be 'scan', 'archive' or 'notify_users'")
         return v
 
     @field_validator("cron_expression")
@@ -488,6 +488,22 @@ def create_app(db, config, analytics=None, ad_lookup=None, email_notifier=None):
         if db.remove_scheduled_task(task_id):
             return {"message": "Gorev silindi"}
         raise HTTPException(404, "Gorev bulunamadi")
+
+    @app.post("/api/schedules/notify-users/run-now/{source_id}")
+    async def notify_users_run_now(source_id: int):
+        """notify_users gorevi zamanlayiciyi beklemeden hemen calistir.
+
+        EmailNotifier ve ADLookup app.state'ten alinir; ikisi de yoksa
+        scheduler'in _run_notify_users'i 'skipped' sonucu doner (hata
+        atmaz). Gonderim sonucu: her kullanici icin sayisal ozet.
+        """
+        from src.scheduler.task_scheduler import TaskScheduler
+        src = _get_source(db, source_id)
+        ad = getattr(app.state, "ad_lookup", None)
+        notifier = getattr(app.state, "email_notifier", None)
+        ts = TaskScheduler(db, config, ad_lookup=ad, email_notifier=notifier)
+        fake_task = {"id": 0, "source_id": src.id, "task_type": "notify_users"}
+        return ts._run_notify_users(fake_task)
 
     # --- REPORT EXPORT API ---
 

--- a/src/scheduler/task_scheduler.py
+++ b/src/scheduler/task_scheduler.py
@@ -15,9 +15,11 @@ logger = logging.getLogger("file_activity.scheduler")
 class TaskScheduler:
     """Zamanlanmış görevleri yöneten scheduler."""
 
-    def __init__(self, db, config):
+    def __init__(self, db, config, ad_lookup=None, email_notifier=None):
         self.db = db
         self.config = config
+        self.ad_lookup = ad_lookup
+        self.email_notifier = email_notifier
         self.scheduler = BackgroundScheduler(
             job_defaults={"coalesce": True, "max_instances": 1}
         )
@@ -85,6 +87,8 @@ class TaskScheduler:
                 result = self._run_scan(source_id)
             elif task_type == "archive":
                 result = self._run_archive(task)
+            elif task_type == "notify_users":
+                result = self._run_notify_users(task)
             else:
                 result = {"status": "error", "message": f"Bilinmeyen görev türü: {task_type}"}
 
@@ -146,6 +150,109 @@ class TaskScheduler:
 
         engine = ArchiveEngine(self.db, self.config)
         return engine.archive_files(files, src.archive_dest, src.unc_path, source_id, f"scheduled:{task['id']}")
+
+    def _run_notify_users(self, task):
+        """Kullanici bildirim gorevi — verimlilik raporunu e-posta ile gonder.
+
+        Her dosya sahibi icin:
+          1. compute_user_score(db, owner) ile skor hesapla
+          2. ad_lookup.lookup(owner) ile e-posta cozumle
+          3. email_notifier.send_user_report(...) ile HTML e-posta gonder
+
+        AD/SMTP erisilmezse 'skipped' sayar ama hata atmaz. Sonuc ozeti
+        scheduled_tasks run log'una yazilir. Ayrintili gonderim kaydi
+        notification_log tablosunda tutulur (EmailNotifier yapar).
+        """
+        source_id = task["source_id"]
+
+        # Lazy import: scheduler ana import agini yuklemesin
+        from src.user_activity.efficiency_score import compute_user_score
+
+        if self.email_notifier is None or not self.email_notifier.available:
+            msg = "EmailNotifier mevcut degil veya SMTP devre disi"
+            logger.warning("notify_users atlandi (gorev %s): %s", task.get("id"), msg)
+            return {"status": "skipped", "message": msg,
+                    "sent": 0, "skipped": 0, "failed": 0}
+
+        scan_id = self.db.get_latest_scan_id(source_id, include_running=False)
+        if not scan_id:
+            return {"status": "error", "message": "Tarama verisi bulunamadi",
+                    "sent": 0, "skipped": 0, "failed": 0}
+
+        # Kaynakta sahibi olan tum kullanicilar
+        with self.db.get_cursor() as cur:
+            cur.execute(
+                """
+                SELECT owner, COUNT(*) AS file_count
+                FROM scanned_files
+                WHERE scan_id = ? AND owner IS NOT NULL AND owner != ''
+                GROUP BY owner
+                ORDER BY file_count DESC
+                """,
+                (scan_id,),
+            )
+            owners = [row["owner"] for row in cur.fetchall()]
+
+        if not owners:
+            return {"status": "completed", "message": "Bu taramada sahibi olan dosya yok",
+                    "sent": 0, "skipped": 0, "failed": 0}
+
+        sent = 0
+        skipped = 0
+        failed = 0
+        skipped_users: list = []
+
+        for owner in owners:
+            # 1. Skor hesapla
+            try:
+                score = compute_user_score(self.db, owner, scan_id=scan_id)
+            except Exception as e:
+                logger.warning("skor hesaplama hatasi %s: %s", owner, e)
+                failed += 1
+                continue
+
+            # 2. AD'den e-posta coz
+            email = None
+            display_name = None
+            if self.ad_lookup is not None:
+                try:
+                    info = self.ad_lookup.lookup(owner)
+                    if info:
+                        email = info.get("email")
+                        display_name = info.get("display_name")
+                except Exception as e:
+                    logger.debug("AD lookup hatasi %s: %s", owner, e)
+            if not email:
+                skipped += 1
+                skipped_users.append({"owner": owner, "reason": "no email"})
+                continue
+
+            # 3. Gonder
+            result = self.email_notifier.send_user_report(
+                username=owner,
+                email=email,
+                score_result=score,
+                display_name=display_name,
+            )
+            if result.get("ok"):
+                sent += 1
+            else:
+                failed += 1
+                logger.warning("notify gonderilemedi %s (%s): %s", owner, email,
+                               result.get("error"))
+
+        status = "completed" if failed == 0 else ("partial" if sent > 0 else "error")
+        return {
+            "status": status,
+            "scan_id": scan_id,
+            "source_id": source_id,
+            "candidates": len(owners),
+            "sent": sent,
+            "skipped": skipped,
+            "failed": failed,
+            # Ilk 20 atlanani detay icin ekle — log cok sisirilmesin
+            "skipped_users_sample": skipped_users[:20],
+        }
 
     def reload_tasks(self):
         """Görevleri yeniden yükle."""

--- a/src/scheduler/task_scheduler.py
+++ b/src/scheduler/task_scheduler.py
@@ -197,12 +197,22 @@ class TaskScheduler:
             return {"status": "completed", "message": "Bu taramada sahibi olan dosya yok",
                     "sent": 0, "skipped": 0, "failed": 0}
 
+        total = len(owners)
+        logger.info("notify_users: %d kullaniciya bildirim gonderilecek", total)
+
         sent = 0
         skipped = 0
         failed = 0
         skipped_users: list = []
+        # Her 25 kullanicida bir ilerleme logu
+        progress_step = max(25, total // 10)
 
-        for owner in owners:
+        for idx, owner in enumerate(owners, start=1):
+            if idx % progress_step == 0 or idx == total:
+                logger.info(
+                    "notify_users ilerleme: %d/%d (sent=%d, skipped=%d, failed=%d)",
+                    idx, total, sent, skipped, failed,
+                )
             # 1. Skor hesapla
             try:
                 score = compute_user_score(self.db, owner, scan_id=scan_id)

--- a/src/scheduler/task_scheduler.py
+++ b/src/scheduler/task_scheduler.py
@@ -207,49 +207,74 @@ class TaskScheduler:
         # Her 25 kullanicida bir ilerleme logu
         progress_step = max(25, total // 10)
 
-        for idx, owner in enumerate(owners, start=1):
-            if idx % progress_step == 0 or idx == total:
-                logger.info(
-                    "notify_users ilerleme: %d/%d (sent=%d, skipped=%d, failed=%d)",
-                    idx, total, sent, skipped, failed,
-                )
-            # 1. Skor hesapla
+        # Persistent SMTP session — her kullanicida yeni TCP baglanti
+        # acmamak icin (rate-limited sunucularda onemli). EmailNotifier'in
+        # session() API'si yoksa eski fallback'e (her send kendi baglantisi).
+        session_cm = None
+        if hasattr(self.email_notifier, "session"):
             try:
-                score = compute_user_score(self.db, owner, scan_id=scan_id)
+                session_cm = self.email_notifier.session()
+                smtp_session = session_cm.__enter__()
             except Exception as e:
-                logger.warning("skor hesaplama hatasi %s: %s", owner, e)
-                failed += 1
-                continue
+                logger.warning("SMTP oturumu acilamadi, per-send baglanti: %s", e)
+                session_cm = None
+                smtp_session = None
+        else:
+            smtp_session = None
 
-            # 2. AD'den e-posta coz
-            email = None
-            display_name = None
-            if self.ad_lookup is not None:
+        try:
+            for idx, owner in enumerate(owners, start=1):
+                if idx % progress_step == 0 or idx == total:
+                    logger.info(
+                        "notify_users ilerleme: %d/%d (sent=%d, skipped=%d, failed=%d)",
+                        idx, total, sent, skipped, failed,
+                    )
+                # 1. Skor hesapla
                 try:
-                    info = self.ad_lookup.lookup(owner)
-                    if info:
-                        email = info.get("email")
-                        display_name = info.get("display_name")
+                    score = compute_user_score(self.db, owner, scan_id=scan_id)
                 except Exception as e:
-                    logger.debug("AD lookup hatasi %s: %s", owner, e)
-            if not email:
-                skipped += 1
-                skipped_users.append({"owner": owner, "reason": "no email"})
-                continue
+                    logger.warning("skor hesaplama hatasi %s: %s", owner, e)
+                    failed += 1
+                    continue
 
-            # 3. Gonder
-            result = self.email_notifier.send_user_report(
-                username=owner,
-                email=email,
-                score_result=score,
-                display_name=display_name,
-            )
-            if result.get("ok"):
-                sent += 1
-            else:
-                failed += 1
-                logger.warning("notify gonderilemedi %s (%s): %s", owner, email,
-                               result.get("error"))
+                # 2. AD'den e-posta coz
+                email = None
+                display_name = None
+                if self.ad_lookup is not None:
+                    try:
+                        info = self.ad_lookup.lookup(owner)
+                        if info:
+                            email = info.get("email")
+                            display_name = info.get("display_name")
+                    except Exception as e:
+                        logger.debug("AD lookup hatasi %s: %s", owner, e)
+                if not email:
+                    skipped += 1
+                    skipped_users.append({"owner": owner, "reason": "no email"})
+                    continue
+
+                # 3. Gonder — smtp_session varsa onu kullan, yoksa per-send
+                send_kwargs = {
+                    "username": owner,
+                    "email": email,
+                    "score_result": score,
+                    "display_name": display_name,
+                }
+                if smtp_session is not None:
+                    send_kwargs["smtp_session"] = smtp_session
+                result = self.email_notifier.send_user_report(**send_kwargs)
+                if result.get("ok"):
+                    sent += 1
+                else:
+                    failed += 1
+                    logger.warning("notify gonderilemedi %s (%s): %s", owner, email,
+                                   result.get("error"))
+        finally:
+            if session_cm is not None:
+                try:
+                    session_cm.__exit__(None, None, None)
+                except Exception as e:
+                    logger.debug("SMTP oturumu kapatma hatasi: %s", e)
 
         status = "completed" if failed == 0 else ("partial" if sent > 0 else "error")
         return {

--- a/src/service/file_activity_service.py
+++ b/src/service/file_activity_service.py
@@ -62,11 +62,27 @@ class FileActivityService:
             except Exception as e:
                 logger.error("Watcher failed for %s: %s", src.name, e)
 
-        # Start scheduler
+        # Start scheduler (with AD + email notifier wired in for notify_users tasks)
         try:
-            self.scheduler = TaskScheduler(self.db, self.config)
+            try:
+                from src.user_activity.ad_lookup import ADLookup
+                ad_lookup = ADLookup(self.db, self.config)
+            except Exception as e:
+                logger.warning("ADLookup baslatilamadi: %s", e)
+                ad_lookup = None
+            try:
+                from src.user_activity.email_notifier import EmailNotifier
+                email_notifier = EmailNotifier(self.db, self.config)
+            except Exception as e:
+                logger.warning("EmailNotifier baslatilamadi: %s", e)
+                email_notifier = None
+            self.scheduler = TaskScheduler(self.db, self.config,
+                                           ad_lookup=ad_lookup,
+                                           email_notifier=email_notifier)
             self.scheduler.start()
-            logger.info("Task scheduler started")
+            logger.info("Task scheduler started (ad=%s, smtp=%s)",
+                        getattr(ad_lookup, "available", False),
+                        getattr(email_notifier, "available", False))
         except Exception as e:
             logger.error("Scheduler failed: %s", e)
 


### PR DESCRIPTION
## Summary

Final PR in the user-notification series. Wires the efficiency score (PR B #17) + SMTP notifier (PR C #18) into the existing APScheduler pipeline. Customers can configure "every Monday at 09:00" and each user who owns files in the source automatically receives their personal report with the admin CC'd.

## Changes

### `src/scheduler/task_scheduler.py`
- Constructor accepts optional `ad_lookup` + `email_notifier` (both `None` by default so existing code paths keep working)
- `_execute_task` routes `task_type="notify_users"` to new `_run_notify_users`
- `_run_notify_users(task)`:
  1. Early-exits as `skipped` if email_notifier missing/unavailable
  2. Resolves latest completed `scan_id` for `source_id`
  3. Groups `scanned_files` by owner (descending by file count)
  4. Per owner: `compute_user_score` → AD lookup → `send_user_report`
  5. Aggregates `sent/skipped/failed` counters; first 20 skipped users reported for diagnosis
  6. Returns `completed/partial/error` based on counters; scheduler run log stores the summary

### `src/dashboard/api.py`
- `ScheduleCreate` validator now accepts `'scan'`, `'archive'`, or `'notify_users'`. Users can POST `/api/schedules` with `task_type=notify_users` directly via the existing endpoint — no separate create endpoint needed.
- **New** `POST /api/schedules/notify-users/run-now/{source_id}` — triggers `_run_notify_users` immediately without waiting for the cron. Uses `getattr(app.state, ...)` so it works even before PR A/C are merged; the scheduler's "skipped" path clearly reports what's missing.

### `src/service/file_activity_service.py`
- When the Windows service starts `TaskScheduler`, construct `ADLookup` and `EmailNotifier` from config and pass them in. Failures during construction (ldap3 missing, SMTP disabled) degrade gracefully via logged warnings; scheduler still starts and scan/archive tasks continue to work.

## How a customer uses this

1. Configure `smtp:` and `active_directory:` sections in `config.yaml` (from PR A + PR C)
2. Restart service
3. POST `/api/schedules` with:
   ```json
   {
     "task_type": "notify_users",
     "source_id": 1,
     "cron_expression": "0 9 * * 1"
   }
   ```
4. Every Monday at 09:00, the scheduler wakes up, iterates users, sends reports with admin in CC
5. Before production: hit `/api/schedules/notify-users/run-now/1` to verify end-to-end without waiting a week

## Test plan
- [x] `py_compile` passes on all 3 modified files
- [x] Scheduler with no notifier → `_run_notify_users` returns `skipped` without raising
- [ ] End-to-end with PRs A/B/C merged + real SMTP + real AD: 10 users → 10 sends, each CC'd to admin
- [ ] Cron validation: `"bad cron"` rejected by `ScheduleCreate` validator
- [ ] Run-now endpoint idempotent — running twice doesn't double-send (no de-dup today, but also doesn't crash)

## Notes

- Part of 4-PR series: **A** (AD lookup #12) → **B** (efficiency score #17) → **C** (SMTP notifier #18) → **D (this)**. D composes on A/B/C; merging D before the others leaves the scheduler code in place but `_run_notify_users` always takes the "skipped" path.
- No de-duplication across runs: if you schedule daily, users get a daily email. Use a more conservative cron (weekly, monthly) or add a `min_hours_between_notifications` policy in a follow-up if that becomes a problem.
- `service/file_activity_service.py` gracefully handles import failures — if someone deploys D without PR A/C merged, service still starts.