### PR TITLE
PowerShell module: Import-Module FileActivity (#57)

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,50 @@ $f="$env:TEMP\fa.ps1"; (New-Object Net.WebClient).DownloadFile("https://raw.gith
 | GET | `/api/users/overview` | User activity overview |
 | GET | `/api/anomalies` | Anomaly alerts |
 
+## PowerShell Module
+
+A PowerShell module ships in `powershell/FileActivity/` and is installed
+automatically by `setup-source.ps1` to `C:\FileActivity\powershell\` (added
+to the user PSModulePath). Cmdlets return PowerShell objects so they pipe
+naturally.
+
+```powershell
+# After install, in a new PowerShell session:
+Import-Module FileActivity
+
+# Latest scan summary, big-file duplicates:
+Get-FileActivitySummary -SourceId 1
+Get-FileActivityDuplicates -SourceId 1 |
+    Where-Object FileSize -gt 1GB |
+    Sort-Object WasteSize -Descending |
+    Select-Object -First 10
+
+# Ransomware alert dashboard for ops:
+Get-FileActivityRansomware | Where-Object Severity -eq 'critical'
+
+# Verify audit chain integrity (compliance reports):
+$result = Test-FileActivityAuditChain
+if (-not $result.Verified) {
+    Write-Warning "AUDIT CHAIN BROKEN at seq $($result.BrokenAtSeq)"
+}
+```
+
+Cmdlets:
+
+| Cmdlet | Endpoint |
+|--------|----------|
+| `Get-FileActivityScan` | `GET /api/sources/{id}/scans` |
+| `Start-FileActivityScan` | `POST /api/scan/{id}` |
+| `Get-FileActivitySummary` | `GET /api/overview/{id}` |
+| `Get-FileActivityDuplicates` | `GET /api/reports/duplicates/{id}` |
+| `Get-FileActivityRansomware` | `GET /api/security/ransomware/alerts` |
+| `Invoke-FileActivityArchive` | `POST /api/archive/run` (or `dry-run`) |
+| `Get-FileActivityAudit` | `GET /api/audit/events` |
+| `Test-FileActivityAuditChain` | `GET /api/audit/verify` |
+
+Override the dashboard URL with `Set-FileActivityBaseUrl 'http://other-host:8085'`
+or by setting `$env:FILEACTIVITY_BASE_URL` before importing the module.
+
 ## Technology Stack
 
 | Layer | Technology |

--- a/deploy/setup-source.ps1
+++ b/deploy/setup-source.ps1
@@ -285,6 +285,27 @@ Set-Content "$InstallDir\update.cmd" $updateCmd
 
 Write-Host "  [OK] fa.cmd, start_dashboard.cmd, update.cmd" -ForegroundColor Green
 
+# --- 5b. PowerShell module (Import-Module FileActivity) ---
+$psModuleSrc  = Join-Path $srcRoot 'powershell\FileActivity'
+$psModuleRoot = Join-Path $InstallDir 'powershell'
+$psModuleDest = Join-Path $psModuleRoot 'FileActivity'
+if (Test-Path $psModuleSrc) {
+    if (-not (Test-Path $psModuleRoot)) {
+        New-Item -Path $psModuleRoot -ItemType Directory -Force | Out-Null
+    }
+    if (Test-Path $psModuleDest) { Remove-Item $psModuleDest -Recurse -Force }
+    Copy-Item -Path $psModuleSrc -Destination $psModuleDest -Recurse -Force
+
+    # Append to PSModulePath (User scope) if not already present
+    $userPSModule = [Environment]::GetEnvironmentVariable('PSModulePath', 'User')
+    if (-not $userPSModule) { $userPSModule = '' }
+    if ($userPSModule -notlike "*$psModuleRoot*") {
+        $newPath = if ($userPSModule) { "$userPSModule;$psModuleRoot" } else { $psModuleRoot }
+        [Environment]::SetEnvironmentVariable('PSModulePath', $newPath, 'User')
+    }
+    Write-Host "  [OK] PowerShell module installed (Import-Module FileActivity)" -ForegroundColor Green
+}
+
 # --- 6. Firewall ---
 Write-Host "[6/6] Firewall kurali (port $DashPort)..." -ForegroundColor Yellow
 try {

--- a/powershell/FileActivity/FileActivity.psd1
+++ b/powershell/FileActivity/FileActivity.psd1
@@ -1,0 +1,23 @@
+@{
+    RootModule = 'FileActivity.psm1'
+    ModuleVersion = '1.0.0'
+    GUID = 'a1b2c3d4-e5f6-7890-abcd-ef1234567890'
+    Author = 'deepdarbe'
+    Description = 'PowerShell wrapper for FILE ACTIVITY REST API.'
+    PowerShellVersion = '5.1'
+    FunctionsToExport = @(
+        'Get-FileActivityScan',
+        'Start-FileActivityScan',
+        'Get-FileActivitySummary',
+        'Get-FileActivityDuplicates',
+        'Get-FileActivityRansomware',
+        'Invoke-FileActivityArchive',
+        'Get-FileActivityAudit',
+        'Test-FileActivityAuditChain',
+        'Set-FileActivityBaseUrl',
+        'Get-FileActivityBaseUrl'
+    )
+    CmdletsToExport = @()
+    VariablesToExport = @()
+    AliasesToExport = @()
+}

--- a/powershell/FileActivity/FileActivity.psm1
+++ b/powershell/FileActivity/FileActivity.psm1
@@ -1,0 +1,55 @@
+# FileActivity PowerShell module
+# Wraps the FILE ACTIVITY dashboard REST API (default http://localhost:8085)
+# so that pipeline-friendly PSCustomObject results can be composed naturally.
+
+# Module-scoped base URL with environment variable fallback.
+$script:BaseUrl = if ($env:FILEACTIVITY_BASE_URL) {
+    $env:FILEACTIVITY_BASE_URL.TrimEnd('/')
+} else {
+    'http://localhost:8085'
+}
+
+# Dot-source every Functions/*.ps1 so each cmdlet lives in its own file.
+$functionFolder = Join-Path $PSScriptRoot 'Functions'
+if (Test-Path $functionFolder) {
+    Get-ChildItem -Path $functionFolder -Filter '*.ps1' | ForEach-Object {
+        . $_.FullName
+    }
+}
+
+function Set-FileActivityBaseUrl {
+    <#
+    .SYNOPSIS
+        Override the dashboard base URL used by FileActivity cmdlets.
+
+    .DESCRIPTION
+        Useful when targeting a remote FILE ACTIVITY dashboard or a non-default
+        port. The new value persists for the lifetime of the PowerShell session.
+
+    .PARAMETER Url
+        Full URL including scheme and port (e.g. http://other-host:8085).
+
+    .EXAMPLE
+        Set-FileActivityBaseUrl 'http://files01.lan:8085'
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string]$Url
+    )
+    $script:BaseUrl = $Url.TrimEnd('/')
+}
+
+function Get-FileActivityBaseUrl {
+    <#
+    .SYNOPSIS
+        Return the dashboard base URL currently used by FileActivity cmdlets.
+
+    .EXAMPLE
+        Get-FileActivityBaseUrl
+    #>
+    [CmdletBinding()]
+    param()
+    return $script:BaseUrl
+}
+
+Export-ModuleMember -Function * -Variable @() -Cmdlet @()

--- a/powershell/FileActivity/Functions/Get-FileActivityAudit.ps1
+++ b/powershell/FileActivity/Functions/Get-FileActivityAudit.ps1
@@ -1,0 +1,70 @@
+function Get-FileActivityAudit {
+    <#
+    .SYNOPSIS
+        Retrieve audit events from the tamper-evident audit log.
+
+    .DESCRIPTION
+        Returns audit events (file operations, archive ops, scans, ransomware
+        actions) over the requested window. Wraps GET /api/audit/events.
+
+    .PARAMETER SourceId
+        Optional source filter.
+
+    .PARAMETER EventType
+        Optional event type filter (e.g. archive, restore, scan, alert).
+
+    .PARAMETER Username
+        Optional user filter.
+
+    .PARAMETER Days
+        Lookback window in days (1-365). Default 7.
+
+    .PARAMETER Page
+        Page index (1-10000). Default 1.
+
+    .EXAMPLE
+        Get-FileActivityAudit -EventType archive -Days 30
+
+    .OUTPUTS
+        PSCustomObject with: Id, Seq, Timestamp, EventType, SourceId, Username,
+        FilePath, Details
+    #>
+    [CmdletBinding()]
+    param(
+        [int]$SourceId,
+        [string]$EventType,
+        [string]$Username,
+        [int]$Days = 7,
+        [int]$Page = 1
+    )
+    $params = @("days=$Days", "page=$Page")
+    if ($PSBoundParameters.ContainsKey('SourceId')) { $params += "source_id=$SourceId" }
+    if ($EventType) { $params += "event_type=$([uri]::EscapeDataString($EventType))" }
+    if ($Username)  { $params += "username=$([uri]::EscapeDataString($Username))" }
+    $url = "$script:BaseUrl/api/audit/events?" + ($params -join '&')
+    try {
+        $r = Invoke-RestMethod -Uri $url -Method GET -ErrorAction Stop
+        # API returns either a list or a paged object {events, total, page,...}
+        $events = if ($r -is [System.Collections.IEnumerable] -and -not ($r -is [string])) {
+            $r
+        } elseif ($r.events) {
+            $r.events
+        } else {
+            @($r)
+        }
+        foreach ($e in $events) {
+            [PSCustomObject]@{
+                Id        = $e.id
+                Seq       = $e.seq
+                Timestamp = $e.timestamp
+                EventType = $e.event_type
+                SourceId  = $e.source_id
+                Username  = $e.username
+                FilePath  = $e.file_path
+                Details   = $e.details
+            }
+        }
+    } catch {
+        Write-Error "Get-FileActivityAudit failed: $_"
+    }
+}

--- a/powershell/FileActivity/Functions/Get-FileActivityDuplicates.ps1
+++ b/powershell/FileActivity/Functions/Get-FileActivityDuplicates.ps1
@@ -1,0 +1,57 @@
+function Get-FileActivityDuplicates {
+    <#
+    .SYNOPSIS
+        Retrieve duplicate file groups for a source.
+
+    .DESCRIPTION
+        Returns groups of duplicate files (same content hash) with the wasted
+        bytes per group. Wraps GET /api/reports/duplicates/{id}.
+
+    .PARAMETER SourceId
+        Numeric source ID.
+
+    .PARAMETER Page
+        1-based page index. Default 1.
+
+    .PARAMETER PageSize
+        Rows per page (1-500). Default 50.
+
+    .PARAMETER MinSize
+        Minimum file size in bytes to include. Default 0 (no filter).
+
+    .EXAMPLE
+        Get-FileActivityDuplicates -SourceId 1 |
+            Where-Object FileSize -gt 1GB |
+            Sort-Object WasteSize -Descending |
+            Select-Object -First 10
+
+    .OUTPUTS
+        PSCustomObject (one per duplicate group) with: ContentHash, FileSize,
+        FileSizeFormatted, Count, WasteSize, WasteSizeFormatted, Files
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][int]$SourceId,
+        [int]$Page = 1,
+        [int]$PageSize = 50,
+        [long]$MinSize = 0
+    )
+    $url = "$script:BaseUrl/api/reports/duplicates/$SourceId" +
+           "?page=$Page&page_size=$PageSize&min_size=$MinSize"
+    try {
+        $r = Invoke-RestMethod -Uri $url -Method GET -ErrorAction Stop
+        foreach ($g in $r.groups) {
+            [PSCustomObject]@{
+                ContentHash        = $g.content_hash
+                FileSize           = $g.file_size
+                FileSizeFormatted  = $g.file_size_formatted
+                Count              = $g.count
+                WasteSize          = $g.waste_size
+                WasteSizeFormatted = $g.waste_size_formatted
+                Files              = $g.files
+            }
+        }
+    } catch {
+        Write-Error "Get-FileActivityDuplicates failed: $_"
+    }
+}

--- a/powershell/FileActivity/Functions/Get-FileActivityRansomware.ps1
+++ b/powershell/FileActivity/Functions/Get-FileActivityRansomware.ps1
@@ -1,0 +1,43 @@
+function Get-FileActivityRansomware {
+    <#
+    .SYNOPSIS
+        Retrieve recent ransomware detection alerts.
+
+    .DESCRIPTION
+        Returns ransomware alerts raised in the last N minutes. Wraps
+        GET /api/security/ransomware/alerts.
+
+    .PARAMETER SinceMinutes
+        Lookback window in minutes (1-10080). Default 60.
+
+    .EXAMPLE
+        Get-FileActivityRansomware | Where-Object Severity -eq 'critical'
+
+    .OUTPUTS
+        PSCustomObject with: Id, SourceId, RuleName, Severity, Username,
+        DetectedAt, Details, AcknowledgedAt, AcknowledgedBy
+    #>
+    [CmdletBinding()]
+    param(
+        [int]$SinceMinutes = 60
+    )
+    $url = "$script:BaseUrl/api/security/ransomware/alerts?since_minutes=$SinceMinutes"
+    try {
+        $response = Invoke-RestMethod -Uri $url -Method GET -ErrorAction Stop
+        $response | ForEach-Object {
+            [PSCustomObject]@{
+                Id              = $_.id
+                SourceId        = $_.source_id
+                RuleName        = $_.rule_name
+                Severity        = $_.severity
+                Username        = $_.username
+                DetectedAt      = $_.detected_at
+                Details         = $_.details
+                AcknowledgedAt  = $_.acknowledged_at
+                AcknowledgedBy  = $_.acknowledged_by
+            }
+        }
+    } catch {
+        Write-Error "Get-FileActivityRansomware failed: $_"
+    }
+}

--- a/powershell/FileActivity/Functions/Get-FileActivityScan.ps1
+++ b/powershell/FileActivity/Functions/Get-FileActivityScan.ps1
@@ -1,0 +1,46 @@
+function Get-FileActivityScan {
+    <#
+    .SYNOPSIS
+        Retrieve scan history for a source.
+
+    .DESCRIPTION
+        Returns scan_run records for the given source ID, newest first.
+        Wraps GET /api/sources/{id}/scans.
+
+    .PARAMETER SourceId
+        Numeric source ID. Use the sources list from the dashboard to discover IDs.
+
+    .PARAMETER Limit
+        Max number of scans to return. Default 20.
+
+    .EXAMPLE
+        Get-FileActivityScan -SourceId 1 | Where-Object Status -eq 'completed'
+
+    .OUTPUTS
+        PSCustomObject with: Id, SourceId, StartedAt, CompletedAt, TotalFiles,
+        TotalSize, Errors, Status
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][int]$SourceId,
+        [int]$Limit = 20
+    )
+    $url = "$script:BaseUrl/api/sources/$SourceId/scans?limit=$Limit"
+    try {
+        $response = Invoke-RestMethod -Uri $url -Method GET -ErrorAction Stop
+        $response | ForEach-Object {
+            [PSCustomObject]@{
+                Id          = $_.id
+                SourceId    = $_.source_id
+                StartedAt   = $_.started_at
+                CompletedAt = $_.completed_at
+                TotalFiles  = $_.total_files
+                TotalSize   = $_.total_size
+                Errors      = $_.errors
+                Status      = $_.status
+            }
+        }
+    } catch {
+        Write-Error "Get-FileActivityScan failed: $_"
+    }
+}

--- a/powershell/FileActivity/Functions/Get-FileActivitySummary.ps1
+++ b/powershell/FileActivity/Functions/Get-FileActivitySummary.ps1
@@ -1,0 +1,47 @@
+function Get-FileActivitySummary {
+    <#
+    .SYNOPSIS
+        Retrieve the latest scan summary (KPIs) for a source.
+
+    .DESCRIPTION
+        Returns the precomputed Instant Overview KPIs for the most recent
+        completed scan. Wraps GET /api/overview/{id}.
+
+    .PARAMETER SourceId
+        Numeric source ID.
+
+    .EXAMPLE
+        Get-FileActivitySummary -SourceId 1
+
+    .OUTPUTS
+        PSCustomObject with: SourceId, ScanId, HasData, TotalFiles, TotalSize,
+        TotalSizeFormatted, StaleSize, LargeSize, DuplicateWasteSize,
+        TopExtensions, TopOwners
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][int]$SourceId
+    )
+    $url = "$script:BaseUrl/api/overview/$SourceId"
+    try {
+        $r = Invoke-RestMethod -Uri $url -Method GET -ErrorAction Stop
+        [PSCustomObject]@{
+            SourceId             = $SourceId
+            ScanId               = $r.scan_id
+            HasData              = [bool]$r.has_data
+            TotalFiles           = $r.total_files
+            TotalSize            = $r.total_size
+            TotalSizeFormatted   = $r.total_size_formatted
+            StaleSize            = $r.stale_size
+            StaleSizeFormatted   = $r.stale_size_formatted
+            LargeSize            = $r.large_size
+            LargeSizeFormatted   = $r.large_size_formatted
+            DuplicateWasteSize   = $r.duplicate_waste_size
+            DuplicateWasteFormatted = $r.duplicate_waste_formatted
+            TopExtensions        = $r.top_extensions
+            TopOwners            = $r.top_owners
+        }
+    } catch {
+        Write-Error "Get-FileActivitySummary failed: $_"
+    }
+}

--- a/powershell/FileActivity/Functions/Invoke-FileActivityArchive.ps1
+++ b/powershell/FileActivity/Functions/Invoke-FileActivityArchive.ps1
@@ -1,0 +1,51 @@
+function Invoke-FileActivityArchive {
+    <#
+    .SYNOPSIS
+        Trigger an archive run for a source.
+
+    .DESCRIPTION
+        Posts to /api/archive/run to start the copy-verify-delete archive
+        workflow for the supplied source. Use -DryRun to preview without
+        moving anything (calls /api/archive/dry-run instead).
+
+    .PARAMETER SourceId
+        Numeric source ID to archive.
+
+    .PARAMETER DryRun
+        Switch - when present, the call is sent to /api/archive/dry-run so
+        no files are actually moved.
+
+    .EXAMPLE
+        Invoke-FileActivityArchive -SourceId 1 -DryRun
+
+    .OUTPUTS
+        PSCustomObject with: SourceId, OperationId, FilesArchived, BytesArchived,
+        Status, DryRun
+    #>
+    [CmdletBinding(SupportsShouldProcess)]
+    param(
+        [Parameter(Mandatory)][int]$SourceId,
+        [switch]$DryRun
+    )
+    $endpoint = if ($DryRun) { 'dry-run' } else { 'run' }
+    $url = "$script:BaseUrl/api/archive/$endpoint"
+    $body = @{ source_id = $SourceId } | ConvertTo-Json
+    $action = if ($DryRun) { 'Dry-run archive' } else { 'Archive' }
+    if (-not $PSCmdlet.ShouldProcess("source $SourceId", $action)) {
+        return
+    }
+    try {
+        $r = Invoke-RestMethod -Uri $url -Method POST -Body $body `
+                               -ContentType 'application/json' -ErrorAction Stop
+        [PSCustomObject]@{
+            SourceId       = $SourceId
+            OperationId    = $r.operation_id
+            FilesArchived  = $r.files_archived
+            BytesArchived  = $r.bytes_archived
+            Status         = $r.status
+            DryRun         = [bool]$DryRun
+        }
+    } catch {
+        Write-Error "Invoke-FileActivityArchive failed: $_"
+    }
+}

--- a/powershell/FileActivity/Functions/Start-FileActivityScan.ps1
+++ b/powershell/FileActivity/Functions/Start-FileActivityScan.ps1
@@ -1,0 +1,38 @@
+function Start-FileActivityScan {
+    <#
+    .SYNOPSIS
+        Start a new scan for a source.
+
+    .DESCRIPTION
+        Triggers an asynchronous scan on the given source by POSTing to
+        /api/scan/{id}. The dashboard runs the scan in a background thread;
+        poll Get-FileActivityScan to follow progress.
+
+    .PARAMETER SourceId
+        Numeric source ID to scan.
+
+    .EXAMPLE
+        Start-FileActivityScan -SourceId 1
+
+    .OUTPUTS
+        PSCustomObject with: SourceId, Status, Message
+    #>
+    [CmdletBinding(SupportsShouldProcess)]
+    param(
+        [Parameter(Mandatory)][int]$SourceId
+    )
+    $url = "$script:BaseUrl/api/scan/$SourceId"
+    if (-not $PSCmdlet.ShouldProcess("source $SourceId", 'Start scan')) {
+        return
+    }
+    try {
+        $response = Invoke-RestMethod -Uri $url -Method POST -ErrorAction Stop
+        [PSCustomObject]@{
+            SourceId = $SourceId
+            Status   = $response.status
+            Message  = $response.message
+        }
+    } catch {
+        Write-Error "Start-FileActivityScan failed: $_"
+    }
+}

--- a/powershell/FileActivity/Functions/Test-FileActivityAuditChain.ps1
+++ b/powershell/FileActivity/Functions/Test-FileActivityAuditChain.ps1
@@ -1,0 +1,45 @@
+function Test-FileActivityAuditChain {
+    <#
+    .SYNOPSIS
+        Verify the integrity of the tamper-evident audit chain.
+
+    .DESCRIPTION
+        Calls GET /api/audit/verify and projects the result into a flat
+        PSCustomObject so callers can use:
+            if ((Test-FileActivityAuditChain).Verified) { ... }
+
+    .PARAMETER SinceSeq
+        Verify the chain from this sequence number forward. Default 1.
+
+    .PARAMETER EndSeq
+        Optional upper bound sequence number.
+
+    .EXAMPLE
+        $r = Test-FileActivityAuditChain
+        if (-not $r.Verified) { Write-Warning "Chain broken at seq $($r.BrokenAtSeq)" }
+
+    .OUTPUTS
+        PSCustomObject with: Verified (bool), BrokenAtSeq (int|null),
+        BrokenReason (string|null), Total (int)
+    #>
+    [CmdletBinding()]
+    param(
+        [int]$SinceSeq = 1,
+        [int]$EndSeq
+    )
+    $url = "$script:BaseUrl/api/audit/verify?since_seq=$SinceSeq"
+    if ($PSBoundParameters.ContainsKey('EndSeq')) {
+        $url += "&end_seq=$EndSeq"
+    }
+    try {
+        $r = Invoke-RestMethod -Uri $url -Method GET -ErrorAction Stop
+        [PSCustomObject]@{
+            Verified     = [bool]$r.verified
+            BrokenAtSeq  = $r.broken_at
+            BrokenReason = $r.broken_reason
+            Total        = $r.total
+        }
+    } catch {
+        Write-Error "Test-FileActivityAuditChain failed: $_"
+    }
+}

--- a/powershell/Tests/FileActivity.Tests.ps1
+++ b/powershell/Tests/FileActivity.Tests.ps1
@@ -1,0 +1,73 @@
+Describe 'FileActivity Module' {
+    BeforeAll {
+        $modulePath = Join-Path $PSScriptRoot '..' 'FileActivity' 'FileActivity.psd1'
+        Import-Module $modulePath -Force
+    }
+
+    AfterAll {
+        Remove-Module FileActivity -Force -ErrorAction SilentlyContinue
+    }
+
+    It 'Imports cleanly' {
+        Get-Module FileActivity | Should -Not -BeNullOrEmpty
+    }
+
+    It 'Exports expected cmdlets' {
+        $exports = (Get-Module FileActivity).ExportedFunctions.Keys
+        $expected = @(
+            'Get-FileActivityScan',
+            'Start-FileActivityScan',
+            'Get-FileActivitySummary',
+            'Get-FileActivityDuplicates',
+            'Get-FileActivityRansomware',
+            'Invoke-FileActivityArchive',
+            'Get-FileActivityAudit',
+            'Test-FileActivityAuditChain'
+        )
+        foreach ($cmd in $expected) {
+            $exports | Should -Contain $cmd
+        }
+    }
+
+    It 'Exposes Set-FileActivityBaseUrl and Get-FileActivityBaseUrl' {
+        $exports = (Get-Module FileActivity).ExportedFunctions.Keys
+        $exports | Should -Contain 'Set-FileActivityBaseUrl'
+        $exports | Should -Contain 'Get-FileActivityBaseUrl'
+    }
+
+    It 'Defaults base URL to localhost:8085 when env var unset' {
+        # Re-import with env var cleared to assert the documented default.
+        $previous = $env:FILEACTIVITY_BASE_URL
+        try {
+            Remove-Item Env:FILEACTIVITY_BASE_URL -ErrorAction SilentlyContinue
+            $modulePath = Join-Path $PSScriptRoot '..' 'FileActivity' 'FileActivity.psd1'
+            Import-Module $modulePath -Force
+            (Get-FileActivityBaseUrl) | Should -Be 'http://localhost:8085'
+        } finally {
+            if ($null -ne $previous) { $env:FILEACTIVITY_BASE_URL = $previous }
+        }
+    }
+
+    It 'Set-FileActivityBaseUrl updates the module-scoped URL' {
+        Set-FileActivityBaseUrl 'http://example.com:1234'
+        (Get-FileActivityBaseUrl) | Should -Be 'http://example.com:1234'
+    }
+
+    It 'Set-FileActivityBaseUrl trims trailing slashes' {
+        Set-FileActivityBaseUrl 'http://example.com:1234/'
+        (Get-FileActivityBaseUrl) | Should -Be 'http://example.com:1234'
+    }
+
+    It 'Every cmdlet ships comment-based help' {
+        $cmds = @(
+            'Get-FileActivityScan', 'Start-FileActivityScan',
+            'Get-FileActivitySummary', 'Get-FileActivityDuplicates',
+            'Get-FileActivityRansomware', 'Invoke-FileActivityArchive',
+            'Get-FileActivityAudit', 'Test-FileActivityAuditChain'
+        )
+        foreach ($cmd in $cmds) {
+            $help = Get-Help $cmd -ErrorAction SilentlyContinue
+            $help.Synopsis | Should -Not -BeNullOrEmpty
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Closes #57. Implemented by parallel subagent.

PowerShell module wrapping the dashboard REST API. Cmdlets return `PSCustomObject` (PascalCase props) so they pipe naturally. Module installs via `setup-source.ps1`, registered to user `PSModulePath`.

## Cmdlets (10)

| Cmdlet | Endpoint |
|---|---|
| `Get-FileActivityScan` | `GET /api/sources/{id}/scans` |
| `Start-FileActivityScan` | `POST /api/scan/{id}` |
| `Get-FileActivitySummary` | `GET /api/overview/{id}` |
| `Get-FileActivityDuplicates` | `GET /api/reports/duplicates/{id}` |
| `Get-FileActivityRansomware` | `GET /api/security/ransomware/alerts` |
| `Invoke-FileActivityArchive` | `POST /api/archive/run` (`-DryRun`) |
| `Get-FileActivityAudit` | `GET /api/audit/events` |
| `Test-FileActivityAuditChain` | `GET /api/audit/verify` |
| `Set-FileActivityBaseUrl`, `Get-FileActivityBaseUrl` | session helpers |

## Files
- **New** `powershell/FileActivity/{FileActivity.psd1, FileActivity.psm1, Functions/*.ps1}` (8 cmdlets)
- **New** `powershell/Tests/FileActivity.Tests.ps1`
- `deploy/setup-source.ps1` — step 5b copies module to `C:\FileActivity\powershell\` + adds to `PSModulePath`
- `README.md` — new "PowerShell Module" section

## Key implementation
- All cmdlets use `[CmdletBinding()]`, comment-based help, `Invoke-RestMethod`, `try/catch` + `Write-Error`, `PSCustomObject` PascalCase projection
- `Start-FileActivityScan` and `Invoke-FileActivityArchive` use `SupportsShouldProcess` (`-WhatIf`/`-Confirm`)
- `$script:BaseUrl` initialised from `$env:FILEACTIVITY_BASE_URL` (default `http://localhost:8085`)
- ASCII-only files (no BOM)

## Test plan
- [x] Pester tests cover clean import, expected exports, base-URL set/get, presence of comment-based help on every cmdlet
- [ ] Live test on Windows: `Import-Module FileActivity; Get-FileActivitySummary -SourceId 1`

## Notes
Subagent flagged that `GET /api/sources/{id}/scans` doesn't exist yet — `Get-FileActivityScan` will surface the API's 404 via `Write-Error` until that endpoint lands. Easy follow-up.

---
_Generated by [Claude Code](https://claude.ai/code/session_01A1UzS1A4DZNk1akoP4uhZ7)_