### PR TITLE
Cache AI Insights per scan so "Geçmiş analiz yükleniyor" resolves instantly

### DIFF
--- a/src/dashboard/api.py
+++ b/src/dashboard/api.py
@@ -919,10 +919,42 @@ def create_app(db, config, analytics=None, ad_lookup=None, email_notifier=None):
     # --- INSIGHTS API ---
 
     @app.get("/api/insights/{source_id}")
-    async def get_insights(source_id: int):
+    async def get_insights(source_id: int, refresh: bool = False):
+        """AI Insights: son scan icin cached sonucu doner, yoksa hesaplar.
+
+        refresh=true ile yeniden hesaplamayi force ederek cache'i tazeler.
+        Cache'te yoksa ilk cagri agir; sonraki cagrilar anlik.
+        """
         from src.analyzer.ai_insights import InsightsEngine
+        scan_id = db.get_latest_scan_id(source_id, include_running=False)
+        if not refresh and scan_id:
+            cached = db.get_scan_insights(scan_id)
+            if cached:
+                cached["from_cache"] = True
+                return cached
+
         engine = InsightsEngine(db)
-        return engine.generate_insights(source_id)
+        result = engine.generate_insights(source_id)
+        # Sonraki acilislar anlik olsun diye scan_id varsa cache'e yaz
+        if scan_id:
+            try:
+                db.save_scan_insights(scan_id, result)
+            except Exception as e:
+                logger.warning("insights cache yazilamadi: %s", e)
+        result["from_cache"] = False
+        return result
+
+    @app.post("/api/insights/{source_id}/recompute")
+    async def insights_recompute(source_id: int):
+        """Insights'i yeniden hesapla ve cache'i tazele."""
+        from src.analyzer.ai_insights import InsightsEngine
+        scan_id = db.get_latest_scan_id(source_id, include_running=False)
+        if not scan_id:
+            raise HTTPException(404, "Tamamlanmis scan yok")
+        result = InsightsEngine(db).generate_insights(source_id)
+        db.save_scan_insights(scan_id, result)
+        return {"status": "ok", "scan_id": scan_id,
+                "insights_count": len(result.get("insights", []))}
 
     # --- RISK SCORE API ---
 

--- a/src/scanner/file_scanner.py
+++ b/src/scanner/file_scanner.py
@@ -654,9 +654,8 @@ class FileScanner:
             file_count, format_size(total_size), elapsed, fps, errors
         )
 
-        # KPI summary hesapla (Overview sayfasi bu JSON'u okur, scanned_files
-        # tablosunu taramaz). Scan basarili olmayabilir (hata/kismi),
-        # yine de mumkun oldugu kadar ozet cikart.
+        # KPI summary + AI insights cache — Dashboard Overview + AI Onerileri
+        # paneli bu JSON'lari okur, scanned_files tablosunu taramaz.
         if status == "completed" and file_count > 0:
             try:
                 t0 = time.time()
@@ -667,6 +666,19 @@ class FileScanner:
                 )
             except Exception as e:
                 logger.warning("Scan summary hesaplanamadi (scan_id=%d): %s", scan_id, e)
+
+            try:
+                from src.analyzer.ai_insights import InsightsEngine
+                t0 = time.time()
+                engine = InsightsEngine(self.db)
+                insights_result = engine.generate_insights(source_id)
+                self.db.save_scan_insights(scan_id, insights_result)
+                logger.info(
+                    "AI insights hesaplandi ve cache'lendi (scan_id=%d, %d insight, %.1f sn)",
+                    scan_id, len(insights_result.get("insights", [])), time.time() - t0,
+                )
+            except Exception as e:
+                logger.warning("AI insights hesaplanamadi (scan_id=%d): %s", scan_id, e)
 
         # Son ilerleme durumunu guncelle
         progress.update({

--- a/src/storage/database.py
+++ b/src/storage/database.py
@@ -275,7 +275,9 @@ class Database:
                 errors          INTEGER DEFAULT 0,
                 status          TEXT DEFAULT 'running',
                 summary_json    TEXT,
-                summary_computed_at TEXT
+                summary_computed_at TEXT,
+                insights_json   TEXT,
+                insights_computed_at TEXT
             )
         """)
 
@@ -284,6 +286,8 @@ class Database:
         for col_def in (
             "summary_json TEXT",
             "summary_computed_at TEXT",
+            "insights_json TEXT",
+            "insights_computed_at TEXT",
         ):
             col_name = col_def.split()[0]
             try:
@@ -1993,6 +1997,35 @@ class Database:
         summary["scan_id"] = scan_id
         summary["computed_at"] = now
         return summary
+
+    def save_scan_insights(self, scan_id: int, insights_payload: dict) -> None:
+        """InsightsEngine cikti'sini scan_runs'a kaydet.
+
+        Payload: {insights: [...], score: N, generated_at, scan_id}
+        """
+        from datetime import datetime as _dt
+        now = _dt.now().strftime("%Y-%m-%d %H:%M:%S")
+        with self.get_cursor() as cur:
+            cur.execute(
+                "UPDATE scan_runs SET insights_json=?, insights_computed_at=? WHERE id=?",
+                (json.dumps(insights_payload, ensure_ascii=False, default=str), now, scan_id),
+            )
+
+    def get_scan_insights(self, scan_id: int) -> Optional[dict]:
+        """Kayitli insights'i oku. None ise hic hesaplanmamis."""
+        with self.get_cursor() as cur:
+            row = cur.execute(
+                "SELECT insights_json, insights_computed_at FROM scan_runs WHERE id=?",
+                (scan_id,),
+            ).fetchone()
+        if not row or not row["insights_json"]:
+            return None
+        try:
+            d = json.loads(row["insights_json"])
+            d["cached_at"] = row["insights_computed_at"]
+            return d
+        except Exception:
+            return None
 
     def get_scan_summary(self, scan_id: int) -> Optional[dict]:
         """Kayitli scan summary'yi oku. Hic hesaplanmamissa None doner."""


### PR DESCRIPTION
## Summary

Sister PR to #24. Overview opens instantly now, but the **"Geçmiş analiz yükleniyor"** panel (AI Insights) still blocks on heavy queries. Same fix pattern: compute once at scan completion, cache as JSON on `scan_runs`, read from cache.

## Problem

`/api/insights/{source_id}` runs 11 aggregate queries (temp files, stale, duplicates, security risks, riskiest folders, growth prediction, cleanup, audit …) over `scanned_files` every dashboard load. On 2.5M rows that's minutes.

## Changes

### Schema (`src/storage/database.py`)
- `scan_runs.insights_json TEXT` + `insights_computed_at TEXT`. Idempotent via the same CREATE/ALTER try/except path used for summary columns.

### Cache helpers (`src/storage/database.py`)
- `save_scan_insights(scan_id, payload)` — persists full `InsightsEngine` output.
- `get_scan_insights(scan_id)` — reads JSON back with `cached_at` stamp; None if never computed.

### Endpoint (`src/dashboard/api.py`)
- `GET /api/insights/{source_id}?refresh=false` returns cached payload if present (`from_cache: true`). On cache miss: runs `InsightsEngine`, writes cache, returns result.
- `POST /api/insights/{source_id}/recompute` — explicit refresh.

### Scanner (`src/scanner/file_scanner.py`)
- After `compute_scan_summary`, also run `InsightsEngine` and cache. Logs insight count + duration. Failure non-fatal; endpoint lazy-computes if pre-cache failed.

## Migration path

- **New scans**: both summary + insights written at scan completion. Dashboard fully instant.
- **Existing scans**: no startup backfill for insights (would slow every restart on 2.5M-row scans). First `/api/insights` request pays the one-time cost; result cached until next scan.

## Test plan
- [x] `py_compile` passes
- [ ] First dashboard open after merge: AI Onerileri takes ~30s once, then instant forever
- [ ] New scan completes → insights log line present → dashboard shows them immediately
- [ ] `refresh=true` query string forces recompute (visible in logs)