### PR TITLE
Fix unresolved conflict markers in config.yaml (critical, breaks YAML parsing)

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -147,7 +147,6 @@ dashboard:
   host: "0.0.0.0"
   port: 8085
 
-<<<<<<< HEAD
 security:
   # Fidye yazilimi tespit motoru (#37). Watcher event akisini dinler,
   # asagidaki dort kuralla anomali yakalar ve opsiyonel olarak SMB
@@ -175,7 +174,7 @@ security:
       - "_ZZZZ_canary_DO_NOT_DELETE.txt"
     auto_kill_session: false           # opt-in: SMB oturumunu Close-SmbSession ile sonlandir
     notification_email: ""             # bos degilse bu adrese kritik uyari maili gider
-=======
+
 audit:
   # Tamper-evident hash-chained audit log (issue #38).
   # When chain_enabled=true, every audit event written via the
@@ -194,4 +193,3 @@ audit:
   # Optional Ed25519 PEM (or raw 32-byte) private key for detached
   # signatures over the export's SHA-256. Empty = no signing.
   signing_key_path: ""
->>>>>>> 64a1ba5 (Tamper-evident audit log chain + WORM export (closes #38))


### PR DESCRIPTION
## Summary
**Critical fix.** Master `config.yaml` carried unresolved Git conflict markers (`<<<<<<<`, `=======`, `>>>>>>>`) since PR #45 (audit log chain) rebase. CI didn't catch this because YAML isn't linted in the existing workflow — only `py_compile` + ruff over Python.

## Resolution
Keep both top-level sections side-by-side: `security:` (from #43 ransomware) and `audit:` (from #38 chain). They don't collide; the rebase just couldn't decide and dumped both with markers between them.

## Verification
```
python -c "import yaml; yaml.safe_load(open('config.yaml'))"  # exit 0
grep -n "<<<<<<<\|=======\|>>>>>>>" config.yaml  # empty
```

## Follow-up
Open a separate issue: **add `yaml.safe_load` smoke check to `.github/workflows/ci.yml`** so this can never recur. Should be a single bash step in the lint job.

---
_Generated by [Claude Code](https://claude.ai/code/session_01A1UzS1A4DZNk1akoP4uhZ7)_