### PR TITLE
Win32FindFirstFileExW + LARGE_FETCH scanner backend (closes #31)

### DIFF
--- a/src/scanner/backends/__init__.py
+++ b/src/scanner/backends/__init__.py
@@ -1,0 +1,42 @@
+"""Scanner backends package.
+
+Backends implement the :class:`ScannerBackend` protocol and provide
+alternate walk strategies for the file scanner (e.g. ctypes-based Win32
+``FindFirstFileExW`` for faster local Windows scans, SMB parallel
+backend for multi-threaded UNC scans, etc.).
+
+The :class:`FileScanner` can dispatch to any backend that conforms to
+this protocol. The protocol intentionally stays minimal: a backend is
+just something that, given a root path, yields file records as dicts.
+"""
+
+from __future__ import annotations
+
+from typing import Iterator, Protocol, runtime_checkable
+
+
+@runtime_checkable
+class ScannerBackend(Protocol):
+    """Protocol all scanner backends implement.
+
+    A backend is initialized with a configuration dictionary (typically
+    the project ``config.yaml`` loaded as a dict) and exposes a single
+    :meth:`walk` method that yields one dict per file encountered under
+    ``root``.
+
+    Yielded dicts should at minimum contain:
+
+    - ``file_path``: absolute path as ``str``
+    - ``file_size``: size in bytes as ``int``
+    - ``creation_time``: ``"YYYY-MM-DD HH:MM:SS"`` or ``None``
+    - ``last_access_time``: ``"YYYY-MM-DD HH:MM:SS"`` or ``None``
+    - ``last_modify_time``: ``"YYYY-MM-DD HH:MM:SS"`` or ``None``
+    - ``attributes``: raw Win32 attribute bitmask as ``int``
+    """
+
+    def __init__(self, config: dict) -> None: ...
+
+    def walk(self, root: str) -> Iterator[dict]: ...
+
+
+__all__ = ["ScannerBackend"]

--- a/src/scanner/backends/win32_find_ex.py
+++ b/src/scanner/backends/win32_find_ex.py
@@ -1,0 +1,367 @@
+"""FindFirstFileExW + LARGE_FETCH ctypes scanner backend.
+
+This backend walks a directory tree using the raw Win32
+``FindFirstFileExW`` / ``FindNextFileW`` / ``FindClose`` family from
+``kernel32.dll`` with the ``FindExInfoBasic`` info level (skips the
+8.3 alternate-name lookup) and the ``FIND_FIRST_EX_LARGE_FETCH`` flag
+(requests 64 KB result buffers on Windows 7+).
+
+Compared to :func:`os.walk` / :func:`os.scandir`, which under the hood
+call ``FindFirstFileW`` with default flags, this typically gives a
+2-3x speedup on large local NTFS trees because it avoids the short-name
+probe and reduces the number of kernel round trips.
+
+The module is import-safe on non-Windows platforms: ctypes bindings are
+loaded lazily inside :meth:`Win32FindExBackend.__init__`. Instantiating
+the class on a non-Windows host raises ``RuntimeError``.
+
+References
+----------
+- https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-findfirstfileexw
+- https://learn.microsoft.com/en-us/windows/win32/api/minwinbase/ns-minwinbase-win32_find_dataw
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import sys
+from datetime import datetime
+from typing import Iterator, Optional
+
+logger = logging.getLogger("file_activity.scanner.backends.win32_find_ex")
+
+
+# ----------------------------------------------------------------------
+# Win32 constants
+# ----------------------------------------------------------------------
+
+# FINDEX_INFO_LEVELS
+FindExInfoStandard = 0
+FindExInfoBasic = 1  # Skip populating cAlternateFileName (8.3 short name)
+
+# FINDEX_SEARCH_OPS
+FindExSearchNameMatch = 0
+
+# dwAdditionalFlags
+FIND_FIRST_EX_LARGE_FETCH = 2  # 64 KB result buffers (Windows 7+)
+
+# Return value meaning "no handle"
+INVALID_HANDLE_VALUE = -1
+
+# File attribute bits we care about
+FILE_ATTRIBUTE_DIRECTORY = 0x10
+FILE_ATTRIBUTE_REPARSE_POINT = 0x400
+
+# Win32 error codes
+ERROR_FILE_NOT_FOUND = 2
+ERROR_PATH_NOT_FOUND = 3
+ERROR_ACCESS_DENIED = 5
+ERROR_NO_MORE_FILES = 18
+ERROR_INVALID_PARAMETER = 87
+
+# FILETIME (100ns intervals since 1601-01-01) → Unix epoch offset (seconds)
+_FILETIME_EPOCH_OFFSET = 11644473600
+_FILETIME_TICKS_PER_SEC = 10_000_000
+
+# Long-path threshold: Windows legacy MAX_PATH is 260, but we switch to the
+# \\?\ prefix a bit earlier to stay safe when joining sub-paths during recursion.
+_LONG_PATH_THRESHOLD = 240
+
+
+# ----------------------------------------------------------------------
+# ctypes structure / prototype builders (Windows-only)
+# ----------------------------------------------------------------------
+
+
+def _build_ctypes_bindings():
+    """Build and return ctypes bindings, structures, and kernel32 handle.
+
+    Imported lazily so this module stays import-safe on non-Windows hosts.
+    Returns a dict of symbols used by the backend.
+    """
+    import ctypes
+    from ctypes import wintypes
+
+    class FILETIME(ctypes.Structure):
+        _fields_ = [
+            ("dwLowDateTime", wintypes.DWORD),
+            ("dwHighDateTime", wintypes.DWORD),
+        ]
+
+    class WIN32_FIND_DATAW(ctypes.Structure):
+        _fields_ = [
+            ("dwFileAttributes", wintypes.DWORD),
+            ("ftCreationTime", FILETIME),
+            ("ftLastAccessTime", FILETIME),
+            ("ftLastWriteTime", FILETIME),
+            ("nFileSizeHigh", wintypes.DWORD),
+            ("nFileSizeLow", wintypes.DWORD),
+            ("dwReserved0", wintypes.DWORD),
+            ("dwReserved1", wintypes.DWORD),
+            ("cFileName", wintypes.WCHAR * 260),
+            ("cAlternateFileName", wintypes.WCHAR * 14),
+        ]
+
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+
+    # HANDLE FindFirstFileExW(
+    #   LPCWSTR lpFileName,
+    #   FINDEX_INFO_LEVELS fInfoLevelId,
+    #   LPVOID lpFindFileData,
+    #   FINDEX_SEARCH_OPS fSearchOp,
+    #   LPVOID lpSearchFilter,     // must be NULL
+    #   DWORD dwAdditionalFlags);
+    FindFirstFileExW = kernel32.FindFirstFileExW
+    FindFirstFileExW.argtypes = [
+        wintypes.LPCWSTR,
+        ctypes.c_int,
+        ctypes.c_void_p,
+        ctypes.c_int,
+        ctypes.c_void_p,
+        wintypes.DWORD,
+    ]
+    FindFirstFileExW.restype = wintypes.HANDLE
+
+    # BOOL FindNextFileW(HANDLE, LPWIN32_FIND_DATAW);
+    FindNextFileW = kernel32.FindNextFileW
+    FindNextFileW.argtypes = [wintypes.HANDLE, ctypes.c_void_p]
+    FindNextFileW.restype = wintypes.BOOL
+
+    # BOOL FindClose(HANDLE);
+    FindClose = kernel32.FindClose
+    FindClose.argtypes = [wintypes.HANDLE]
+    FindClose.restype = wintypes.BOOL
+
+    return {
+        "ctypes": ctypes,
+        "FILETIME": FILETIME,
+        "WIN32_FIND_DATAW": WIN32_FIND_DATAW,
+        "FindFirstFileExW": FindFirstFileExW,
+        "FindNextFileW": FindNextFileW,
+        "FindClose": FindClose,
+        "INVALID_HANDLE_VALUE": ctypes.c_void_p(-1).value,
+    }
+
+
+# ----------------------------------------------------------------------
+# Helpers
+# ----------------------------------------------------------------------
+
+
+def _filetime_to_str(high: int, low: int) -> Optional[str]:
+    """Convert a FILETIME (high, low DWORDs) to ``"YYYY-MM-DD HH:MM:SS"``.
+
+    Returns ``None`` if the FILETIME is zero or out of range for Python's
+    datetime (e.g. corrupted or 1601 epoch placeholders).
+    """
+    ticks = (high << 32) | low
+    if ticks == 0:
+        return None
+    try:
+        seconds = ticks / _FILETIME_TICKS_PER_SEC - _FILETIME_EPOCH_OFFSET
+        return datetime.fromtimestamp(seconds).strftime("%Y-%m-%d %H:%M:%S")
+    except (OverflowError, OSError, ValueError):
+        return None
+
+
+def _long_path(path: str) -> str:
+    """Prepend ``\\\\?\\`` when the path is close to the legacy MAX_PATH limit.
+
+    UNC paths become ``\\\\?\\UNC\\server\\share\\...``, local paths become
+    ``\\\\?\\C:\\...``.
+    """
+    if path.startswith("\\\\?\\"):
+        return path
+    if len(path) < _LONG_PATH_THRESHOLD:
+        return path
+    if path.startswith("\\\\"):
+        return "\\\\?\\UNC\\" + path[2:]
+    return "\\\\?\\" + path
+
+
+def _strip_long_prefix(path: str) -> str:
+    """Reverse of :func:`_long_path` for yielded ``file_path`` fields."""
+    if path.startswith("\\\\?\\UNC\\"):
+        return "\\\\" + path[8:]
+    if path.startswith("\\\\?\\"):
+        return path[4:]
+    return path
+
+
+# ----------------------------------------------------------------------
+# Backend
+# ----------------------------------------------------------------------
+
+
+class Win32FindExBackend:
+    """Scanner backend that walks a tree via ``FindFirstFileExW``.
+
+    Parameters
+    ----------
+    config:
+        Project configuration dictionary. Currently unused — accepted for
+        protocol compatibility with other backends.
+    """
+
+    def __init__(self, config: dict) -> None:
+        if sys.platform != "win32":
+            raise RuntimeError("Win32FindExBackend requires Windows")
+
+        self.config = config or {}
+        # If we hit ERROR_INVALID_PARAMETER from LARGE_FETCH once (pre-Win7),
+        # disable it for the remainder of this backend's lifetime.
+        self._large_fetch_supported = True
+
+        bindings = _build_ctypes_bindings()
+        self._ctypes = bindings["ctypes"]
+        self._WIN32_FIND_DATAW = bindings["WIN32_FIND_DATAW"]
+        self._FindFirstFileExW = bindings["FindFirstFileExW"]
+        self._FindNextFileW = bindings["FindNextFileW"]
+        self._FindClose = bindings["FindClose"]
+        self._INVALID_HANDLE_VALUE = bindings["INVALID_HANDLE_VALUE"]
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def walk(self, root: str) -> Iterator[dict]:
+        """Recursively yield one dict per file found under ``root``.
+
+        Directories are recursed into but not yielded. Symlinks / reparse
+        points are yielded but not followed.
+        """
+        # Use a work-stack instead of recursion so deep trees don't blow
+        # the Python stack (Windows allows up to 32k path components).
+        stack = [root]
+        while stack:
+            current = stack.pop()
+            yield from self._walk_one(current, stack)
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+
+    def _walk_one(self, directory: str, stack: list) -> Iterator[dict]:
+        """Iterate a single directory, pushing subdirs onto ``stack``."""
+        search_root = _long_path(directory)
+        # FindFirstFileExW wants a wildcard pattern, not a directory name.
+        pattern = os.path.join(search_root, "*")
+
+        handle, first_entry = self._open(pattern)
+        if handle is None:
+            return
+
+        try:
+            # Emit the entry that FindFirstFileExW already returned.
+            entry = first_entry
+            while True:
+                name = entry.cFileName
+                if name and name not in (".", ".."):
+                    attrs = entry.dwFileAttributes
+                    full = os.path.join(directory, name)
+                    if attrs & FILE_ATTRIBUTE_DIRECTORY:
+                        # Don't follow reparse points (symlinks / junctions).
+                        if not (attrs & FILE_ATTRIBUTE_REPARSE_POINT):
+                            stack.append(full)
+                    else:
+                        size = (entry.nFileSizeHigh << 32) | entry.nFileSizeLow
+                        yield {
+                            "file_path": _strip_long_prefix(full),
+                            "file_size": size,
+                            "creation_time": _filetime_to_str(
+                                entry.ftCreationTime.dwHighDateTime,
+                                entry.ftCreationTime.dwLowDateTime,
+                            ),
+                            "last_access_time": _filetime_to_str(
+                                entry.ftLastAccessTime.dwHighDateTime,
+                                entry.ftLastAccessTime.dwLowDateTime,
+                            ),
+                            "last_modify_time": _filetime_to_str(
+                                entry.ftLastWriteTime.dwHighDateTime,
+                                entry.ftLastWriteTime.dwLowDateTime,
+                            ),
+                            "attributes": attrs,
+                        }
+
+                # Reuse the same buffer for the next entry.
+                next_entry = self._WIN32_FIND_DATAW()
+                ok = self._FindNextFileW(
+                    handle, self._ctypes.byref(next_entry)
+                )
+                if not ok:
+                    err = self._ctypes.get_last_error()
+                    if err == ERROR_NO_MORE_FILES:
+                        break
+                    self._log_win_error(err, directory, context="FindNextFileW")
+                    break
+                entry = next_entry
+        finally:
+            # Always release the handle, including on exception.
+            try:
+                self._FindClose(handle)
+            except OSError:
+                # Defensive: if the DLL itself raises, there is nothing
+                # useful we can do — swallow to let the original error
+                # (if any) surface.
+                logger.debug("FindClose raised on %s", directory[:100])
+
+    def _open(self, pattern: str):
+        """Call ``FindFirstFileExW`` with LARGE_FETCH (falling back if needed).
+
+        Returns a ``(handle, first_entry)`` pair, or ``(None, None)`` if
+        the directory cannot be opened.
+        """
+        data = self._WIN32_FIND_DATAW()
+        flags = FIND_FIRST_EX_LARGE_FETCH if self._large_fetch_supported else 0
+
+        handle = self._FindFirstFileExW(
+            pattern,
+            FindExInfoBasic,
+            self._ctypes.byref(data),
+            FindExSearchNameMatch,
+            None,
+            flags,
+        )
+
+        if handle == self._INVALID_HANDLE_VALUE or handle is None or handle == 0:
+            err = self._ctypes.get_last_error()
+
+            # Pre-Windows 7: LARGE_FETCH is rejected. Disable permanently
+            # and retry once without the flag.
+            if err == ERROR_INVALID_PARAMETER and self._large_fetch_supported:
+                logger.debug(
+                    "FIND_FIRST_EX_LARGE_FETCH rejected (pre-Win7?), "
+                    "disabling and retrying"
+                )
+                self._large_fetch_supported = False
+                handle = self._FindFirstFileExW(
+                    pattern,
+                    FindExInfoBasic,
+                    self._ctypes.byref(data),
+                    FindExSearchNameMatch,
+                    None,
+                    0,
+                )
+                if handle == self._INVALID_HANDLE_VALUE or handle in (None, 0):
+                    err = self._ctypes.get_last_error()
+                    self._log_win_error(err, pattern, context="FindFirstFileExW")
+                    return None, None
+                return handle, data
+
+            self._log_win_error(err, pattern, context="FindFirstFileExW")
+            return None, None
+
+        return handle, data
+
+    @staticmethod
+    def _log_win_error(err: int, path: str, context: str) -> None:
+        """Log a Win32 error code at the appropriate level."""
+        short = path[:160]
+        if err in (ERROR_FILE_NOT_FOUND, ERROR_PATH_NOT_FOUND, ERROR_ACCESS_DENIED):
+            logger.debug("%s: Win32 error %d on %s", context, err, short)
+        else:
+            logger.warning("%s: Win32 error %d on %s", context, err, short)
+
+
+__all__ = ["Win32FindExBackend"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,14 @@
+"""Pytest configuration: ensure the project root is on sys.path.
+
+Tests import the project as ``src.<module>`` rather than relying on an
+installed package, so we prepend the repository root to ``sys.path``.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_PROJECT_ROOT = Path(__file__).resolve().parent.parent
+if str(_PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PROJECT_ROOT))

--- a/tests/test_win32_find_ex_backend.py
+++ b/tests/test_win32_find_ex_backend.py
@@ -1,0 +1,192 @@
+"""Tests for Win32FindExBackend.
+
+The backend is only exercised on Windows (ctypes calls kernel32).
+On other platforms the module is still import-safe, and we verify
+that instantiation raises RuntimeError with a clear message.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Cross-platform import safety
+# ---------------------------------------------------------------------------
+
+
+def test_module_import_is_cross_platform() -> None:
+    """Module must import cleanly on any platform (ctypes loaded lazily)."""
+    import src.scanner.backends.win32_find_ex as mod  # noqa: F401
+
+    assert hasattr(mod, "Win32FindExBackend")
+
+
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="Non-Windows guard only checked on non-Windows hosts",
+)
+def test_non_windows_init_raises() -> None:
+    """On non-Windows, constructor must raise RuntimeError."""
+    from src.scanner.backends.win32_find_ex import Win32FindExBackend
+
+    with pytest.raises(RuntimeError, match="Windows"):
+        Win32FindExBackend({})
+
+
+# ---------------------------------------------------------------------------
+# Windows-only functional tests
+# ---------------------------------------------------------------------------
+
+pytestmark_win = pytest.mark.skipif(
+    sys.platform != "win32",
+    reason="Win32FindExBackend only runs on Windows",
+)
+
+
+@pytest.fixture
+def populated_tree(tmp_path: Path) -> tuple[Path, set[str], Path]:
+    """Create ~50 files at 3 depth levels, plus one long-path directory.
+
+    Returns
+    -------
+    (root, expected_file_paths, long_dir)
+    """
+    root = tmp_path / "scan_root"
+    root.mkdir()
+
+    expected: set[str] = set()
+
+    # Level 1: 10 files directly under root
+    for i in range(10):
+        p = root / f"l1_file_{i:02d}.txt"
+        p.write_text(f"l1-{i}")
+        expected.add(str(p))
+
+    # Level 2: 4 subdirs × 5 files = 20
+    for d in range(4):
+        sub = root / f"sub_{d}"
+        sub.mkdir()
+        for i in range(5):
+            p = sub / f"l2_file_{i}.txt"
+            p.write_text(f"l2-{d}-{i}")
+            expected.add(str(p))
+
+        # Level 3 under each sub: 5 files
+        sub3 = sub / "nested"
+        sub3.mkdir()
+        for i in range(5):
+            p = sub3 / f"l3_file_{i}.txt"
+            p.write_text(f"l3-{d}-{i}")
+            expected.add(str(p))
+
+    # Long-path directory (component name pushes total path near MAX_PATH)
+    long_name = "L" * 200
+    long_dir = root / long_name
+    try:
+        long_dir.mkdir()
+        long_file = long_dir / "deep.txt"
+        long_file.write_text("long")
+        expected.add(str(long_file))
+    except OSError:
+        # Filesystem may still reject; not fatal for the rest of the test.
+        long_dir = root
+
+    return root, expected, long_dir
+
+
+@pytestmark_win
+def test_walk_yields_all_files(populated_tree) -> None:
+    from src.scanner.backends.win32_find_ex import Win32FindExBackend
+
+    root, expected, _ = populated_tree
+    backend = Win32FindExBackend({})
+
+    found = {os.path.normpath(r["file_path"]) for r in backend.walk(str(root))}
+    expected_norm = {os.path.normpath(p) for p in expected}
+
+    missing = expected_norm - found
+    assert not missing, f"Backend missed {len(missing)} files, e.g. {list(missing)[:3]}"
+
+
+@pytestmark_win
+def test_walk_parses_attributes(tmp_path: Path) -> None:
+    """Regular files must have DIRECTORY bit clear; backend never yields dirs."""
+    from src.scanner.backends.win32_find_ex import (
+        FILE_ATTRIBUTE_DIRECTORY,
+        Win32FindExBackend,
+    )
+
+    root = tmp_path / "attr_root"
+    root.mkdir()
+    (root / "plain.txt").write_text("hi")
+    (root / "nested_dir").mkdir()
+    (root / "nested_dir" / "inner.txt").write_text("x")
+
+    backend = Win32FindExBackend({})
+    records = list(backend.walk(str(root)))
+
+    # Backend yields files only, never the directory entry itself.
+    names = {os.path.basename(r["file_path"]) for r in records}
+    assert "plain.txt" in names
+    assert "inner.txt" in names
+    assert "nested_dir" not in names
+
+    for r in records:
+        assert r["attributes"] & FILE_ATTRIBUTE_DIRECTORY == 0, (
+            f"File yielded with DIRECTORY bit set: {r}"
+        )
+        assert isinstance(r["file_size"], int)
+        assert r["file_size"] >= 0
+
+
+@pytestmark_win
+def test_walk_parses_timestamps(tmp_path: Path) -> None:
+    """FILETIME conversion should produce parseable YYYY-MM-DD HH:MM:SS."""
+    import re
+
+    from src.scanner.backends.win32_find_ex import Win32FindExBackend
+
+    root = tmp_path / "ts_root"
+    root.mkdir()
+    (root / "a.txt").write_text("a")
+
+    backend = Win32FindExBackend({})
+    records = list(backend.walk(str(root)))
+    assert records, "expected at least one record"
+
+    pattern = re.compile(r"^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$")
+    r = records[0]
+    for key in ("creation_time", "last_access_time", "last_modify_time"):
+        val = r[key]
+        assert val is None or pattern.match(val), (
+            f"{key} not in expected format: {val!r}"
+        )
+
+
+@pytestmark_win
+def test_walk_empty_directory(tmp_path: Path) -> None:
+    from src.scanner.backends.win32_find_ex import Win32FindExBackend
+
+    empty = tmp_path / "empty"
+    empty.mkdir()
+
+    backend = Win32FindExBackend({})
+    records = list(backend.walk(str(empty)))
+    assert records == []
+
+
+@pytestmark_win
+def test_walk_missing_directory_is_silent(tmp_path: Path) -> None:
+    """Missing path should log + continue, not raise."""
+    from src.scanner.backends.win32_find_ex import Win32FindExBackend
+
+    missing = tmp_path / "does_not_exist"
+    backend = Win32FindExBackend({})
+    # Should simply yield nothing.
+    assert list(backend.walk(str(missing))) == []


### PR DESCRIPTION
## Summary

- New ctypes scanner backend `Win32FindExBackend` in `src/scanner/backends/win32_find_ex.py` that walks trees via `FindFirstFileExW` / `FindNextFileW` / `FindClose` from `kernel32`, using `FindExInfoBasic` (skip 8.3 alt-name lookup) + `FIND_FIRST_EX_LARGE_FETCH` (64 KB buffers, Win7+). Targets the documented 2-3x speedup on large local NTFS trees vs `os.walk`.
- New `src/scanner/backends/__init__.py` introducing a `ScannerBackend` Protocol (issue #30 was not yet merged, so this PR establishes the protocol).
- pytest suite under `tests/test_win32_find_ex_backend.py` with `skipif(sys.platform != 'win32')` for the functional parts; cross-platform tests cover import safety and the non-Windows `RuntimeError` guard.

## Design notes

- **Lazy ctypes load:** bindings are built inside `__init__`, so the module imports cleanly on Linux / macOS CI. Non-Windows instantiation raises `RuntimeError("Win32FindExBackend requires Windows")`.
- **Safe handle management:** `FindClose` runs in a `try/finally`, including on exception; `FindClose` itself is guarded so a DLL-level error can't mask the real cause.
- **Long paths:** `\\?\` (and `\\?\UNC\`) prefix is applied when the path reaches 240 chars; yielded `file_path` values strip the prefix back off for consistency with existing scanner output.
- **Pre-Win7 fallback:** on the first `ERROR_INVALID_PARAMETER` (87) from `LARGE_FETCH`, the backend disables the flag for the rest of its lifetime and retries the same call.
- **Reparse points:** directories with `FILE_ATTRIBUTE_REPARSE_POINT` are not recursed into (avoids symlink / junction loops).
- **Work-stack, not recursion:** deep NTFS trees (32k path components is legal) won't blow Python's stack.
- **Error classification:** `ERROR_FILE_NOT_FOUND` (2), `ERROR_PATH_NOT_FOUND` (3), `ERROR_ACCESS_DENIED` (5) log at `DEBUG` and continue; other errors log at `WARNING`.
- **FileScanner untouched** — wiring the new backend through scanner dispatch is a separate follow-up, as requested in the issue.

## Scope note

Issue #30 (SMB parallel backend) has not been merged at the time of this PR, so this change creates `src/scanner/backends/__init__.py` from scratch with a minimal `ScannerBackend` `Protocol`. If #30 lands first, a tiny merge will be needed to reconcile.

## Benchmark

A benchmark was not run as part of this PR — the agent environment is Linux and the backend is ctypes-only (no-op here). Recommended local benchmark on Windows with a 100k-file fixture:

```python
import time, os
from src.scanner.backends.win32_find_ex import Win32FindExBackend

root = r"C:\path\to\100k_file_fixture"

t0 = time.perf_counter()
n_ex = sum(1 for _ in Win32FindExBackend({}).walk(root))
t_ex = time.perf_counter() - t0

t0 = time.perf_counter()
n_ow = sum(len(files) for _, _, files in os.walk(root))
t_ow = time.perf_counter() - t0

print(f"Win32FindEx : {n_ex:,} files in {t_ex:.2f}s")
print(f"os.walk     : {n_ow:,} files in {t_ow:.2f}s")
print(f"Speedup     : {t_ow / t_ex:.2f}x")
```

Expected: 2-3x speedup on local NTFS, roughly break-even on SMB (where network latency dominates and the parallel backend from #30 will be the relevant win).

## Test plan

- [x] `python -m compileall -q src/` passes
- [x] Module imports on Linux without pulling in ctypes bindings
- [x] `Win32FindExBackend({})` raises `RuntimeError` on non-Windows
- [x] pytest collects the suite on Linux (2 pass, 5 skip)
- [ ] Run full suite on a Windows host to exercise `walk`, attribute parsing, timestamp formatting, empty-dir, missing-dir, and the long-path case
- [ ] Run the benchmark snippet above against a 100k-file NTFS fixture and paste results into this PR body

https://claude.ai/code/session_01A1UzS1A4DZNk1akoP4uhZ7

---
_Generated by [Claude Code](https://claude.ai/code/session_01A1UzS1A4DZNk1akoP4uhZ7)_