### PR TITLE
Orphaned-SID report + bulk reassignment (#56)

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -175,6 +175,18 @@ security:
     auto_kill_session: false           # opt-in: SMB oturumunu Close-SmbSession ile sonlandir
     notification_email: ""             # bos degilse bu adrese kritik uyari maili gider
 
+  # Orphaned-SID report + bulk reassignment (#56). Surfaces files whose
+  # owner principal no longer resolves in AD (departed users, deleted
+  # service accounts) and supports bulk re-owner to a manager / archive
+  # account. Reassignment is Windows-only; the report itself works on
+  # any platform. dry_run defaults true on the API; flip
+  # require_dual_approval_for_reassign to enforce a 2-person rule.
+  orphan_sid:
+    enabled: true
+    cache_ttl_minutes: 1440
+    max_unique_sids: 1000
+    require_dual_approval_for_reassign: false
+
 audit:
   # Tamper-evident hash-chained audit log (issue #38).
   # When chain_enabled=true, every audit event written via the

--- a/src/dashboard/api.py
+++ b/src/dashboard/api.py
@@ -2669,6 +2669,130 @@ def create_app(db, config, analytics=None, ad_lookup=None, email_notifier=None):
         return result
 
     # ─────────────────────────────────────────────────────────────────
+    # Orphaned-SID report + bulk reassignment (#56)
+    # ─────────────────────────────────────────────────────────────────
+
+    def _get_orphan_analyzer():
+        existing = getattr(app.state, "orphan_sid_analyzer", None)
+        if existing is not None:
+            return existing
+        from src.security.orphan_sid import OrphanSidAnalyzer
+        analyzer = OrphanSidAnalyzer(db, config, ad_lookup=ad_lookup)
+        app.state.orphan_sid_analyzer = analyzer
+        return analyzer
+
+    @app.get("/api/security/orphan-sids/{source_id}")
+    async def orphan_sids_report(source_id: int,
+                                 max_unique_sids: Optional[int] = None):
+        """Detect orphan owner SIDs in the latest scan for ``source_id``."""
+        analyzer = _get_orphan_analyzer()
+        scan_id = db.get_latest_scan_id(source_id, include_running=False)
+        if not scan_id:
+            raise HTTPException(404, f"No scan_runs found for source {source_id}")
+        cap = max_unique_sids if max_unique_sids is not None else analyzer.max_unique_sids_default
+        result = analyzer.detect_orphans(scan_id, max_unique_sids=int(cap))
+        result["source_id"] = source_id
+        return result
+
+    @app.get("/api/security/orphan-sids/{source_id}/files")
+    async def orphan_sid_files(source_id: int,
+                               sid: str = Query(..., min_length=1),
+                               page: int = Query(1, ge=1),
+                               page_size: int = Query(100, ge=1, le=1000)):
+        analyzer = _get_orphan_analyzer()
+        return analyzer.get_orphan_files(source_id, sid, page=page, page_size=page_size)
+
+    class OrphanReassignRequest(BaseModel):
+        source_id: int
+        sid: str
+        new_owner: str
+        dry_run: bool = True
+        max_files: Optional[int] = None
+
+    @app.post("/api/security/orphan-sids/reassign")
+    async def orphan_sid_reassign(req: OrphanReassignRequest):
+        analyzer = _get_orphan_analyzer()
+        # Honour the opt-in dual-approval rule: refuse non-dry-run runs
+        # unless the caller explicitly asked for it. (Dual-approval UX
+        # itself is out of scope for this PR — this just blocks an
+        # accidental single-button live reassignment.)
+        if (not req.dry_run) and analyzer.require_dual_approval_for_reassign:
+            raise HTTPException(
+                403,
+                "Live reassignment requires dual approval; submit via the "
+                "approval workflow or set dry_run=true to preview.",
+            )
+        if (not req.dry_run) and not analyzer.is_supported():
+            raise HTTPException(501, "Live reassignment requires Windows + pywin32")
+        try:
+            return analyzer.reassign_owner(
+                req.source_id, req.sid, req.new_owner,
+                dry_run=req.dry_run, max_files=req.max_files,
+            )
+        except NotImplementedError as e:
+            raise HTTPException(501, str(e)) from e
+        except ValueError as e:
+            raise HTTPException(400, str(e)) from e
+
+    @app.get("/api/security/orphan-sids/{source_id}/export.csv")
+    async def orphan_sid_export_csv(source_id: int):
+        """Streaming CSV download of orphan files for offline review."""
+        from fastapi.responses import StreamingResponse
+        import io
+
+        analyzer = _get_orphan_analyzer()
+        scan_id = db.get_latest_scan_id(source_id, include_running=False)
+        if not scan_id:
+            raise HTTPException(404, f"No scan_runs found for source {source_id}")
+
+        # Detect, then stream the file rows. We re-implement the row
+        # generation here (instead of writing to a temp file) so the
+        # response can stream incrementally on million-row shares.
+        report = analyzer.detect_orphans(scan_id)
+        orphan_sids = [row["sid"] for row in report.get("orphan_sids", [])]
+
+        def _iter():
+            buf = io.StringIO()
+            writer = __import__("csv").writer(buf)
+            writer.writerow([
+                "path", "owner_sid", "file_size",
+                "last_modify_time", "owner_resolved",
+            ])
+            yield buf.getvalue()
+            buf.seek(0)
+            buf.truncate(0)
+
+            if not orphan_sids:
+                return
+
+            placeholders = ",".join(["?"] * len(orphan_sids))
+            params: list = [source_id, scan_id, *orphan_sids]
+            with db.get_cursor() as cur:
+                cur.execute(
+                    f"""SELECT file_path, owner, file_size, last_modify_time
+                        FROM scanned_files
+                        WHERE source_id = ? AND scan_id = ?
+                          AND owner IN ({placeholders})
+                        ORDER BY file_path""",
+                    tuple(params),
+                )
+                for r in cur.fetchall():
+                    writer.writerow([
+                        r["file_path"], r["owner"], r["file_size"],
+                        r["last_modify_time"] or "", "false",
+                    ])
+                    yield buf.getvalue()
+                    buf.seek(0)
+                    buf.truncate(0)
+
+        filename = f"orphan_sids_source{source_id}_scan{scan_id}.csv"
+        return StreamingResponse(
+            _iter(),
+            media_type="text/csv",
+            headers={"Content-Disposition": f"attachment; filename={filename}"},
+        )
+
+    # ─────────────────────────────────────────────────────────────────
     # Syslog/CEF integration (#50)
     # ─────────────────────────────────────────────────────────────────
 

--- a/src/security/orphan_sid.py
+++ b/src/security/orphan_sid.py
@@ -1,0 +1,451 @@
+"""Orphaned-SID report and bulk reassignment (issue #56).
+
+Walks the most recent ``scanned_files`` rows for a source/scan, groups
+them by their owner identifier (SID or DOMAIN\\Name string), then asks
+``ADLookup`` whether each owner still resolves. Owners that don't
+resolve are surfaced as "orphan SIDs" — files that nobody owns anymore
+because the principal has been deleted from Active Directory (typical
+for departed staff, decommissioned service accounts, etc.).
+
+The ``orphan_sid_cache`` table memoises the AD lookup result so a
+re-run of ``detect_orphans`` doesn't re-query AD for SIDs we just
+checked. The TTL is configurable
+(``security.orphan_sid.cache_ttl_minutes``, default 1440 = 24h).
+
+Bulk reassignment uses ``win32security.SetNamedSecurityInfo`` with
+``OWNER_SECURITY_INFORMATION`` and is Windows-only. Everything else
+(``detect_orphans``, ``get_orphan_files``, ``export_csv``) is DB-only
+and works fine on Linux + CI. ``pywin32`` is lazily imported so the
+module is import-safe on every platform.
+
+Defaults are intentionally conservative: ``reassign_owner(dry_run=True)``
+is the default, per-file failures are logged at DEBUG and never abort
+the batch, and an opt-in ``require_dual_approval_for_reassign`` config
+flag is honoured by the ``/reassign`` endpoint.
+"""
+
+from __future__ import annotations
+
+import csv
+import logging
+import sys
+import time
+from datetime import datetime, timedelta
+from typing import Optional
+
+logger = logging.getLogger("file_activity.security.orphan_sid")
+
+
+_DEFAULT_CACHE_TTL_MIN = 1440  # 24 hours
+_DEFAULT_MAX_UNIQUE_SIDS = 1000
+_SAMPLE_PATHS_PER_SID = 5
+
+
+class OrphanSidAnalyzer:
+    """Detect file-owner SIDs that no longer resolve via AD, support
+    bulk reassignment to a manager / archive owner.
+
+    Cross-platform safe — pywin32 lazily imported. Reassignment
+    methods raise NotImplementedError on non-Windows.
+    """
+
+    def __init__(self, db, config: dict, ad_lookup=None):
+        self.db = db
+        self.ad_lookup = ad_lookup
+        cfg = ((config or {}).get("security", {}) or {}).get("orphan_sid", {}) or {}
+        self.enabled = bool(cfg.get("enabled", True))
+        self.cache_ttl_minutes = int(cfg.get("cache_ttl_minutes", _DEFAULT_CACHE_TTL_MIN))
+        self.max_unique_sids_default = int(cfg.get("max_unique_sids", _DEFAULT_MAX_UNIQUE_SIDS))
+        self.require_dual_approval_for_reassign = bool(
+            cfg.get("require_dual_approval_for_reassign", False)
+        )
+
+    # ──────────────────────────────────────────────
+    # Capability probe
+    # ──────────────────────────────────────────────
+
+    def is_supported(self) -> bool:
+        """True on Windows with pywin32 importable. False otherwise.
+
+        ``detect_orphans``/``get_orphan_files``/``export_csv`` work on
+        Linux too (DB-only). Only ``reassign_owner`` requires Windows.
+        """
+        if sys.platform != "win32":
+            return False
+        try:
+            import win32security  # noqa: F401
+            return True
+        except Exception:  # pragma: no cover - import probe only
+            return False
+
+    # ──────────────────────────────────────────────
+    # Detection
+    # ──────────────────────────────────────────────
+
+    def detect_orphans(self, scan_id: int,
+                       max_unique_sids: int = _DEFAULT_MAX_UNIQUE_SIDS) -> dict:
+        """Walk ``scanned_files`` for the scan, group by owner SID,
+        check each via ``ad_lookup`` (cached in ``orphan_sid_cache``).
+
+        Returns::
+
+            {scan_id, total_files, total_orphan_files, orphan_sids: [
+                {sid, file_count, total_size, sample_paths: [up to 5]}
+            ], elapsed_seconds}
+
+        Caching: ``orphan_sid_cache.resolved=0`` means the SID didn't
+        resolve on the last check; we re-check after
+        ``cache_ttl_minutes`` (default 1440 = 24h).
+        """
+        started = time.time()
+        cap = int(max_unique_sids or self.max_unique_sids_default)
+
+        # Group by owner up-front so we only ever do ONE AD lookup per
+        # distinct owner string per scan, no matter how many files
+        # share an orphaned principal.
+        with self.db.get_cursor() as cur:
+            cur.execute(
+                """
+                SELECT owner,
+                       COUNT(*)        AS file_count,
+                       SUM(file_size)  AS total_size
+                FROM scanned_files
+                WHERE scan_id = ?
+                  AND owner IS NOT NULL
+                  AND owner <> ''
+                GROUP BY owner
+                ORDER BY file_count DESC
+                LIMIT ?
+                """,
+                (int(scan_id), cap),
+            )
+            owner_rows = [dict(r) for r in cur.fetchall()]
+
+            cur.execute(
+                "SELECT COUNT(*) AS c FROM scanned_files WHERE scan_id = ?",
+                (int(scan_id),),
+            )
+            total_files = int(cur.fetchone()["c"])
+
+        orphan_sids: list[dict] = []
+        total_orphan_files = 0
+
+        for row in owner_rows:
+            owner = row["owner"]
+            file_count = int(row["file_count"] or 0)
+            total_size = int(row["total_size"] or 0)
+
+            resolved = self._check_owner_cached(owner)
+            if resolved:
+                continue
+
+            sample_paths = self._sample_paths_for_owner(scan_id, owner)
+            orphan_sids.append({
+                "sid": owner,
+                "file_count": file_count,
+                "total_size": total_size,
+                "sample_paths": sample_paths,
+            })
+            total_orphan_files += file_count
+
+        elapsed = time.time() - started
+        logger.info(
+            "Orphan-SID scan: scan_id=%s total_files=%d orphan_sids=%d "
+            "orphan_files=%d in %.2fs",
+            scan_id, total_files, len(orphan_sids), total_orphan_files, elapsed,
+        )
+        return {
+            "scan_id": int(scan_id),
+            "total_files": total_files,
+            "total_orphan_files": total_orphan_files,
+            "orphan_sids": orphan_sids,
+            "elapsed_seconds": round(elapsed, 3),
+        }
+
+    # ──────────────────────────────────────────────
+    # Drill-down
+    # ──────────────────────────────────────────────
+
+    def get_orphan_files(self, source_id: int, sid: str,
+                         page: int = 1, page_size: int = 100) -> dict:
+        """Paginated list of files owned by an orphan SID."""
+        page = max(1, int(page or 1))
+        page_size = max(1, min(int(page_size or 100), 1000))
+        offset = (page - 1) * page_size
+
+        with self.db.get_cursor() as cur:
+            cur.execute(
+                """SELECT COUNT(*) AS c FROM scanned_files
+                   WHERE source_id = ? AND owner = ?""",
+                (int(source_id), sid),
+            )
+            total = int(cur.fetchone()["c"])
+
+            cur.execute(
+                """SELECT file_path, file_name, file_size,
+                          last_access_time, last_modify_time, owner
+                   FROM scanned_files
+                   WHERE source_id = ? AND owner = ?
+                   ORDER BY file_path
+                   LIMIT ? OFFSET ?""",
+                (int(source_id), sid, page_size, offset),
+            )
+            files = [dict(r) for r in cur.fetchall()]
+
+        return {
+            "source_id": int(source_id),
+            "sid": sid,
+            "page": page,
+            "page_size": page_size,
+            "total": total,
+            "files": files,
+        }
+
+    # ──────────────────────────────────────────────
+    # Bulk reassignment (Windows-only)
+    # ──────────────────────────────────────────────
+
+    def reassign_owner(self, source_id: int, old_sid: str,
+                       new_owner: str, dry_run: bool = True,
+                       max_files: Optional[int] = None) -> dict:
+        """Set new owner on every matching file. Windows-only.
+
+        Returns ``{scanned, changed, errors, dry_run, elapsed_seconds}``.
+        Logs per-file failures at DEBUG and never aborts the batch on
+        a single bad ACL — the operator should still get a summary so
+        they can re-run on the failures.
+        """
+        if not new_owner or not str(new_owner).strip():
+            raise ValueError("new_owner is required")
+
+        if not dry_run and sys.platform != "win32":
+            raise NotImplementedError(
+                "OrphanSidAnalyzer.reassign_owner requires Windows + pywin32"
+            )
+
+        started = time.time()
+        scanned = 0
+        changed = 0
+        errors = 0
+
+        with self.db.get_cursor() as cur:
+            sql = (
+                "SELECT file_path FROM scanned_files "
+                "WHERE source_id = ? AND owner = ? "
+                "ORDER BY file_path"
+            )
+            params: list = [int(source_id), old_sid]
+            if max_files is not None:
+                sql += " LIMIT ?"
+                params.append(int(max_files))
+            cur.execute(sql, tuple(params))
+            paths = [r["file_path"] for r in cur.fetchall()]
+
+        if dry_run:
+            elapsed = time.time() - started
+            return {
+                "scanned": len(paths),
+                "changed": 0,
+                "errors": 0,
+                "dry_run": True,
+                "elapsed_seconds": round(elapsed, 3),
+            }
+
+        # Real run — Windows path. Resolve the new owner string once,
+        # then SetNamedSecurityInfo per file.
+        try:
+            import win32security  # type: ignore
+        except Exception as e:  # pragma: no cover - import-time on Windows
+            raise NotImplementedError(
+                f"pywin32 unavailable on this host: {e}"
+            )
+
+        try:
+            new_sid, _domain, _typ = win32security.LookupAccountName(None, new_owner)
+        except Exception as e:
+            raise ValueError(f"Cannot resolve new_owner {new_owner!r}: {e}")
+
+        for path in paths:
+            scanned += 1
+            try:
+                win32security.SetNamedSecurityInfo(
+                    path,
+                    win32security.SE_FILE_OBJECT,
+                    win32security.OWNER_SECURITY_INFORMATION,
+                    new_sid,
+                    None,
+                    None,
+                    None,
+                )
+                changed += 1
+            except Exception as e:
+                errors += 1
+                logger.debug("Reassign failed for %s: %s", path, e)
+                continue
+
+        elapsed = time.time() - started
+        logger.info(
+            "Orphan-SID reassign done: source=%s old_sid=%s new_owner=%s "
+            "scanned=%d changed=%d errors=%d in %.2fs",
+            source_id, old_sid, new_owner, scanned, changed, errors, elapsed,
+        )
+        return {
+            "scanned": scanned,
+            "changed": changed,
+            "errors": errors,
+            "dry_run": False,
+            "elapsed_seconds": round(elapsed, 3),
+        }
+
+    # ──────────────────────────────────────────────
+    # CSV export
+    # ──────────────────────────────────────────────
+
+    def export_csv(self, source_id: int, scan_id: int,
+                   output_path: str) -> int:
+        """CSV of orphan files for offline review.
+
+        Cols: ``path, owner_sid, file_size, last_modify_time, owner_resolved``.
+        Returns the row count.
+        """
+        # Re-use detect_orphans to get the orphan SID set; that also
+        # populates the cache so the per-file check below is cheap.
+        report = self.detect_orphans(int(scan_id))
+        orphan_sids = {row["sid"] for row in report.get("orphan_sids", [])}
+
+        rows_written = 0
+        with open(output_path, "w", newline="", encoding="utf-8") as fh:
+            writer = csv.writer(fh)
+            writer.writerow([
+                "path", "owner_sid", "file_size",
+                "last_modify_time", "owner_resolved",
+            ])
+            if not orphan_sids:
+                return 0
+
+            placeholders = ",".join(["?"] * len(orphan_sids))
+            params: list = [int(source_id), int(scan_id), *orphan_sids]
+            with self.db.get_cursor() as cur:
+                cur.execute(
+                    f"""SELECT file_path, owner, file_size, last_modify_time
+                        FROM scanned_files
+                        WHERE source_id = ? AND scan_id = ?
+                          AND owner IN ({placeholders})
+                        ORDER BY file_path""",
+                    tuple(params),
+                )
+                for r in cur.fetchall():
+                    writer.writerow([
+                        r["file_path"],
+                        r["owner"],
+                        r["file_size"],
+                        r["last_modify_time"] or "",
+                        "false",
+                    ])
+                    rows_written += 1
+        logger.info(
+            "Orphan-SID CSV export: source=%s scan=%s rows=%d -> %s",
+            source_id, scan_id, rows_written, output_path,
+        )
+        return rows_written
+
+    # ──────────────────────────────────────────────
+    # Internals
+    # ──────────────────────────────────────────────
+
+    def _check_owner_cached(self, owner: str) -> bool:
+        """Return True if the owner currently resolves, False if it
+        looks orphaned. Consults ``orphan_sid_cache`` first; only
+        falls through to ``ad_lookup`` if the cached entry is missing
+        or stale.
+        """
+        cached = self._cache_get(owner)
+        if cached is not None and not cached["stale"]:
+            return bool(cached["resolved"])
+
+        # Either no cache row or it's past the TTL — re-check via AD.
+        resolved, name = self._lookup_owner(owner)
+        self._cache_put(owner, resolved, name)
+        return resolved
+
+    def _lookup_owner(self, owner: str) -> tuple[bool, Optional[str]]:
+        """Ask ADLookup whether ``owner`` still exists. Treats any
+        result with ``found=False`` (or a None/empty result) as orphaned.
+        Never raises — failure to query AD => assume unresolved so the
+        operator gets a finding rather than a silent skip.
+        """
+        if self.ad_lookup is None:
+            return False, None
+        try:
+            res = self.ad_lookup.lookup(owner)
+        except Exception as e:
+            logger.debug("ad_lookup raised on %s: %s", owner, e)
+            return False, None
+        if not res:
+            return False, None
+        if not res.get("found"):
+            return False, res.get("display_name")
+        return True, res.get("display_name")
+
+    def _cache_get(self, sid: str) -> Optional[dict]:
+        with self.db.get_cursor() as cur:
+            cur.execute(
+                "SELECT resolved, resolved_name, checked_at "
+                "FROM orphan_sid_cache WHERE sid = ?",
+                (sid,),
+            )
+            row = cur.fetchone()
+        if not row:
+            return None
+        checked_at = self._parse_ts(row["checked_at"])
+        ttl = timedelta(minutes=self.cache_ttl_minutes)
+        stale = (datetime.utcnow() - checked_at) > ttl if checked_at else True
+        return {
+            "resolved": bool(row["resolved"]),
+            "resolved_name": row["resolved_name"],
+            "checked_at": checked_at,
+            "stale": stale,
+        }
+
+    def _cache_put(self, sid: str, resolved: bool,
+                   resolved_name: Optional[str]) -> None:
+        with self.db.get_cursor() as cur:
+            cur.execute(
+                """INSERT INTO orphan_sid_cache (sid, resolved, resolved_name, checked_at)
+                   VALUES (?, ?, ?, CURRENT_TIMESTAMP)
+                   ON CONFLICT(sid) DO UPDATE SET
+                       resolved = excluded.resolved,
+                       resolved_name = excluded.resolved_name,
+                       checked_at = CURRENT_TIMESTAMP""",
+                (sid, 1 if resolved else 0, resolved_name),
+            )
+
+    def _sample_paths_for_owner(self, scan_id: int, owner: str) -> list[str]:
+        with self.db.get_cursor() as cur:
+            cur.execute(
+                """SELECT file_path FROM scanned_files
+                   WHERE scan_id = ? AND owner = ?
+                   ORDER BY file_path
+                   LIMIT ?""",
+                (int(scan_id), owner, _SAMPLE_PATHS_PER_SID),
+            )
+            return [r["file_path"] for r in cur.fetchall()]
+
+    @staticmethod
+    def _parse_ts(value) -> Optional[datetime]:
+        """SQLite TIMESTAMP DEFAULT CURRENT_TIMESTAMP returns a string
+        like ``2026-04-23 12:34:56`` — turn it into a UTC ``datetime``.
+        Returns None if the value is missing or unparseable.
+        """
+        if value is None:
+            return None
+        if isinstance(value, datetime):
+            return value
+        s = str(value)
+        for fmt in ("%Y-%m-%d %H:%M:%S", "%Y-%m-%d %H:%M:%S.%f",
+                    "%Y-%m-%dT%H:%M:%S", "%Y-%m-%dT%H:%M:%S.%f"):
+            try:
+                return datetime.strptime(s, fmt)
+            except ValueError:
+                continue
+        return None

--- a/src/storage/database.py
+++ b/src/storage/database.py
@@ -640,6 +640,24 @@ class Database:
         cur.execute("CREATE INDEX IF NOT EXISTS idx_acl_trustee ON file_acl_snapshots(trustee_sid)")
         cur.execute("CREATE INDEX IF NOT EXISTS idx_acl_scan ON file_acl_snapshots(scan_id)")
 
+        # Orphan-SID cache (#56). Memoises AD lookup results keyed by the
+        # owner string (SID or DOMAIN\Name) so re-running detect_orphans
+        # doesn't hammer AD for SIDs we just checked. resolved=0 means
+        # the principal didn't resolve last time we asked; the analyzer
+        # rechecks once cache_ttl_minutes have elapsed.
+        cur.execute("""
+            CREATE TABLE IF NOT EXISTS orphan_sid_cache (
+                sid TEXT PRIMARY KEY,
+                resolved INTEGER NOT NULL DEFAULT 0,
+                resolved_name TEXT,
+                checked_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+            )
+        """)
+        cur.execute(
+            "CREATE INDEX IF NOT EXISTS idx_orphan_sid_resolved "
+            "ON orphan_sid_cache(resolved)"
+        )
+
         # FTS5 full-text search (arsivlenmis dosyalar icin)
         cur.execute("""
             CREATE VIRTUAL TABLE IF NOT EXISTS archived_files_fts USING fts5(

--- a/tests/test_orphan_sid.py
+++ b/tests/test_orphan_sid.py
@@ -1,0 +1,259 @@
+"""Tests for issue #56: Orphaned-SID report + bulk reassignment.
+
+Linux-runnable. The Windows-only path (``reassign_owner`` with
+``dry_run=False``) is covered by asserting that it raises
+``NotImplementedError`` on non-Windows hosts; everything else exercises
+the DB-backed report against synthetic ``scanned_files`` rows in a tmp
+SQLite, plus a stubbed ``ad_lookup`` that simulates orphaned vs.
+resolved owners.
+"""
+
+from __future__ import annotations
+
+import csv
+import os
+import sys
+
+import pytest
+
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if REPO_ROOT not in sys.path:
+    sys.path.insert(0, REPO_ROOT)
+
+from src.security.orphan_sid import OrphanSidAnalyzer  # noqa: E402
+from src.storage.database import Database  # noqa: E402
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Test doubles
+# ──────────────────────────────────────────────────────────────────────
+
+
+class StubADLookup:
+    """Records every lookup call. Anything in ``orphans`` returns
+    ``found=False`` (= orphaned); everything else returns ``found=True``.
+    """
+
+    def __init__(self, orphans):
+        self.orphans = set(orphans)
+        self.calls = []
+
+    def lookup(self, name, force_refresh=False):  # noqa: D401 - stub
+        self.calls.append(name)
+        if name in self.orphans:
+            return {
+                "username": name,
+                "email": None,
+                "display_name": None,
+                "found": False,
+                "source": "live",
+            }
+        return {
+            "username": name,
+            "email": f"{name}@example.com",
+            "display_name": name.upper(),
+            "found": True,
+            "source": "live",
+        }
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Fixtures
+# ──────────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def db_with_files(tmp_path):
+    """Returns ``(db, source_id, scan_id)`` with three owners pre-seeded:
+
+    - ``DOMAIN\\alice``  : 3 files (orphan)
+    - ``DOMAIN\\bob``    : 2 files (resolved)
+    - ``S-1-5-21-DELETED``: 4 files (orphan)
+    """
+    db = Database({"path": str(tmp_path / "orphan.db")})
+    db.connect()
+    with db.get_cursor() as cur:
+        cur.execute("INSERT INTO sources (name, unc_path) VALUES ('s1', '/share')")
+        source_id = cur.lastrowid
+        cur.execute("INSERT INTO scan_runs (source_id) VALUES (?)", (source_id,))
+        scan_id = cur.lastrowid
+
+        rows = []
+        for i in range(3):
+            rows.append((source_id, scan_id,
+                         f"/share/alice/file{i}.txt", f"alice/file{i}.txt",
+                         f"file{i}.txt", "txt", 100 + i, "DOMAIN\\alice"))
+        for i in range(2):
+            rows.append((source_id, scan_id,
+                         f"/share/bob/file{i}.txt", f"bob/file{i}.txt",
+                         f"file{i}.txt", "txt", 200 + i, "DOMAIN\\bob"))
+        for i in range(4):
+            rows.append((source_id, scan_id,
+                         f"/share/legacy/file{i}.txt", f"legacy/file{i}.txt",
+                         f"file{i}.txt", "txt", 300 + i, "S-1-5-21-DELETED"))
+        cur.executemany(
+            """INSERT INTO scanned_files
+               (source_id, scan_id, file_path, relative_path, file_name,
+                extension, file_size, owner)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
+            rows,
+        )
+    return db, source_id, scan_id
+
+
+def _make_analyzer(db, ad_lookup, **overrides):
+    cfg = {
+        "security": {
+            "orphan_sid": {
+                "enabled": True,
+                "cache_ttl_minutes": 1440,
+                "max_unique_sids": 1000,
+                **overrides,
+            }
+        }
+    }
+    return OrphanSidAnalyzer(db, cfg, ad_lookup=ad_lookup)
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Tests
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_is_supported_false_on_linux(db_with_files):
+    db, _src, _scan = db_with_files
+    a = _make_analyzer(db, StubADLookup(orphans=[]))
+    if sys.platform == "win32":
+        pytest.skip("Linux-only assertion")
+    assert a.is_supported() is False
+
+
+def test_detect_orphans_finds_expected_sids(db_with_files):
+    """Two of the three owners are orphaned; alice's 3 + legacy's 4
+    files should add up to 7 orphan files.
+    """
+    db, _src, scan_id = db_with_files
+    ad = StubADLookup(orphans=["DOMAIN\\alice", "S-1-5-21-DELETED"])
+    a = _make_analyzer(db, ad)
+
+    out = a.detect_orphans(scan_id)
+    assert out["scan_id"] == scan_id
+    assert out["total_files"] == 9
+    assert out["total_orphan_files"] == 7
+
+    sids = {row["sid"] for row in out["orphan_sids"]}
+    assert sids == {"DOMAIN\\alice", "S-1-5-21-DELETED"}
+
+    by_sid = {row["sid"]: row for row in out["orphan_sids"]}
+    assert by_sid["DOMAIN\\alice"]["file_count"] == 3
+    assert by_sid["S-1-5-21-DELETED"]["file_count"] == 4
+    # sample_paths capped at 5; legacy has 4 so we get 4.
+    assert len(by_sid["S-1-5-21-DELETED"]["sample_paths"]) == 4
+    assert len(by_sid["DOMAIN\\alice"]["sample_paths"]) == 3
+    # bob (resolved) must NOT appear.
+    assert "DOMAIN\\bob" not in sids
+
+
+def test_cache_persists_across_calls(db_with_files):
+    """Second detect_orphans must use the cache and not re-query AD."""
+    db, _src, scan_id = db_with_files
+    ad = StubADLookup(orphans=["DOMAIN\\alice", "S-1-5-21-DELETED"])
+    a = _make_analyzer(db, ad)
+
+    a.detect_orphans(scan_id)
+    first_call_count = len(ad.calls)
+    assert first_call_count == 3  # alice + bob + legacy SID
+
+    a.detect_orphans(scan_id)
+    # No additional AD calls — every owner is in the cache and fresh.
+    assert len(ad.calls) == first_call_count
+
+    # Cache rows present.
+    with db.get_cursor() as cur:
+        cur.execute("SELECT COUNT(*) AS c FROM orphan_sid_cache")
+        assert cur.fetchone()["c"] == 3
+        cur.execute("SELECT resolved FROM orphan_sid_cache "
+                    "WHERE sid = 'DOMAIN\\alice'")
+        assert cur.fetchone()["resolved"] == 0
+        cur.execute("SELECT resolved FROM orphan_sid_cache "
+                    "WHERE sid = 'DOMAIN\\bob'")
+        assert cur.fetchone()["resolved"] == 1
+
+
+def test_get_orphan_files_paginates(db_with_files):
+    db, source_id, _scan = db_with_files
+    a = _make_analyzer(db, StubADLookup(orphans=[]))
+
+    page1 = a.get_orphan_files(source_id, "S-1-5-21-DELETED",
+                               page=1, page_size=2)
+    assert page1["total"] == 4
+    assert page1["page"] == 1
+    assert len(page1["files"]) == 2
+
+    page2 = a.get_orphan_files(source_id, "S-1-5-21-DELETED",
+                               page=2, page_size=2)
+    assert len(page2["files"]) == 2
+    assert {f["file_path"] for f in page2["files"]} & \
+           {f["file_path"] for f in page1["files"]} == set()
+
+    page3 = a.get_orphan_files(source_id, "S-1-5-21-DELETED",
+                               page=3, page_size=2)
+    assert page3["files"] == []
+
+
+def test_export_csv_writes_headers_and_rows(db_with_files, tmp_path):
+    db, source_id, scan_id = db_with_files
+    ad = StubADLookup(orphans=["DOMAIN\\alice", "S-1-5-21-DELETED"])
+    a = _make_analyzer(db, ad)
+
+    out_path = tmp_path / "orphan.csv"
+    rows_written = a.export_csv(source_id, scan_id, str(out_path))
+    assert rows_written == 7  # 3 alice + 4 legacy
+
+    with open(out_path, newline="", encoding="utf-8") as fh:
+        reader = csv.reader(fh)
+        rows = list(reader)
+    assert rows[0] == ["path", "owner_sid", "file_size",
+                        "last_modify_time", "owner_resolved"]
+    assert len(rows) - 1 == 7
+    # bob's files (resolved owner) must NOT be in the export.
+    paths = [r[0] for r in rows[1:]]
+    assert not any("/bob/" in p for p in paths)
+    # All rows record owner_resolved=false.
+    assert all(r[4] == "false" for r in rows[1:])
+
+
+def test_reassign_owner_raises_on_linux(db_with_files):
+    db, source_id, _scan = db_with_files
+    a = _make_analyzer(db, StubADLookup(orphans=[]))
+    if sys.platform == "win32":
+        pytest.skip("Linux-only assertion")
+    with pytest.raises(NotImplementedError):
+        a.reassign_owner(source_id, "DOMAIN\\alice",
+                          new_owner="DOMAIN\\manager", dry_run=False)
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Bonus coverage (defensive paths) — kept tight so we stay near the
+# 6-test target while still exercising dry_run, validation, and the
+# is_supported() docstring contract.
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_reassign_owner_dry_run_is_default_and_safe(db_with_files):
+    """Dry run must work cross-platform and never call into pywin32."""
+    db, source_id, _scan = db_with_files
+    a = _make_analyzer(db, StubADLookup(orphans=[]))
+    out = a.reassign_owner(source_id, "DOMAIN\\alice",
+                            new_owner="DOMAIN\\manager")
+    assert out["dry_run"] is True
+    assert out["scanned"] == 3
+    assert out["changed"] == 0
+    assert out["errors"] == 0
+
+
+def test_reassign_owner_rejects_blank_new_owner(db_with_files):
+    db, source_id, _scan = db_with_files
+    a = _make_analyzer(db, StubADLookup(orphans=[]))
+    with pytest.raises(ValueError):
+        a.reassign_owner(source_id, "DOMAIN\\alice", new_owner="   ")


### PR DESCRIPTION
## Summary
Closes #56. Implemented by parallel subagent.

`OrphanSidAnalyzer` detects file-owner SIDs that no longer resolve via AD, supports bulk reassignment to a manager / archive owner. Cross-platform safe — pywin32 lazily imported; reassignment is Windows-only.

## Changes
- **New** `src/security/orphan_sid.py` — `OrphanSidAnalyzer` (detect_orphans, get_orphan_files, reassign_owner, export_csv, is_supported)
- **New** `tests/test_orphan_sid.py` — 8 Linux-runnable tests, 8/8 pass
- `src/storage/database.py` — `orphan_sid_cache` table + `idx_orphan_sid_resolved` index
- `src/dashboard/api.py` — 4 endpoints lazy-built via `_get_orphan_analyzer()`
- `config.yaml` — `security.orphan_sid` block

## API
- `GET /api/security/orphan-sids/{source_id}` — orphan SID report
- `GET /api/security/orphan-sids/{source_id}/files?sid=` — drill-down, paginated
- `POST /api/security/orphan-sids/reassign` — Pydantic body, dual-approval gate
- `GET /api/security/orphan-sids/{source_id}/export.csv` — streaming download

## Safeguards
- `dry_run=True` is the default on `reassign_owner` AND the API request model
- Live reassignment refused if `require_dual_approval_for_reassign` set (HTTP 403)
- pywin32 lazily imported inside the real-run branch only
- Per-file failures logged at DEBUG, counted into `errors` — one bad ACL never aborts the batch
- AD lookups memoised in `orphan_sid_cache` (default TTL 24h)
- HTTP 501 on non-Windows for live reassignment

## Test plan
- [x] `python -m compileall -q src/` clean
- [x] `pytest tests/test_orphan_sid.py -v` → 8/8 pass
- [x] Full suite: 126 passed, 6 skipped
- [ ] Real Windows test with deleted-SID files

---
_Generated by [Claude Code](https://claude.ai/code/session_01A1UzS1A4DZNk1akoP4uhZ7)_