### PR TITLE
NTFS ACL / effective-permissions analyzer (#49)

### DIFF
--- a/src/dashboard/api.py
+++ b/src/dashboard/api.py
@@ -2567,4 +2567,105 @@ def create_app(db, config, analytics=None, ad_lookup=None, email_notifier=None):
             "notification_email": det.notification_email or None,
         }
 
+    # ─────────────────────────────────────────────────────────────────
+    # NTFS ACL / effective-permissions analyzer (#49)
+    #
+    # Lazy-construct the analyzer so a missing/disabled `security`
+    # config block doesn't break the rest of the dashboard. Endpoints
+    # all degrade gracefully when running on Linux: the live
+    # `get_effective_acl` returns 501, but the DB-backed queries still
+    # work against any snapshot rows present.
+    # ─────────────────────────────────────────────────────────────────
+
+    def _get_acl_analyzer():
+        existing = getattr(app.state, "acl_analyzer", None)
+        if existing is not None:
+            return existing
+        from src.security.acl_analyzer import AclAnalyzer
+        analyzer = AclAnalyzer(db, config, ad_lookup=ad_lookup)
+        app.state.acl_analyzer = analyzer
+        return analyzer
+
+    @app.get("/api/security/acl")
+    async def get_effective_acl(path: str = Query(..., min_length=1)):
+        """Live effective DACL read for one path. Windows-only."""
+        analyzer = _get_acl_analyzer()
+        if not analyzer.is_supported():
+            raise HTTPException(501, "ACL live read requires Windows + pywin32")
+        try:
+            return analyzer.get_effective_acl(path)
+        except FileNotFoundError as e:
+            raise HTTPException(404, f"Path not found: {path}") from e
+        except PermissionError as e:
+            raise HTTPException(403, f"Access denied reading ACL: {e}") from e
+        except Exception as e:
+            raise HTTPException(500, f"ACL read failed: {e}") from e
+
+    @app.get("/api/security/acl/trustee/{sid}/paths")
+    async def acl_paths_for_trustee(sid: str,
+                                    limit: int = Query(100, ge=1, le=10000)):
+        """Paths granting access to a SID, from the latest snapshot."""
+        analyzer = _get_acl_analyzer()
+        return {
+            "trustee_sid": sid,
+            "limit": limit,
+            "paths": analyzer.find_paths_for_trustee(sid, limit=limit),
+        }
+
+    @app.get("/api/security/acl/sprawl")
+    async def acl_sprawl(scan_id: Optional[int] = None,
+                         severity_threshold: Optional[int] = None):
+        """Top over-permissioned trustees (groups + users) for a scan."""
+        analyzer = _get_acl_analyzer()
+        thr = severity_threshold if severity_threshold is not None else analyzer.sprawl_threshold_mask
+        return {
+            "scan_id": scan_id,
+            "severity_threshold": int(thr),
+            "trustees": analyzer.detect_sprawl(scan_id=scan_id,
+                                                severity_threshold=int(thr)),
+        }
+
+    @app.post("/api/security/acl/scan/{source_id}")
+    async def acl_snapshot(source_id: int,
+                           max_files: Optional[int] = None):
+        """Snapshot DACLs for the latest completed scan of `source_id`.
+
+        v1: synchronous in a worker thread, returns once done. Heavy on
+        large shares — consider gating with `max_files` while testing.
+        """
+        analyzer = _get_acl_analyzer()
+        if not analyzer.is_supported():
+            raise HTTPException(501, "ACL snapshot requires Windows + pywin32")
+
+        src = _get_source(db, source_id)
+
+        # Pick the most recent scan_run. Prefer completed; fall back to
+        # whatever exists so an operator can re-run after a partial scan.
+        with db.get_cursor() as cur:
+            cur.execute(
+                """SELECT id FROM scan_runs WHERE source_id=?
+                   ORDER BY
+                     CASE WHEN status='completed' THEN 0 ELSE 1 END,
+                     started_at DESC
+                   LIMIT 1""",
+                (src.id,),
+            )
+            row = cur.fetchone()
+        if not row:
+            raise HTTPException(409, f"No scan_runs found for source {source_id}")
+        scan_id = row["id"]
+
+        # Run the walk in a worker thread so the asyncio loop stays
+        # responsive. We block on it to keep the v1 contract simple
+        # (returns once snapshot is durable).
+        import asyncio
+
+        def _do_snapshot():
+            return analyzer.snapshot_source(src.id, scan_id, max_files=max_files)
+
+        result = await asyncio.get_event_loop().run_in_executor(None, _do_snapshot)
+        result["source_id"] = src.id
+        result["scan_id"] = scan_id
+        return result
+
     return app

--- a/src/security/acl_analyzer.py
+++ b/src/security/acl_analyzer.py
@@ -1,0 +1,362 @@
+"""NTFS ACL / effective-permissions analyzer (issue #49).
+
+Reads on-disk Windows DACLs via pywin32 and persists a normalized snapshot
+of the ACEs to ``file_acl_snapshots`` (created idempotently in
+:meth:`Database._create_tables`). The dashboard then surfaces three
+operator-facing queries on top of that table:
+
+* ``get_effective_acl(path)``       -- live read for a single path.
+* ``find_paths_for_trustee(sid)``   -- "where does this user/group have
+  access?" for the most recent snapshot.
+* ``detect_sprawl(scan_id)``        -- top over-permissioned trustees
+  (e.g. ``Everyone`` / ``Domain Users`` granted Modify+).
+
+pywin32 is lazily imported so the module is import-safe on Linux and CI.
+``is_supported()`` is the single source of truth for callers that want to
+short-circuit on non-Windows hosts. ``snapshot_source()`` walks the
+``scanned_files`` rows for a given scan, calls ``GetFileSecurity`` per
+path, and inserts the resulting rows in batches; per-file failures are
+logged at DEBUG and never abort the run.
+
+Wiring into the scanner is intentionally NOT done here -- that lives
+behind ``security.acl_analyzer.snapshot_during_scan`` and is a follow-up
+PR. The point of this module is to make the data + queries available.
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+import time
+from typing import Optional
+
+logger = logging.getLogger("file_activity.security.acl_analyzer")
+
+
+# ACE flag bit indicating the ACE is inherited from a parent container.
+# https://learn.microsoft.com/windows/win32/secauthz/ace-header
+INHERITED_ACE_FLAG = 0x10
+
+# Known generic ACE types (we also accept anything non-zero as DENY for
+# readability — only ALLOW (0) and DENY (1) appear on a typical DACL).
+ACE_TYPE_ALLOW = 0
+ACE_TYPE_DENY = 1
+
+# Default top-N cap for sprawl + trustee queries. Capped to keep the
+# dashboard responsive on million-file shares.
+_DEFAULT_TOP_N = 50
+_INSERT_BATCH = 500
+
+
+class AclAnalyzer:
+    """NTFS ACL analyzer using pywin32 (lazy loaded — Linux-safe)."""
+
+    # Common standard rights bundles. Anything that does not match exactly
+    # falls back to ``Custom (0x...)`` so the operator can still see the
+    # raw mask in the UI without having to learn the bit layout.
+    PERMISSION_MASK_NAMES = {
+        0x001F01FF: "FullControl",
+        0x001301BF: "Modify",
+        0x001200A9: "Read+Execute",
+        0x00120089: "Read",
+        0x00120116: "Write",
+    }
+
+    def __init__(self, db, config: dict, ad_lookup=None):
+        self.db = db
+        self.ad_lookup = ad_lookup
+        cfg = ((config or {}).get("security", {}) or {}).get("acl_analyzer", {}) or {}
+        self.enabled = bool(cfg.get("enabled", True))
+        self.snapshot_during_scan = bool(cfg.get("snapshot_during_scan", False))
+        # Default sprawl threshold = Modify; anything granting Modify or
+        # higher to a broad principal counts as a finding.
+        self.sprawl_threshold_mask = int(cfg.get("sprawl_threshold_mask", 0x001301BF))
+
+    # ──────────────────────────────────────────────
+    # Capability probes
+    # ──────────────────────────────────────────────
+
+    def is_supported(self) -> bool:
+        """True on Windows with pywin32 importable. False otherwise."""
+        if sys.platform != "win32":
+            return False
+        try:
+            import win32security  # noqa: F401
+            return True
+        except Exception:  # pragma: no cover - import probe only
+            return False
+
+    # ──────────────────────────────────────────────
+    # Live read (Windows-only)
+    # ──────────────────────────────────────────────
+
+    def get_effective_acl(self, path: str) -> dict:
+        """Effective DACL for one path. Windows-only.
+
+        Returns a dict shaped like::
+
+            {path, owner_sid, owner_name,
+             entries: [{trustee_sid, trustee_name, permission_name, mask,
+                        ace_type, is_inherited, source}],
+             errors: [...]}
+
+        Per-ACE failures (e.g. an unresolvable SID) populate ``errors``
+        but never raise — the operator should still see the rest of the
+        DACL.
+        """
+        if sys.platform != "win32":
+            raise NotImplementedError("AclAnalyzer.get_effective_acl requires Windows")
+
+        import win32security  # type: ignore
+
+        sd = win32security.GetFileSecurity(
+            path,
+            win32security.OWNER_SECURITY_INFORMATION
+            | win32security.DACL_SECURITY_INFORMATION,
+        )
+        owner_sid = sd.GetSecurityDescriptorOwner()
+        owner_sid_str = win32security.ConvertSidToStringSid(owner_sid)
+        owner_name = self._sid_to_name(owner_sid)
+        dacl = sd.GetSecurityDescriptorDacl()
+
+        entries: list[dict] = []
+        errors: list[str] = []
+        if dacl is not None:
+            for i in range(dacl.GetAceCount()):
+                try:
+                    ace = dacl.GetAce(i)
+                    # Object ACEs are 6-tuples; standard ACEs are 3-tuples.
+                    # Either way the first element is (ace_type, ace_flags),
+                    # the second is the access mask, and the SID is at the
+                    # tail. Pull from the end so both shapes work.
+                    header = ace[0]
+                    ace_type, ace_flags = header[0], header[1]
+                    mask = ace[1]
+                    sid = ace[-1]
+                    is_inherited = bool(ace_flags & INHERITED_ACE_FLAG)
+                    entries.append({
+                        "trustee_sid": str(win32security.ConvertSidToStringSid(sid)),
+                        "trustee_name": self._sid_to_name(sid),
+                        "permission_name": self._mask_to_name(mask),
+                        "mask": int(mask),
+                        "ace_type": "ALLOW" if ace_type == ACE_TYPE_ALLOW else "DENY",
+                        "is_inherited": is_inherited,
+                        "source": "inherited" if is_inherited else "direct",
+                    })
+                except Exception as e:
+                    logger.debug("ACE %d on %s failed: %s", i, path, e)
+                    errors.append(f"ace_{i}: {e}")
+
+        return {
+            "path": path,
+            "owner_sid": str(owner_sid_str),
+            "owner_name": owner_name,
+            "entries": entries,
+            "errors": errors,
+        }
+
+    # ──────────────────────────────────────────────
+    # DB-backed queries (cross-platform)
+    # ──────────────────────────────────────────────
+
+    def find_paths_for_trustee(self, trustee_sid: str,
+                               limit: int = 100) -> list[dict]:
+        """Where does this SID have access? Returns rows from the most
+        recent snapshot per file_path so re-scans don't double-count.
+        """
+        limit = max(1, min(int(limit or 100), 10_000))
+        with self.db.get_cursor() as cur:
+            cur.execute(
+                """
+                SELECT
+                    s.file_path,
+                    s.trustee_sid,
+                    s.trustee_name,
+                    s.permissions_mask,
+                    s.permission_name,
+                    s.is_inherited,
+                    s.ace_type,
+                    s.scan_id,
+                    s.recorded_at
+                FROM file_acl_snapshots s
+                JOIN (
+                    SELECT file_path, trustee_sid, MAX(id) AS max_id
+                    FROM file_acl_snapshots
+                    WHERE trustee_sid = ?
+                    GROUP BY file_path, trustee_sid
+                ) latest
+                  ON latest.max_id = s.id
+                WHERE s.ace_type = 'ALLOW'
+                ORDER BY s.permissions_mask DESC, s.file_path ASC
+                LIMIT ?
+                """,
+                (trustee_sid, limit),
+            )
+            return [dict(r) for r in cur.fetchall()]
+
+    def detect_sprawl(self, scan_id: Optional[int] = None,
+                      severity_threshold: int = 0x001301BF) -> list[dict]:
+        """Top over-permissioned trustees.
+
+        Groups ``file_acl_snapshots`` by ``trustee_sid`` and returns the
+        50 worst offenders (most files with >= threshold). Only ALLOW
+        ACEs count; DENY ACEs reduce, not increase, exposure.
+
+        ``scan_id`` is optional — if omitted, ALL snapshots are scanned.
+        """
+        threshold = int(severity_threshold)
+        params: list = [threshold]
+        clause = ""
+        if scan_id is not None:
+            clause = " AND scan_id = ?"
+            params.append(int(scan_id))
+
+        sql = (
+            "SELECT trustee_sid, trustee_name, "
+            "       COUNT(DISTINCT file_path) AS file_count, "
+            "       MAX(permissions_mask)     AS max_mask, "
+            "       MAX(permission_name)      AS sample_permission_name "
+            "FROM file_acl_snapshots "
+            "WHERE ace_type = 'ALLOW' "
+            "  AND permissions_mask >= ? "
+            f" {clause} "
+            "GROUP BY trustee_sid, trustee_name "
+            "ORDER BY file_count DESC "
+            "LIMIT ?"
+        )
+        params.append(_DEFAULT_TOP_N)
+
+        with self.db.get_cursor() as cur:
+            cur.execute(sql, tuple(params))
+            return [dict(r) for r in cur.fetchall()]
+
+    # ──────────────────────────────────────────────
+    # Snapshot writer (Windows-only path walk)
+    # ──────────────────────────────────────────────
+
+    def snapshot_source(self, source_id: int, scan_id: int,
+                        max_files: Optional[int] = None) -> dict:
+        """Walk ``scanned_files`` for the scan, persist DACLs.
+
+        Heavy operation — emits a progress log every 1000 files. Per-file
+        ``GetFileSecurity`` failures are tallied in the ``errors`` count
+        and logged at DEBUG. Returns
+        ``{scanned, errors, elapsed_seconds, written}``.
+        """
+        if not self.is_supported():
+            raise NotImplementedError("AclAnalyzer.snapshot_source requires Windows + pywin32")
+
+        started = time.time()
+        scanned = 0
+        errors = 0
+        written = 0
+        batch: list[tuple] = []
+
+        with self.db.get_cursor() as cur:
+            cur.execute(
+                "SELECT file_path FROM scanned_files WHERE source_id=? AND scan_id=?",
+                (int(source_id), int(scan_id)),
+            )
+            rows = cur.fetchall()
+
+        paths = [r["file_path"] for r in rows]
+        if max_files is not None:
+            paths = paths[: int(max_files)]
+
+        for path in paths:
+            scanned += 1
+            try:
+                acl = self.get_effective_acl(path)
+            except Exception as e:
+                errors += 1
+                logger.debug("ACL read failed for %s: %s", path, e)
+                continue
+
+            for entry in acl.get("entries", []):
+                batch.append((
+                    int(scan_id),
+                    path,
+                    entry["trustee_sid"],
+                    entry.get("trustee_name"),
+                    int(entry["mask"]),
+                    entry.get("permission_name"),
+                    1 if entry.get("is_inherited") else 0,
+                    entry.get("ace_type"),
+                ))
+                if len(batch) >= _INSERT_BATCH:
+                    written += self._flush_batch(batch)
+                    batch = []
+
+            if scanned % 1000 == 0:
+                logger.info(
+                    "ACL snapshot progress: scanned=%d errors=%d written=%d",
+                    scanned, errors, written,
+                )
+
+        if batch:
+            written += self._flush_batch(batch)
+
+        elapsed = time.time() - started
+        logger.info(
+            "ACL snapshot done: scanned=%d errors=%d written=%d in %.1fs",
+            scanned, errors, written, elapsed,
+        )
+        return {
+            "scanned": scanned,
+            "errors": errors,
+            "written": written,
+            "elapsed_seconds": round(elapsed, 3),
+        }
+
+    # ──────────────────────────────────────────────
+    # Internals
+    # ──────────────────────────────────────────────
+
+    def _flush_batch(self, batch: list[tuple]) -> int:
+        with self.db.get_cursor() as cur:
+            cur.executemany(
+                """
+                INSERT INTO file_acl_snapshots (
+                    scan_id, file_path, trustee_sid, trustee_name,
+                    permissions_mask, permission_name, is_inherited, ace_type
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                batch,
+            )
+            return cur.rowcount or len(batch)
+
+    def _mask_to_name(self, mask: int) -> str:
+        """Resolve an access mask to a friendly bundle name.
+
+        Exact match wins; anything else falls through to ``Custom (0x..)``
+        so the operator still sees the raw bits without learning the
+        layout. Matches are *exact* on purpose — fuzzy matching produces
+        misleading labels (e.g. Modify+Delete looks like FullControl).
+        """
+        try:
+            mask_i = int(mask)
+        except Exception:
+            return f"Custom ({mask!r})"
+        name = self.PERMISSION_MASK_NAMES.get(mask_i)
+        if name:
+            return name
+        return f"Custom (0x{mask_i:08X})"
+
+    def _sid_to_name(self, sid) -> Optional[str]:
+        """Resolve a SID -> ``DOMAIN\\Name``. Falls back to the string
+        SID on failure. Best-effort only; never raises.
+        """
+        if sid is None:
+            return None
+        try:
+            import win32security  # type: ignore
+            name, domain, _typ = win32security.LookupAccountSid(None, sid)
+            if domain:
+                return f"{domain}\\{name}"
+            return name
+        except Exception:
+            try:
+                import win32security  # type: ignore
+                return str(win32security.ConvertSidToStringSid(sid))
+            except Exception:
+                return str(sid)

--- a/src/storage/database.py
+++ b/src/storage/database.py
@@ -598,6 +598,28 @@ class Database:
             "ON ransomware_alerts(triggered_at DESC)"
         )
 
+        # NTFS ACL snapshots (#49). Per-file DACL rows captured during a
+        # scan; one row per ACE so the dashboard can answer "where does
+        # this trustee have access?" and "which trustees are
+        # over-permissioned?" without re-walking the filesystem.
+        cur.execute("""
+            CREATE TABLE IF NOT EXISTS file_acl_snapshots (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                scan_id INTEGER REFERENCES scan_runs(id) ON DELETE CASCADE,
+                file_path TEXT NOT NULL,
+                trustee_sid TEXT NOT NULL,
+                trustee_name TEXT,
+                permissions_mask INTEGER,
+                permission_name TEXT,
+                is_inherited INTEGER DEFAULT 0,
+                ace_type TEXT,
+                recorded_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+            )
+        """)
+        cur.execute("CREATE INDEX IF NOT EXISTS idx_acl_path ON file_acl_snapshots(file_path)")
+        cur.execute("CREATE INDEX IF NOT EXISTS idx_acl_trustee ON file_acl_snapshots(trustee_sid)")
+        cur.execute("CREATE INDEX IF NOT EXISTS idx_acl_scan ON file_acl_snapshots(scan_id)")
+
         # FTS5 full-text search (arsivlenmis dosyalar icin)
         cur.execute("""
             CREATE VIRTUAL TABLE IF NOT EXISTS archived_files_fts USING fts5(

--- a/tests/test_acl_analyzer.py
+++ b/tests/test_acl_analyzer.py
@@ -1,0 +1,259 @@
+"""Tests for issue #49: NTFS ACL / effective-permissions analyzer.
+
+Designed to run on Linux. Anything that requires a real Windows ACL
+read is gated behind ``sys.platform == 'win32'``; the rest exercises the
+DB-backed queries against synthetic ``file_acl_snapshots`` rows in a tmp
+SQLite, plus pure-Python helpers (``_mask_to_name``, ``is_supported``).
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+import pytest
+
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if REPO_ROOT not in sys.path:
+    sys.path.insert(0, REPO_ROOT)
+
+from src.security.acl_analyzer import AclAnalyzer  # noqa: E402
+from src.storage.database import Database  # noqa: E402
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Fixtures
+# ──────────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def analyzer(tmp_path):
+    db_path = tmp_path / "acl.db"
+    db = Database({"path": str(db_path)})
+    db.connect()
+    # Seed scan_runs (1, 2) so the file_acl_snapshots FK to scan_runs is
+    # satisfied. file_acl_snapshots.scan_id REFERENCES scan_runs(id).
+    with db.get_cursor() as cur:
+        cur.execute("INSERT INTO sources (name, unc_path) VALUES ('t', '/t')")
+        for _ in range(2):
+            cur.execute("INSERT INTO scan_runs (source_id) VALUES (1)")
+    cfg = {
+        "security": {
+            "acl_analyzer": {
+                "enabled": True,
+                "snapshot_during_scan": False,
+                "sprawl_threshold_mask": 0x001301BF,
+            }
+        }
+    }
+    return AclAnalyzer(db, cfg), db
+
+
+def _insert_snapshot(db, **kwargs):
+    """Insert one synthetic file_acl_snapshots row with sane defaults."""
+    row = {
+        "scan_id": 1,
+        "file_path": "/share/foo.txt",
+        "trustee_sid": "S-1-1-0",  # Everyone
+        "trustee_name": "Everyone",
+        "permissions_mask": 0x001F01FF,  # FullControl
+        "permission_name": "FullControl",
+        "is_inherited": 0,
+        "ace_type": "ALLOW",
+    }
+    row.update(kwargs)
+    with db.get_cursor() as cur:
+        cur.execute(
+            """INSERT INTO file_acl_snapshots
+               (scan_id, file_path, trustee_sid, trustee_name,
+                permissions_mask, permission_name, is_inherited, ace_type)
+               VALUES (?,?,?,?,?,?,?,?)""",
+            (
+                row["scan_id"], row["file_path"], row["trustee_sid"],
+                row["trustee_name"], row["permissions_mask"],
+                row["permission_name"], row["is_inherited"], row["ace_type"],
+            ),
+        )
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Tests
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_is_supported_false_on_linux(analyzer):
+    """On non-Windows hosts the analyzer must self-identify as unsupported."""
+    a, _db = analyzer
+    if sys.platform == "win32":
+        pytest.skip("Linux-only assertion")
+    assert a.is_supported() is False
+
+
+def test_mask_to_name_resolves_known_bundles(analyzer):
+    a, _ = analyzer
+    assert a._mask_to_name(0x001F01FF) == "FullControl"
+    assert a._mask_to_name(0x001301BF) == "Modify"
+    assert a._mask_to_name(0x001200A9) == "Read+Execute"
+    assert a._mask_to_name(0x00120089) == "Read"
+    assert a._mask_to_name(0x00120116) == "Write"
+
+
+def test_mask_to_name_falls_back_to_custom(analyzer):
+    a, _ = analyzer
+    out = a._mask_to_name(0xCAFEBABE)
+    assert out.startswith("Custom (0x")
+    # Hex must round-trip in upper-case 8 chars.
+    assert "CAFEBABE" in out
+
+
+def test_mask_to_name_handles_garbage(analyzer):
+    a, _ = analyzer
+    assert a._mask_to_name("not a mask").startswith("Custom (")
+
+
+def test_get_effective_acl_raises_on_linux(analyzer, tmp_path):
+    a, _ = analyzer
+    if sys.platform == "win32":
+        pytest.skip("Linux-only assertion: would actually read an ACL on Windows")
+    with pytest.raises(NotImplementedError):
+        a.get_effective_acl(str(tmp_path))
+
+
+def test_snapshot_source_raises_on_linux(analyzer):
+    a, _ = analyzer
+    if sys.platform == "win32":
+        pytest.skip("Linux-only assertion")
+    with pytest.raises(NotImplementedError):
+        a.snapshot_source(source_id=1, scan_id=1)
+
+
+def test_detect_sprawl_groups_by_trustee(analyzer):
+    """Sprawl picks up the Everyone-grants-Modify+ pattern."""
+    a, db = analyzer
+    # Everyone with FullControl on three files (severity well above Modify).
+    for path in ("/share/a", "/share/b", "/share/c"):
+        _insert_snapshot(db, file_path=path, trustee_sid="S-1-1-0",
+                         trustee_name="Everyone",
+                         permissions_mask=0x001F01FF,
+                         permission_name="FullControl")
+    # Domain Users with Modify on two files.
+    for path in ("/share/x", "/share/y"):
+        _insert_snapshot(db, file_path=path,
+                         trustee_sid="S-1-5-21-DU",
+                         trustee_name="DOMAIN\\Domain Users",
+                         permissions_mask=0x001301BF,
+                         permission_name="Modify")
+    # One Read-only ACE — must NOT show up at threshold=Modify.
+    _insert_snapshot(db, file_path="/share/readonly", trustee_sid="S-1-1-0",
+                     permissions_mask=0x00120089, permission_name="Read")
+    # One DENY entry — DENY doesn't grant access, must be excluded.
+    _insert_snapshot(db, file_path="/share/denied", trustee_sid="S-1-1-0",
+                     permissions_mask=0x001F01FF,
+                     permission_name="FullControl",
+                     ace_type="DENY")
+
+    out = a.detect_sprawl()
+    assert isinstance(out, list)
+    # Two distinct trustees above threshold.
+    sids = {row["trustee_sid"] for row in out}
+    assert "S-1-1-0" in sids
+    assert "S-1-5-21-DU" in sids
+
+    by_sid = {row["trustee_sid"]: row for row in out}
+    # Everyone has 3 distinct ALLOW paths above threshold.
+    assert by_sid["S-1-1-0"]["file_count"] == 3
+    # Domain Users has 2.
+    assert by_sid["S-1-5-21-DU"]["file_count"] == 2
+    # Order is by file_count DESC.
+    assert out[0]["trustee_sid"] == "S-1-1-0"
+
+
+def test_detect_sprawl_filters_by_scan_id(analyzer):
+    a, db = analyzer
+    _insert_snapshot(db, scan_id=1, file_path="/share/keep",
+                     trustee_sid="S-1-1-0", trustee_name="Everyone")
+    _insert_snapshot(db, scan_id=2, file_path="/share/skip",
+                     trustee_sid="S-1-1-0", trustee_name="Everyone")
+    out = a.detect_sprawl(scan_id=1)
+    assert len(out) == 1
+    assert out[0]["file_count"] == 1
+
+
+def test_detect_sprawl_respects_threshold(analyzer):
+    """Bumping the threshold above FullControl removes everything."""
+    a, db = analyzer
+    _insert_snapshot(db, file_path="/share/foo")
+    out = a.detect_sprawl(severity_threshold=0x7FFFFFFF)
+    assert out == []
+
+
+def test_find_paths_for_trustee_returns_only_matching_sid(analyzer):
+    a, db = analyzer
+    _insert_snapshot(db, file_path="/a", trustee_sid="S-1-1-0",
+                     trustee_name="Everyone")
+    _insert_snapshot(db, file_path="/b", trustee_sid="S-1-1-0",
+                     trustee_name="Everyone",
+                     permissions_mask=0x001301BF, permission_name="Modify")
+    _insert_snapshot(db, file_path="/other", trustee_sid="S-1-5-32-544",
+                     trustee_name="Administrators")
+
+    out = a.find_paths_for_trustee("S-1-1-0")
+    paths = sorted(r["file_path"] for r in out)
+    assert paths == ["/a", "/b"]
+    # Permission_name carried through.
+    perms = {r["file_path"]: r["permission_name"] for r in out}
+    assert perms["/a"] == "FullControl"
+    assert perms["/b"] == "Modify"
+
+
+def test_find_paths_for_trustee_skips_deny_aces(analyzer):
+    a, db = analyzer
+    _insert_snapshot(db, file_path="/blocked", trustee_sid="S-1-1-0",
+                     ace_type="DENY")
+    out = a.find_paths_for_trustee("S-1-1-0")
+    assert out == []
+
+
+def test_find_paths_for_trustee_dedupes_per_path(analyzer):
+    """Re-snapshotting the same path must not double-count."""
+    a, db = analyzer
+    # Two snapshots of the same path/trustee — only the most recent counts.
+    _insert_snapshot(db, scan_id=1, file_path="/p", trustee_sid="S-1-1-0",
+                     permissions_mask=0x00120089, permission_name="Read")
+    _insert_snapshot(db, scan_id=2, file_path="/p", trustee_sid="S-1-1-0",
+                     permissions_mask=0x001F01FF, permission_name="FullControl")
+    out = a.find_paths_for_trustee("S-1-1-0")
+    assert len(out) == 1
+    # Latest mask wins.
+    assert out[0]["permission_name"] == "FullControl"
+
+
+def test_find_paths_for_trustee_limit_caps_results(analyzer):
+    a, db = analyzer
+    for i in range(20):
+        _insert_snapshot(db, file_path=f"/f{i}", trustee_sid="S-1-1-0")
+    out = a.find_paths_for_trustee("S-1-1-0", limit=5)
+    assert len(out) == 5
+
+
+def test_table_and_indexes_exist(analyzer):
+    """Schema migration ran — table + indexes are present."""
+    _, db = analyzer
+    with db.get_cursor() as cur:
+        cur.execute("SELECT name FROM sqlite_master "
+                    "WHERE type='table' AND name='file_acl_snapshots'")
+        assert cur.fetchone() is not None
+        cur.execute("SELECT name FROM sqlite_master "
+                    "WHERE type='index' AND name='idx_acl_trustee'")
+        assert cur.fetchone() is not None
+
+
+def test_config_defaults_when_block_missing(tmp_path):
+    """Constructor must tolerate a config dict with no 'security' key."""
+    db_path = tmp_path / "acl.db"
+    db = Database({"path": str(db_path)})
+    db.connect()
+    a = AclAnalyzer(db, {})
+    assert a.enabled is True
+    assert a.snapshot_during_scan is False
+    assert a.sprawl_threshold_mask == 0x001301BF


### PR DESCRIPTION
## Summary
Closes #49. NTFS ACL / effective-permissions analyzer using `pywin32` (lazily loaded — Linux-safe). Implemented by parallel subagent; rebased after PR #51 + #52 landed.

## Changes
- **New** `src/security/acl_analyzer.py` (~300 lines) — `AclAnalyzer` class
- **New** `tests/test_acl_analyzer.py` — 15 Linux-runnable cases
- `src/storage/database.py` — `file_acl_snapshots` table + 3 indices in `_create_tables`
- `src/dashboard/api.py` — 4 endpoints + lazy `_get_acl_analyzer()`

## API methods
- `is_supported()` — pywin32 capability probe (False on Linux)
- `get_effective_acl(path)` — live DACL read (Windows-only)
- `find_paths_for_trustee(sid, limit=100)` — latest-snapshot per (path, sid), ALLOW only
- `detect_sprawl(scan_id?, severity_threshold=Modify+)` — top 50 trustees by file_count
- `snapshot_source(source_id, scan_id, max_files?)` — walks scanned_files, batch inserts (500/batch), progress log every 1000 files

## API endpoints
- `GET /api/security/acl?path=<path>`
- `GET /api/security/acl/trustee/{sid}/paths?limit=100`
- `GET /api/security/acl/sprawl?scan_id=<n>&severity_threshold=<int>`
- `POST /api/security/acl/scan/{source_id}?max_files=<n>` — sync via `run_in_executor`

## Test plan
- [x] `python -m compileall -q src/` clean
- [x] `pytest tests/test_acl_analyzer.py -v` → 15/15 pass
- [x] Full suite: 66 passed, 5 skipped
- [ ] Real Windows admin run with NTFS share

## Notes
- Scanner wiring (auto-snapshot during scan) intentionally deferred — separate follow-up issue.
- `config.yaml` was not modified because the agent saw conflict markers in its worktree (now fixed via PR #52). Analyzer reads config defensively with all defaults wired so it works without a config block.

---
_Generated by [Claude Code](https://claude.ai/code/session_01A1UzS1A4DZNk1akoP4uhZ7)_