### PR TITLE
Fix dict-indexing bug that disabled startup retention/orphan cleanup

### DIFF
--- a/src/storage/database.py
+++ b/src/storage/database.py
@@ -121,20 +121,24 @@ class Database:
                 if retention.get("auto_cleanup_on_startup", True):
                     keep_n = int(retention.get("keep_last_n_scans", 3))
                     # Hizli orphan tespiti — eger varsa bunlari da temizleyecegiz
+                    # NOT: conn.row_factory = dict_factory oldugu icin
+                    # row[0] -> KeyError(0) atar. Sutun adiyla erismek
+                    # zorundayiz veya tek-deger SELECT'i icin scalar() yerine
+                    # alias + dict erisim. Asagida hep alias kullaniyoruz.
                     orphan_row = conn.execute(
-                        "SELECT COUNT(*) FROM scanned_files "
+                        "SELECT COUNT(*) AS cnt FROM scanned_files "
                         "WHERE scan_id NOT IN (SELECT id FROM scan_runs)"
                     ).fetchone()
-                    orphan_count = orphan_row[0] if orphan_row else 0
+                    orphan_count = (orphan_row["cnt"] if orphan_row else 0) or 0
 
                     count_row = conn.execute(
                         "SELECT COUNT(*) AS cnt FROM scan_runs"
                     ).fetchone()
-                    total_scans = count_row[0] if count_row else 0
+                    total_scans = (count_row["cnt"] if count_row else 0) or 0
                     source_row = conn.execute(
                         "SELECT COUNT(DISTINCT source_id) AS cnt FROM scan_runs"
                     ).fetchone()
-                    total_sources = source_row[0] if source_row else 0
+                    total_sources = (source_row["cnt"] if source_row else 0) or 0
 
                     needs_retention = total_scans > keep_n * max(total_sources, 1)
                     needs_orphan = orphan_count > 0


### PR DESCRIPTION
## Summary

**Critical fix.** The startup retention + orphan cleanup added in PRs #22 and #23 has been silently failing on every dashboard restart because of a dict-indexing bug. The customer's 1.27M orphan rows were never removed; AI Insights still scans 3.77M rows instead of 2.5M.

## Root cause

`Database.connect()` startup hook reads aggregate results via `row[0]`:

```python
count_row = conn.execute("SELECT COUNT(*) FROM scan_runs").fetchone()
total_scans = count_row[0] if count_row else 0
```

But the connection has `row_factory = dict_factory` so rows come back as dicts. `dict[0]` → `KeyError(0)`. The exception's str() is just `'0'`, which matches exactly what the customer's log shows:

```
Retention temizligi sirasinda hata (kritik degil): 0
```

The except branch swallowed it as "kritik degil" and the cleanup never ran. Both retention pruning and orphan cleanup have been no-ops since PR #22/#23 merged.

## Fix

Use explicit `AS` aliases and dict-key access on every aggregate read:

```python
row = conn.execute("SELECT COUNT(*) AS cnt FROM ...").fetchone()
n = (row["cnt"] if row else 0) or 0
```

Three callsites fixed (orphan_count, total_scans, total_sources). Added a comment block flagging the `dict_factory + row[0]` hazard for future readers.

## Verified

```python
>>> {'COUNT(*)': 3}[0]    # without alias
KeyError: 0
>>> {'cnt': 3}['cnt']     # with alias
3
```

## Expected effect on customer install

Next dashboard restart will log:
```
Orphan scanned_files satirlari tespit edildi: 1271465 adet, siliniyor
Temizlendi: 0 scan_run, 0 dosya kaydi (eski scan), 1271465 orphan satir
```

After this:
- DB drops from 3.68 GB → ~2 GB
- AI Insights computation goes 3.77M → 2.5M rows scanned
- Once insights cache populates (one-time ~30s), dashboard fully instant

## Test plan
- [x] `py_compile` passes
- [x] Standalone repro of the dict bug + verification fix works
- [ ] On customer install: restart logs orphan delete count of 1.27M+
- [ ] AI insights eventually finishes and caches