### PR TITLE
Prevent WAL bloat regression: adaptive checkpoint + UI warning

### DIFF
--- a/src/dashboard/api.py
+++ b/src/dashboard/api.py
@@ -1617,6 +1617,24 @@ def create_app(db, config, analytics=None, ad_lookup=None, email_notifier=None):
 
     @app.get("/api/system/health")
     async def health():
+        # WAL ve toplam disk durumu
+        wal_warning = None
+        try:
+            wal_path = db.db_path + "-wal"
+            wal_size = os.path.getsize(wal_path) if os.path.exists(wal_path) else 0
+            if wal_size > 500_000_000:
+                wal_warning = {
+                    "wal_size_bytes": wal_size,
+                    "wal_size_formatted": f"{wal_size / 1073741824:.2f} GB"
+                                          if wal_size > 1073741824
+                                          else f"{wal_size / 1048576:.0f} MB",
+                    "severity": "critical" if wal_size > 5_000_000_000 else "warning",
+                    "recommendation": "Kaynaklar -> Veritabani Bakimi -> Optimize Et butonuna basarak "
+                                       "WAL'i temizleyin.",
+                }
+        except Exception:
+            pass
+
         return {
             "status": "ok",
             "time": datetime.now().isoformat(),
@@ -1624,6 +1642,7 @@ def create_app(db, config, analytics=None, ad_lookup=None, email_notifier=None):
             "database": db.health_check(),
             "analytics": analytics.health(),
             "email": email_notifier.health(),
+            "wal_warning": wal_warning,
         }
 
     @app.get("/api/system/analytics")

--- a/src/dashboard/static/index.html
+++ b/src/dashboard/static/index.html
@@ -253,6 +253,10 @@ label { font-size: 12px; color: var(--text-muted); margin-bottom: 6px; display: 
             <div style="font-weight:600">Yeni sürüm mevcut</div>
             <div id="update-badge-info" style="margin-top:2px;opacity:0.9"></div>
         </div>
+        <div id="wal-warning-badge" style="display:none;margin-top:8px;padding:8px;background:var(--danger,#dc2626);color:#fff;border-radius:6px;font-size:11px;cursor:pointer" onclick="showWalDialog()">
+            <div style="font-weight:600">DB Bakimi Onerilir</div>
+            <div id="wal-warning-info" style="margin-top:2px;opacity:0.9"></div>
+        </div>
     </div>
     <div class="nav-section">
         <div class="nav-label">Genel</div>
@@ -1113,6 +1117,20 @@ function showUpdateDialog() {
             }
         })
         .catch(e => alert('Ag hatasi: ' + e));
+}
+
+function showWalDialog() {
+    const w = window._walWarning || {};
+    const msg = `Veritabani Bakimi Onerilir\n\nSQLite WAL dosyasi: ${w.wal_size_formatted || '(bilinmiyor)'}\nSiddet: ${w.severity || 'warning'}\n\nBuyuk WAL dosyalari sorgulari yavaslatir ve disk alani yer. "Optimize Et" butonu:\n  - WAL'i sifirdan tekrar olusturur (checkpoint TRUNCATE)\n  - Tablolari VACUUM + ANALYZE ile siker\n  - Sorgu planlarini gunceller\n\nIslem sirasinda dashboard birkac saniye askida kalabilir.\n\nKaynaklar sayfasina gitmek ister misiniz?`;
+    if (!confirm(msg)) return;
+    // Kaynaklar sayfasina goturelim
+    if (typeof showPage === 'function') {
+        showPage('sources');
+    } else {
+        // showPage yoksa scroll
+        const el = document.querySelector('[onclick*="sources"]');
+        if (el) el.click();
+    }
 }
 
 // ═══════════════════════════════════════════════════
@@ -3114,6 +3132,26 @@ async function loadGrowth() {
             }
         })
         .catch(() => {}); // Ag yoksa sessizce atla
+
+    // WAL dosyasi buyuduyse sidebar'da uyari banner'i goster
+    fetch('/api/system/health')
+        .then(r => r.ok ? r.json() : null)
+        .then(d => {
+            if (d && d.wal_warning) {
+                const badge = document.getElementById('wal-warning-badge');
+                const info = document.getElementById('wal-warning-info');
+                if (badge) {
+                    badge.style.display = 'block';
+                    // Kritik durumda daha belirgin kirmizi
+                    if (d.wal_warning.severity === 'critical') {
+                        badge.style.background = '#991b1b';
+                    }
+                }
+                if (info) info.textContent = `WAL: ${d.wal_warning.wal_size_formatted}`;
+                window._walWarning = d.wal_warning;
+            }
+        })
+        .catch(() => {});
 
     // Dashboard aninda yuklensin - veri arka planda gelsin
     try {

--- a/src/storage/database.py
+++ b/src/storage/database.py
@@ -73,16 +73,38 @@ class Database:
             logger.info(f"SQLite baglantisi kuruldu: {self.db_path}")
             self._create_tables()
 
-            # Baslangicta WAL checkpoint - buyuk WAL dosyalarini temizle
+            # Baslangicta WAL checkpoint — buyuk WAL dosyalarini temizle.
+            # Strateji: 10 MB-1 GB arasi PASSIVE dene (aktif reader kilitlemesin),
+            # 1 GB ustunde TRUNCATE (agresif, WAL dosyasini tamamen sifirlar).
+            # Bir musteri 156 GB WAL ile takildi; PASSIVE hic kuculdememisti,
+            # TRUNCATE bu durumu surekli olarak onlemek icin.
             try:
                 wal_path = self.db_path + "-wal"
                 if os.path.exists(wal_path):
                     wal_size = os.path.getsize(wal_path)
                     if wal_size > 10_000_000:  # 10MB'dan buyukse checkpoint yap
-                        logger.info(f"WAL checkpoint baslatiliyor ({wal_size / 1048576:.1f} MB)...")
-                        conn.execute("PRAGMA wal_checkpoint(PASSIVE)")
+                        mode = "TRUNCATE" if wal_size > 1_073_741_824 else "PASSIVE"
+                        logger.info(
+                            f"WAL checkpoint baslatiliyor ({wal_size / 1048576:.1f} MB, mode={mode})..."
+                        )
+                        conn.execute(f"PRAGMA wal_checkpoint({mode})")
                         wal_after = os.path.getsize(wal_path) if os.path.exists(wal_path) else 0
-                        logger.info(f"WAL checkpoint tamamlandi: {wal_size / 1048576:.1f} MB -> {wal_after / 1048576:.1f} MB")
+                        logger.info(
+                            f"WAL checkpoint tamamlandi: {wal_size / 1048576:.1f} MB "
+                            f"-> {wal_after / 1048576:.1f} MB"
+                        )
+                        # PASSIVE kuculmediyse TRUNCATE'e yukselt
+                        if mode == "PASSIVE" and wal_after >= wal_size * 0.9 and wal_after > 500_000_000:
+                            logger.warning(
+                                "PASSIVE checkpoint WAL'i kuculmedi (%.1f MB), TRUNCATE deneniyor",
+                                wal_after / 1048576,
+                            )
+                            conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+                            wal_after2 = os.path.getsize(wal_path) if os.path.exists(wal_path) else 0
+                            logger.info(
+                                f"TRUNCATE sonucu: {wal_after / 1048576:.1f} MB "
+                                f"-> {wal_after2 / 1048576:.1f} MB"
+                            )
             except Exception as e:
                 logger.warning(f"WAL checkpoint hatasi (kritik degil): {e}")
         except Exception as e:


### PR DESCRIPTION
## Summary

Prevents the 156 GB WAL regression a customer hit this morning. Manual offline `VACUUM` fixed the immediate problem; this PR makes sure it doesn't come back and warns the operator before it grows to "dashboard hangs" territory.

## Root cause

`database.py` startup checkpoint ran `PRAGMA wal_checkpoint(PASSIVE)` regardless of WAL size. PASSIVE cannot shrink a WAL that is held open by any reader — so a huge WAL survives restarts unchanged. The customer saw:

```
WAL checkpoint baslatiliyor (156397.6 MB)...
WAL checkpoint tamamlandi: 156397.6 MB -> 156397.6 MB
```

After startup, risk-score and trend returned OK but every subsequent overview request hung because queries were fighting the 156 GB WAL.

## Changes

### 1. Adaptive startup checkpoint (`src/storage/database.py`)
- 10 MB - 1 GB: `PASSIVE` (gentle, same as before)
- `> 1 GB`: `TRUNCATE` immediately (aggressive — zeros the WAL)
- If PASSIVE runs and doesn't shrink (`>90%` of original size) AND result still `>500 MB`: fall back to `TRUNCATE`

Logs the selected mode and the before/after sizes so operators can see what happened.

### 2. Health endpoint warning (`src/dashboard/api.py`)
`/api/system/health` now includes:
```json
"wal_warning": {
  "wal_size_bytes": 156397500000,
  "wal_size_formatted": "145.66 GB",
  "severity": "critical",
  "recommendation": "Kaynaklar -> Veritabani Bakimi -> Optimize Et..."
}
```

Null when WAL ≤ 500 MB. `severity: "critical"` when > 5 GB.

### 3. Sidebar banner (`src/dashboard/static/index.html`)
Red badge next to the version/update badges when `wal_warning` is non-null. Critical severity flips to a darker red. Clicking opens a dialog explaining what "Optimize Et" does and navigating the user to the Kaynaklar page.

## Test plan
- [x] `py_compile` passes on both Python files
- [ ] Fresh install with empty WAL — no banner shown, checkpoint stays PASSIVE
- [ ] WAL forced to 2 GB (via custom test) — startup uses TRUNCATE, banner visible
- [ ] WAL held open by long reader + PASSIVE checkpoint doesn't shrink — fallback to TRUNCATE engages
- [ ] Optimize Et button still works end-to-end (from PR #15 fix)

## Notes

- No config changes. Thresholds (1 GB for direct TRUNCATE, 500 MB for fallback, 500 MB for banner) are hardcoded but conservative; can be made configurable if anyone hits false positives.
- The long-term win would be finding *why* the WAL grew to 156 GB in the first place — likely a scan cursor that stayed open for hours. Separate investigation; this PR mitigates the symptom.
- Customer is running this install at v1.7.0-dev; fix ships when they `update.cmd` after merge.