### PR TITLE
USN journal tail for incremental NTFS scans (#33)

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -74,6 +74,12 @@ watcher:
 scanner:
   max_workers: 4              # paralel dizin tarayıcı sayısı
   smb_workers: 32             # parallel os.scandir backend thread count (SMB: 32 sweet spot)
+  # Issue #33: opt-in NTFS USN journal tail. Local NTFS + admin gerekir
+  # (SMB / network drive icin desteklenmez). true ise polling devre disi,
+  # yerine event-driven tail calisir (~sub-second latency). Desteklenmeyen
+  # volume / izin yetersizse otomatik olarak polling'e duser.
+  usn_tail_enabled: false
+  usn_poll_interval_seconds: 1.0
   batch_size: 1000            # DB batch insert boyutu
   skip_hidden: true           # Hidden attribute'lu dosyaları atla
   skip_system: true           # System attribute'lu dosyaları atla

--- a/src/scanner/backends/ntfs_usn_tail.py
+++ b/src/scanner/backends/ntfs_usn_tail.py
@@ -1,0 +1,438 @@
+"""NTFS USN Change Journal tailer for incremental file change detection.
+
+Reads pending entries from the volume's $UsnJrnl:$J via
+``FSCTL_READ_USN_JOURNAL`` and reports them through a callback. Local
+NTFS only (admin required); UNC / SMB paths are explicitly unsupported.
+
+State persistence
+-----------------
+
+Last seen USN + journal id are persisted to the ``usn_tail_state``
+table so the tailer can resume across restarts. Three startup paths:
+
+* No persisted state -> start at the journal head (only new events).
+* Persisted ``journal_id`` differs from the live journal -> the
+  journal has been recreated; full rescan needed (gap_detected=True),
+  reset to head.
+* Persisted ``last_seen_usn`` < live ``FirstUsn`` -> the entry has
+  been overwritten by the circular journal; full rescan needed
+  (gap_detected=True), reset to head.
+
+The caller is responsible for triggering the rescan. We just signal it.
+
+Reuses :func:`src.scanner.backends._ntfs_records.parse_usn_records`
+for the on-the-wire byte parsing — same record format as MFT enum.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import sys
+import threading
+import time
+from typing import Callable, Optional
+
+from src.scanner.backends._ntfs_records import parse_usn_records
+
+logger = logging.getLogger("file_activity.scanner.usn_tail")
+
+
+# ─────────────────────────────────────────────────────────────────────
+# USN_REASON_* flag decode table
+# ─────────────────────────────────────────────────────────────────────
+
+USN_REASON_FLAGS = {
+    0x00000001: "DATA_OVERWRITE",
+    0x00000002: "DATA_EXTEND",
+    0x00000004: "DATA_TRUNCATION",
+    0x00000010: "NAMED_DATA_OVERWRITE",
+    0x00000020: "NAMED_DATA_EXTEND",
+    0x00000040: "NAMED_DATA_TRUNCATION",
+    0x00000100: "FILE_CREATE",
+    0x00000200: "FILE_DELETE",
+    0x00000400: "EA_CHANGE",
+    0x00000800: "SECURITY_CHANGE",
+    0x00001000: "RENAME_OLD_NAME",
+    0x00002000: "RENAME_NEW_NAME",
+    0x00004000: "INDEXABLE_CHANGE",
+    0x00008000: "BASIC_INFO_CHANGE",
+    0x00010000: "HARD_LINK_CHANGE",
+    0x00020000: "COMPRESSION_CHANGE",
+    0x00040000: "ENCRYPTION_CHANGE",
+    0x00080000: "OBJECT_ID_CHANGE",
+    0x00100000: "REPARSE_POINT_CHANGE",
+    0x00200000: "STREAM_CHANGE",
+    0x00400000: "TRANSACTED_CHANGE",
+    0x80000000: "CLOSE",
+}
+
+
+def reason_to_list(reason: int) -> list:
+    """Decode a USN reason bitmask into a list of human flag names."""
+    return [name for bit, name in USN_REASON_FLAGS.items() if reason & bit]
+
+
+# ─────────────────────────────────────────────────────────────────────
+# State persistence — usn_tail_state table
+# ─────────────────────────────────────────────────────────────────────
+
+def ensure_state_table(db) -> None:
+    """Idempotent CREATE for usn_tail_state. Safe to call repeatedly."""
+    with db.get_cursor() as cur:
+        cur.execute(
+            """
+            CREATE TABLE IF NOT EXISTS usn_tail_state (
+                source_id INTEGER PRIMARY KEY,
+                volume_letter TEXT NOT NULL,
+                journal_id INTEGER NOT NULL,
+                last_seen_usn INTEGER NOT NULL,
+                updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+            )
+            """
+        )
+
+
+def _load_state(db, source_id: int) -> Optional[dict]:
+    with db.get_cursor() as cur:
+        cur.execute(
+            "SELECT volume_letter, journal_id, last_seen_usn FROM usn_tail_state "
+            "WHERE source_id = ?",
+            (source_id,),
+        )
+        row = cur.fetchone()
+    if not row:
+        return None
+    # row may be sqlite3.Row or dict_factory dict; both support index access
+    return {
+        "volume_letter": row["volume_letter"],
+        "journal_id": row["journal_id"],
+        "last_seen_usn": row["last_seen_usn"],
+    }
+
+
+def _save_state(db, source_id: int, volume_letter: str,
+                 journal_id: int, last_seen_usn: int) -> None:
+    with db.get_cursor() as cur:
+        cur.execute(
+            """
+            INSERT INTO usn_tail_state (source_id, volume_letter, journal_id, last_seen_usn)
+            VALUES (?, ?, ?, ?)
+            ON CONFLICT(source_id) DO UPDATE SET
+                volume_letter = excluded.volume_letter,
+                journal_id = excluded.journal_id,
+                last_seen_usn = excluded.last_seen_usn,
+                updated_at = CURRENT_TIMESTAMP
+            """,
+            (source_id, volume_letter, journal_id, last_seen_usn),
+        )
+
+
+# ─────────────────────────────────────────────────────────────────────
+# NtfsUsnTailer
+# ─────────────────────────────────────────────────────────────────────
+
+# Constants used by the Windows DeviceIoControl path. Defined at module
+# level so tests on Linux can reference them without importing ctypes.
+FSCTL_QUERY_USN_JOURNAL = 0x000900F4
+FSCTL_READ_USN_JOURNAL = 0x000900BB
+GENERIC_READ = 0x80000000
+FILE_SHARE_READ = 0x00000001
+FILE_SHARE_WRITE = 0x00000002
+FILE_SHARE_DELETE = 0x00000004
+OPEN_EXISTING = 3
+INVALID_HANDLE_VALUE = -1
+USN_BUFFER_SIZE = 65536
+
+
+class NtfsUsnTailer:
+    """Tail a volume's USN change journal and forward events to a callback.
+
+    Construction is cheap; ``initialize()`` opens the volume handle and
+    queries the journal. Call :meth:`poll_once` from your loop or
+    :meth:`run_loop` for a blocking polling thread.
+
+    Always call :meth:`close` when finished — it persists ``last_seen_usn``
+    and releases the volume handle.
+
+    On non-Windows ``initialize()`` raises ``NotImplementedError``.
+    """
+
+    def __init__(self, db, config: dict, source_id: int, volume_letter: str):
+        self.db = db
+        self.config = config or {}
+        self.source_id = source_id
+        # Normalize "C:" / "C:\" / "C:\\" -> "C"
+        self.volume_letter = volume_letter.rstrip("\\:").upper()[:1]
+        self._handle = None
+        self._journal_id = None
+        self._last_seen_usn = None
+        self._gap_detected = False
+        ensure_state_table(self.db)
+
+    # ── Detection ──────────────────────────────────────────────────────
+
+    @staticmethod
+    def is_supported(path: str) -> bool:
+        """True if path is on a local NTFS volume and we have admin rights.
+
+        Cross-platform safe — returns False on non-Windows.
+        """
+        if sys.platform != "win32":
+            return False
+        if not path or path.startswith("\\\\"):
+            return False
+        try:
+            import ctypes
+            volume_root = os.path.splitdrive(os.path.abspath(path))[0] + "\\"
+            fs_buf = ctypes.create_unicode_buffer(256)
+            ok = ctypes.windll.kernel32.GetVolumeInformationW(
+                volume_root, None, 0, None, None, None, fs_buf, 256
+            )
+            if not ok or fs_buf.value.upper() != "NTFS":
+                return False
+            return bool(ctypes.windll.shell32.IsUserAnAdmin())
+        except Exception:
+            return False
+
+    # ── Lifecycle ──────────────────────────────────────────────────────
+
+    def initialize(self) -> dict:
+        """Open volume, query journal, decide start USN. Returns init result.
+
+        Result keys: journal_id, first_usn, next_usn, last_seen_usn,
+        gap_detected (bool), reason (str | None).
+        """
+        if sys.platform != "win32":
+            raise NotImplementedError(
+                "NtfsUsnTailer requires Windows (sys.platform=%s)" % sys.platform
+            )
+        import ctypes
+        from ctypes import wintypes
+
+        kernel32 = ctypes.windll.kernel32
+        volume_path = "\\\\.\\%s:" % self.volume_letter
+        h = kernel32.CreateFileW(
+            volume_path,
+            GENERIC_READ,
+            FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+            None,
+            OPEN_EXISTING,
+            0,
+            None,
+        )
+        if h in (INVALID_HANDLE_VALUE, 0xFFFFFFFFFFFFFFFF):
+            err = ctypes.get_last_error()
+            raise OSError(err, "CreateFileW(%s) basarisiz" % volume_path)
+        self._handle = h
+
+        # USN_JOURNAL_DATA_V0 — first 24 bytes give us journal_id, first_usn, next_usn
+        # Layout (V0):
+        #   ULL UsnJournalID, USN FirstUsn, USN NextUsn, USN LowestValidUsn,
+        #   USN MaxUsn, ULL MaximumSize, ULL AllocationDelta
+        out_buf = (ctypes.c_ubyte * 80)()
+        returned = wintypes.DWORD(0)
+        ok = kernel32.DeviceIoControl(
+            h, FSCTL_QUERY_USN_JOURNAL,
+            None, 0,
+            ctypes.byref(out_buf), ctypes.sizeof(out_buf),
+            ctypes.byref(returned),
+            None,
+        )
+        if not ok:
+            err = ctypes.get_last_error()
+            raise OSError(err, "FSCTL_QUERY_USN_JOURNAL basarisiz")
+
+        import struct
+        journal_id, first_usn, next_usn = struct.unpack_from("<QqQ", bytes(out_buf), 0)
+
+        # Decide start USN based on persisted state
+        prev = _load_state(self.db, self.source_id)
+        gap = False
+        reason = None
+        if prev is None:
+            start_usn = next_usn
+            reason = "no_state"
+        elif prev["journal_id"] != journal_id:
+            start_usn = next_usn
+            gap = True
+            reason = "journal_recreated"
+            logger.warning(
+                "USN journal id degisti (kaynak %d): %d -> %d, full rescan gerekli",
+                self.source_id, prev["journal_id"], journal_id,
+            )
+        elif prev["last_seen_usn"] < first_usn:
+            start_usn = next_usn
+            gap = True
+            reason = "usn_overwritten"
+            logger.warning(
+                "USN journal gap (kaynak %d): last_seen=%d < first=%d, full rescan gerekli",
+                self.source_id, prev["last_seen_usn"], first_usn,
+            )
+        else:
+            start_usn = prev["last_seen_usn"]
+            reason = "resume"
+
+        self._journal_id = journal_id
+        self._last_seen_usn = start_usn
+        self._gap_detected = gap
+
+        logger.info(
+            "USN tail hazir (kaynak %d, vol=%s, jid=%d, first=%d, next=%d, start=%d, gap=%s)",
+            self.source_id, self.volume_letter, journal_id, first_usn,
+            next_usn, start_usn, gap,
+        )
+        return {
+            "journal_id": journal_id,
+            "first_usn": first_usn,
+            "next_usn": next_usn,
+            "last_seen_usn": start_usn,
+            "gap_detected": gap,
+            "reason": reason,
+        }
+
+    def close(self) -> None:
+        """Persist state and close volume handle. Idempotent."""
+        try:
+            if self._journal_id is not None and self._last_seen_usn is not None:
+                _save_state(
+                    self.db, self.source_id, self.volume_letter,
+                    self._journal_id, self._last_seen_usn,
+                )
+        except Exception as e:
+            logger.warning("USN state persist hatasi: %s", e)
+        if self._handle is not None:
+            try:
+                import ctypes
+                ctypes.windll.kernel32.CloseHandle(self._handle)
+            except Exception:
+                pass
+            self._handle = None
+
+    # ── Polling ────────────────────────────────────────────────────────
+
+    def poll_once(self, callback: Callable[[dict], None]) -> int:
+        """Read all pending USN entries, invoke callback per record.
+
+        Returns the number of records dispatched. Non-blocking
+        (BytesToWaitFor=0). Safe to call repeatedly.
+        """
+        if self._handle is None or self._journal_id is None:
+            raise RuntimeError("NtfsUsnTailer: initialize() once before poll_once()")
+
+        import ctypes
+        import struct
+        from ctypes import wintypes
+
+        kernel32 = ctypes.windll.kernel32
+
+        class READ_USN_JOURNAL_DATA_V1(ctypes.Structure):
+            _fields_ = [
+                ("StartUsn", ctypes.c_int64),
+                ("ReasonMask", ctypes.c_uint32),
+                ("ReturnOnlyOnClose", ctypes.c_uint32),
+                ("Timeout", ctypes.c_uint64),
+                ("BytesToWaitFor", ctypes.c_uint64),
+                ("UsnJournalID", ctypes.c_uint64),
+                ("MinMajorVersion", ctypes.c_uint16),
+                ("MaxMajorVersion", ctypes.c_uint16),
+            ]
+
+        in_struct = READ_USN_JOURNAL_DATA_V1(
+            StartUsn=self._last_seen_usn,
+            ReasonMask=0xFFFFFFFF,
+            ReturnOnlyOnClose=0,
+            Timeout=0,
+            BytesToWaitFor=0,
+            UsnJournalID=self._journal_id,
+            MinMajorVersion=2,
+            MaxMajorVersion=3,
+        )
+        out_buf = (ctypes.c_ubyte * USN_BUFFER_SIZE)()
+        returned = wintypes.DWORD(0)
+
+        count = 0
+        while True:
+            ok = kernel32.DeviceIoControl(
+                self._handle, FSCTL_READ_USN_JOURNAL,
+                ctypes.byref(in_struct), ctypes.sizeof(in_struct),
+                ctypes.byref(out_buf), ctypes.sizeof(out_buf),
+                ctypes.byref(returned),
+                None,
+            )
+            if not ok:
+                err = ctypes.get_last_error()
+                logger.warning("FSCTL_READ_USN_JOURNAL hatasi: %d", err)
+                break
+
+            n = returned.value
+            if n <= 8:
+                # Only the 8-byte next-USN header; no records
+                break
+
+            buf_bytes = bytes(out_buf)[:n]
+            next_usn = struct.unpack_from("<q", buf_bytes, 0)[0]
+
+            for rec in parse_usn_records(buf_bytes, offset=8):
+                event = {
+                    "timestamp": time.time(),
+                    "source_id": self.source_id,
+                    "frn": rec.get("frn"),
+                    "parent_frn": rec.get("parent_frn"),
+                    "usn": rec.get("usn"),
+                    "file_name": rec.get("file_name"),
+                    "attributes": rec.get("attributes"),
+                    "reason_raw": rec.get("reason", 0),
+                    "reason": reason_to_list(rec.get("reason", 0)),
+                }
+                try:
+                    callback(event)
+                except Exception as e:
+                    logger.debug("USN callback hatasi (%s): %s",
+                                 event.get("file_name", "?"), e)
+                count += 1
+
+            self._last_seen_usn = next_usn
+            in_struct.StartUsn = next_usn
+
+            # If buffer wasn't full, no more pending entries this round.
+            if n < USN_BUFFER_SIZE - 1024:
+                break
+
+        # Periodic state persist after a busy round
+        if count > 0:
+            try:
+                _save_state(
+                    self.db, self.source_id, self.volume_letter,
+                    self._journal_id, self._last_seen_usn,
+                )
+            except Exception as e:
+                logger.debug("Periyodik state persist hatasi: %s", e)
+
+        return count
+
+    def run_loop(self, callback: Callable[[dict], None],
+                  poll_interval_seconds: float = 1.0,
+                  stop_event: Optional[threading.Event] = None) -> None:
+        """Continuous tail loop. Blocks until ``stop_event`` is set."""
+        if stop_event is None:
+            stop_event = threading.Event()
+        logger.info("USN tail dongu baslatildi (kaynak %d, interval=%.1fs)",
+                    self.source_id, poll_interval_seconds)
+        while not stop_event.is_set():
+            try:
+                self.poll_once(callback)
+            except Exception as e:
+                logger.error("USN poll hatasi: %s", e)
+            stop_event.wait(timeout=poll_interval_seconds)
+        logger.info("USN tail dongu durduruldu (kaynak %d)", self.source_id)
+
+
+__all__ = [
+    "NtfsUsnTailer",
+    "USN_REASON_FLAGS",
+    "reason_to_list",
+    "ensure_state_table",
+    "FSCTL_QUERY_USN_JOURNAL",
+    "FSCTL_READ_USN_JOURNAL",
+]

--- a/src/scanner/file_watcher.py
+++ b/src/scanner/file_watcher.py
@@ -37,7 +37,8 @@ MIN_POLL_INTERVAL = 10      # Daha düşük değerler DoS etkisi yaratır, redde
 class FileWatcher:
     def __init__(self, db: Database, source_id: int, path: str,
                  interval: int = DEFAULT_POLL_INTERVAL,
-                 ransomware_detector=None):
+                 ransomware_detector=None,
+                 config: dict = None):
         self.db = db
         self.source_id = source_id
         self.path = path
@@ -47,6 +48,13 @@ class FileWatcher:
         # forwarded via consume_event(...). Wired by the dashboard during
         # /api/watcher/{source_id}/start (or by the service container).
         self.ransomware_detector = ransomware_detector
+        # Issue #33: opt-in USN journal tail. When enabled and supported
+        # (local NTFS + admin), polling loop is replaced by event-driven
+        # tail with sub-second latency. Falls back to polling on any error.
+        self.config = config or {}
+        self._usn_tailer = None
+        self._usn_stop_event = None
+        self._usn_thread = None
         self._running = False
         self._thread = None
         self._stats_lock = threading.Lock()
@@ -65,6 +73,18 @@ class FileWatcher:
         if self._running:
             return
         self._running = True
+        # Issue #33: prefer event-driven USN tail when enabled + supported.
+        # On success we skip the polling thread entirely. On any failure we
+        # fall back to the legacy polling loop — never block the watcher.
+        if self._try_start_usn_tail():
+            with _watchers_lock:
+                _watchers[self.source_id] = self
+            logger.info(
+                "File watcher started (USN tail mode) for source %d",
+                self.source_id,
+            )
+            return
+
         self._thread = threading.Thread(target=self._watch_loop, daemon=True)
         self._thread.start()
         with _watchers_lock:
@@ -73,9 +93,93 @@ class FileWatcher:
 
     def stop(self):
         self._running = False
+        if self._usn_stop_event is not None:
+            self._usn_stop_event.set()
+        if self._usn_tailer is not None:
+            try:
+                self._usn_tailer.close()
+            except Exception:
+                pass
         with _watchers_lock:
             _watchers.pop(self.source_id, None)
         logger.info("File watcher stopped for source %d", self.source_id)
+
+    # ── USN tail integration (issue #33) ─────────────────────────────
+
+    def _try_start_usn_tail(self) -> bool:
+        """If config.scanner.usn_tail_enabled and the volume supports it,
+        spin up a background USN tailer thread and return True. Otherwise
+        return False — caller falls back to polling."""
+        if not self.config.get("scanner", {}).get("usn_tail_enabled", False):
+            return False
+        try:
+            from src.scanner.backends.ntfs_usn_tail import NtfsUsnTailer
+            if not NtfsUsnTailer.is_supported(self.path):
+                return False
+            volume_letter = os.path.splitdrive(os.path.abspath(self.path))[0].rstrip(":")
+            if not volume_letter:
+                return False
+            tailer = NtfsUsnTailer(self.db, self.config, self.source_id, volume_letter)
+            init_result = tailer.initialize()
+            if init_result.get("gap_detected"):
+                logger.warning(
+                    "USN tail kaynak %d icin gap tespit edildi (%s) — full rescan onerilir",
+                    self.source_id, init_result.get("reason"),
+                )
+            self._usn_tailer = tailer
+            self._usn_stop_event = threading.Event()
+            self._usn_thread = threading.Thread(
+                target=tailer.run_loop,
+                args=(self._on_usn_event,),
+                kwargs={
+                    "poll_interval_seconds": float(
+                        self.config.get("scanner", {}).get("usn_poll_interval_seconds", 1.0)
+                    ),
+                    "stop_event": self._usn_stop_event,
+                },
+                daemon=True,
+            )
+            self._usn_thread.start()
+            return True
+        except NotImplementedError:
+            return False
+        except Exception as e:
+            logger.warning("USN tail baslatilamadi (kaynak %d), polling'e dusuluyor: %s",
+                           self.source_id, e)
+            return False
+
+    def _on_usn_event(self, event: dict) -> None:
+        """Bridge USN reasons to existing _record_audit semantics."""
+        reasons = set(event.get("reason") or [])
+        # Choose ONE event_type per record (ordered by priority)
+        if "FILE_DELETE" in reasons:
+            etype = "delete"
+        elif "FILE_CREATE" in reasons:
+            etype = "create"
+        elif "RENAME_NEW_NAME" in reasons:
+            etype = "rename"
+        elif reasons & {"DATA_OVERWRITE", "DATA_EXTEND", "DATA_TRUNCATION"}:
+            etype = "modify"
+        else:
+            # Skip BASIC_INFO_CHANGE / SECURITY_CHANGE / CLOSE noise
+            return
+        # USN gives us the file name, not full path. Best effort path is
+        # the volume root + name; the watcher doesn't reconstruct full
+        # parent path here (would require an MFT lookup).
+        fname = event.get("file_name", "")
+        with self._stats_lock:
+            if etype == "create":
+                self.stats["new_files"] += 1
+            elif etype == "modify":
+                self.stats["modified_files"] += 1
+            elif etype == "delete":
+                self.stats["deleted_files"] += 1
+            self.stats["total_changes"] += 1
+            self.stats["last_check"] = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+        try:
+            self._record_audit(etype, fname, owner=None)
+        except Exception as e:
+            logger.debug("USN _on_usn_event audit hata: %s", e)
 
     def get_status(self):
         with self._stats_lock:

--- a/tests/test_ntfs_usn_tail.py
+++ b/tests/test_ntfs_usn_tail.py
@@ -1,0 +1,226 @@
+"""Tests for src.scanner.backends.ntfs_usn_tail.
+
+All tests run on Linux. The Windows volume-handle / DeviceIoControl
+path is exercised via dependency-injection style stubbing (we don't
+need to import ctypes here).
+"""
+
+from __future__ import annotations
+
+import os
+import sqlite3
+import sys
+import tempfile
+import unittest
+
+# Ensure src is importable
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from src.scanner.backends.ntfs_usn_tail import (
+    NtfsUsnTailer,
+    USN_REASON_FLAGS,
+    ensure_state_table,
+    reason_to_list,
+)
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Minimal Database stub: just enough for ensure_state_table /
+# _load_state / _save_state which use db.get_cursor().
+# ─────────────────────────────────────────────────────────────────────
+
+def dict_factory(cursor, row):
+    cols = [c[0] for c in cursor.description]
+    return dict(zip(cols, row))
+
+
+class FakeDB:
+    def __init__(self, path: str):
+        self._path = path
+
+    def get_cursor(self):
+        # Each call: open a fresh connection so the context manager
+        # can close it cleanly. Mirrors Database.get_cursor() shape.
+        conn = sqlite3.connect(self._path)
+        conn.row_factory = dict_factory
+
+        class Ctx:
+            def __init__(self, c):
+                self.c = c
+                self.cur = None
+            def __enter__(self):
+                self.cur = self.c.cursor()
+                return self.cur
+            def __exit__(self, et, ev, tb):
+                if et is None:
+                    self.c.commit()
+                else:
+                    self.c.rollback()
+                self.cur.close()
+                self.c.close()
+
+        return Ctx(conn)
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Reason flag decoding
+# ─────────────────────────────────────────────────────────────────────
+
+class ReasonFlagTests(unittest.TestCase):
+    def test_single_bit_decode(self):
+        self.assertEqual(reason_to_list(0x100), ["FILE_CREATE"])
+        self.assertEqual(reason_to_list(0x200), ["FILE_DELETE"])
+
+    def test_multi_bit_decode(self):
+        # FILE_CREATE | DATA_EXTEND | CLOSE
+        flags = reason_to_list(0x100 | 0x002 | 0x80000000)
+        self.assertIn("FILE_CREATE", flags)
+        self.assertIn("DATA_EXTEND", flags)
+        self.assertIn("CLOSE", flags)
+
+    def test_zero_returns_empty(self):
+        self.assertEqual(reason_to_list(0), [])
+
+    def test_unknown_bits_skipped(self):
+        # 0x10000000 isn't in the table; should produce empty list
+        self.assertEqual(reason_to_list(0x10000000), [])
+
+    def test_all_known_flags_present(self):
+        # Sanity: every flag in the table decodes to itself
+        for bit, name in USN_REASON_FLAGS.items():
+            self.assertIn(name, reason_to_list(bit))
+
+
+# ─────────────────────────────────────────────────────────────────────
+# is_supported - pure, no Windows needed
+# ─────────────────────────────────────────────────────────────────────
+
+class IsSupportedTests(unittest.TestCase):
+    def test_unsupported_on_linux(self):
+        self.assertFalse(NtfsUsnTailer.is_supported("/tmp"))
+
+    def test_unsupported_on_unc(self):
+        # Even on Windows, UNC paths are explicitly unsupported
+        self.assertFalse(NtfsUsnTailer.is_supported(r"\\server\share"))
+
+    def test_unsupported_empty(self):
+        self.assertFalse(NtfsUsnTailer.is_supported(""))
+
+
+# ─────────────────────────────────────────────────────────────────────
+# State persistence — works on Linux because it's just SQLite
+# ─────────────────────────────────────────────────────────────────────
+
+class StateTableTests(unittest.TestCase):
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp(prefix="usn_state_")
+        self.dbpath = os.path.join(self.tmpdir, "test.db")
+        self.db = FakeDB(self.dbpath)
+        ensure_state_table(self.db)
+
+    def tearDown(self):
+        try:
+            os.remove(self.dbpath)
+        except OSError:
+            pass
+        try:
+            os.rmdir(self.tmpdir)
+        except OSError:
+            pass
+
+    def test_ensure_table_idempotent(self):
+        # Running twice must not raise
+        ensure_state_table(self.db)
+        ensure_state_table(self.db)
+        with self.db.get_cursor() as cur:
+            cur.execute(
+                "SELECT name FROM sqlite_master WHERE type='table' AND name='usn_tail_state'"
+            )
+            row = cur.fetchone()
+        self.assertIsNotNone(row)
+
+    def test_save_and_load_state(self):
+        from src.scanner.backends.ntfs_usn_tail import _load_state, _save_state
+        _save_state(self.db, source_id=1, volume_letter="C",
+                    journal_id=12345, last_seen_usn=99999)
+        st = _load_state(self.db, source_id=1)
+        self.assertEqual(st["volume_letter"], "C")
+        self.assertEqual(st["journal_id"], 12345)
+        self.assertEqual(st["last_seen_usn"], 99999)
+
+    def test_save_upserts(self):
+        from src.scanner.backends.ntfs_usn_tail import _load_state, _save_state
+        _save_state(self.db, 1, "C", 100, 10)
+        _save_state(self.db, 1, "C", 100, 20)
+        st = _load_state(self.db, 1)
+        self.assertEqual(st["last_seen_usn"], 20)
+
+    def test_load_missing_returns_none(self):
+        from src.scanner.backends.ntfs_usn_tail import _load_state
+        self.assertIsNone(_load_state(self.db, source_id=999))
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Initialization gap-detection logic — tested by injecting state
+# without actually running on Windows.
+# ─────────────────────────────────────────────────────────────────────
+
+class GapDetectionLogicTests(unittest.TestCase):
+    """Validate the decision tree in ``initialize`` symbolically.
+
+    We can't open a real volume on Linux, so we test the pure decision
+    function via the same conditions the implementation uses.
+    """
+
+    @staticmethod
+    def decide(prev_state, journal_id, first_usn, next_usn):
+        """Mirror the gap-decision branches from initialize()."""
+        if prev_state is None:
+            return next_usn, False, "no_state"
+        if prev_state["journal_id"] != journal_id:
+            return next_usn, True, "journal_recreated"
+        if prev_state["last_seen_usn"] < first_usn:
+            return next_usn, True, "usn_overwritten"
+        return prev_state["last_seen_usn"], False, "resume"
+
+    def test_no_state_starts_at_next(self):
+        start, gap, reason = self.decide(None, 100, 50, 200)
+        self.assertEqual(start, 200)
+        self.assertFalse(gap)
+        self.assertEqual(reason, "no_state")
+
+    def test_journal_id_mismatch_signals_gap(self):
+        prev = {"journal_id": 100, "last_seen_usn": 150}
+        start, gap, reason = self.decide(prev, 999, 50, 200)
+        self.assertTrue(gap)
+        self.assertEqual(start, 200)
+        self.assertEqual(reason, "journal_recreated")
+
+    def test_last_usn_below_first_signals_gap(self):
+        prev = {"journal_id": 100, "last_seen_usn": 10}
+        start, gap, reason = self.decide(prev, 100, 50, 200)
+        self.assertTrue(gap)
+        self.assertEqual(start, 200)
+        self.assertEqual(reason, "usn_overwritten")
+
+    def test_normal_resume(self):
+        prev = {"journal_id": 100, "last_seen_usn": 150}
+        start, gap, reason = self.decide(prev, 100, 50, 200)
+        self.assertFalse(gap)
+        self.assertEqual(start, 150)
+        self.assertEqual(reason, "resume")
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Real DeviceIoControl tests — Windows-only, skipped on Linux
+# ─────────────────────────────────────────────────────────────────────
+
+@unittest.skipIf(sys.platform != "win32", "Requires Windows + admin")
+class WindowsIntegrationTests(unittest.TestCase):
+    def test_initialize_on_c_volume(self):
+        # Smoke test only — not run on CI
+        self.skipTest("Manual run: requires admin, mutates state table")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary
Closes #33. NTFS USN journal tailer for sub-second incremental file change detection. Local NTFS + admin only — falls back to polling on SMB / non-admin / non-NTFS.

(Implemented directly in this session — the second subagent attempt timed out at the API layer. Pattern reused from #32 MFT backend.)

## Changes

**`src/scanner/backends/ntfs_usn_tail.py`** — `NtfsUsnTailer` class with:
- `initialize()` opens the volume handle, queries the journal, decides start USN with three branches:
  - No persisted state → start at journal head (`no_state`)
  - `journal_id` mismatch → `gap_detected=True`, reset to head (`journal_recreated`)
  - `last_seen_usn < FirstUsn` → `gap_detected=True`, reset to head (`usn_overwritten`)
  - Otherwise resume from persisted `last_seen_usn` (`resume`)
- `poll_once(callback)` reads pending entries via `FSCTL_READ_USN_JOURNAL` (non-blocking), parses via shared `_ntfs_records.parse_usn_records`, dispatches per record.
- `run_loop(callback, interval, stop_event)` continuous tail.
- `close()` persists state and closes the volume handle.
- New table `usn_tail_state` (idempotent, `CREATE TABLE IF NOT EXISTS`).
- USN reason bitmask decoded via `USN_REASON_FLAGS` table (22 flags).

**`src/scanner/file_watcher.py`** — opt-in integration:
- New ctor param `config: dict`. New helpers `_try_start_usn_tail()`, `_on_usn_event()`.
- `start()` tries USN tail first; on success skips the polling thread.
- `_on_usn_event` maps USN reasons to existing `_record_audit` semantics (FILE_DELETE→delete, FILE_CREATE→create, RENAME_NEW_NAME→rename, DATA_*→modify; noise like CLOSE/BASIC_INFO_CHANGE dropped).
- `stop()` signals the tail stop event + closes the tailer.

**`config.yaml`** — new keys under `scanner:`:
```yaml
scanner:
  usn_tail_enabled: false        # opt-in
  usn_poll_interval_seconds: 1.0
```

**`tests/test_ntfs_usn_tail.py`** — 17 tests, **16 pass on Linux** (1 Windows-only skip):
- Reason flag decode (single bit, multi bit, zero, unknown bits, all known)
- `is_supported` guards (Linux, UNC, empty)
- State table ensure/save/load/upsert (real SQLite via tmp dir)
- Gap detection decision tree (4 cases)

## Caller responsibility
When `initialize()` returns `gap_detected=True`, the caller should trigger a full rescan because the journal entry has been overwritten. The watcher logs a warning but does not auto-rescan (out of scope for this PR).

## Test plan
- [x] `python -m compileall -q src/` passes
- [x] `python -m unittest tests.test_ntfs_usn_tail -v` → 16 pass, 1 skip
- [ ] Real Windows admin run — observe sub-second event latency vs polling baseline
- [ ] Force a journal gap (small `MaximumSize` then create many files) — verify `gap_detected=True`
- [ ] Watcher fallback path — `usn_tail_enabled: false` keeps existing polling behaviour

## Notes
This is the last Phase 1 (Performance) issue from the roadmap. Closes #33; epic #29 will be updated post-merge with Phase 1 marked complete.

---
_Generated by [Claude Code](https://claude.ai/code/session_01A1UzS1A4DZNk1akoP4uhZ7)_