### PR TITLE
ci: YAML smoke check + conflict-marker guard (prevents PR #52 regression)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,19 @@ jobs:
         run: |
           python -m compileall -q src/ main.py dev_server.py
 
+      - name: YAML config smoke check (catch unresolved merge markers)
+        run: |
+          python -c "import yaml; yaml.safe_load(open('config.yaml'))"
+          # Bare grep guard for stray conflict markers in any tracked text file
+          if grep -RnE '^(<<<<<<< |======= ?$|>>>>>>> )' \
+              --include='*.py' --include='*.yml' --include='*.yaml' \
+              --include='*.md' --include='*.html' --include='*.cmd' \
+              --include='*.ps1' --include='*.txt' \
+              --exclude-dir='.git' --exclude-dir='node_modules' . ; then
+            echo "::error::Unresolved Git conflict markers detected"
+            exit 1
+          fi
+
       - name: Import-level smoke test for cross-platform modules
         run: |
           # AnalyticsEngine and Database models import cleanly on Linux


### PR DESCRIPTION
## Summary
Follow-up to PR #52 (which fixed unresolved Git conflict markers in `config.yaml`). Adds two cheap checks to the existing CI `syntax` job so the same bug can't ship again.

## Checks added
1. `python -c "import yaml; yaml.safe_load(open('config.yaml'))"` — fails the build if config.yaml has structural damage.
2. Grep across tracked text files (`.py/.yml/.yaml/.md/.html/.cmd/.ps1/.txt`) for canonical Git conflict-marker prefixes. Exits 1 with `::error::` annotation if any found. Excludes `.git` and `node_modules`.

## Test plan
- [x] Workflow syntax validates locally
- [ ] CI run on this PR — both checks pass on a clean tree
- [ ] (Negative test) inject a `<<<<<<<` line in a draft PR — verify CI fails

Adds <5s to the existing job. No new dependencies.

---
_Generated by [Claude Code](https://claude.ai/code/session_01A1UzS1A4DZNk1akoP4uhZ7)_