### PR TITLE
Benchmark harness: PII / scanner / dedup deterministic timings (closes #70)

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1,0 +1,54 @@
+name: Benchmark
+
+# Manual-only — benchmarks are noisy on shared GHA runners and we don't
+# want to gate PRs on them. Run via the Actions tab → Benchmark → Run
+# workflow when validating an optimisation or chasing a regression.
+on:
+  workflow_dispatch:
+    inputs:
+      corpus_size:
+        description: "PII corpus size in MB"
+        required: false
+        default: "100"
+      repeats:
+        description: "Measured repeats per backend"
+        required: false
+        default: "5"
+
+jobs:
+  bench:
+    name: PII engine benchmark
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip --quiet
+          # Core deps + optional accelerated backends. ``requirements-accel.txt``
+          # pulls in hyperscan so the harness can run BOTH backends and report
+          # the speedup in the same table.
+          python -m pip install -r requirements.txt --quiet
+          python -m pip install -r requirements-accel.txt --quiet
+
+      - name: Run bench_pii
+        env:
+          CORPUS_SIZE: ${{ github.event.inputs.corpus_size }}
+          REPEATS: ${{ github.event.inputs.repeats }}
+        run: |
+          python -m tests.bench.bench_pii \
+            --corpus-size "${CORPUS_SIZE:-100}" \
+            --repeats "${REPEATS:-5}" \
+            --history bench_history.jsonl
+
+      - name: Upload bench_history.jsonl
+        uses: actions/upload-artifact@v4
+        with:
+          name: bench-history
+          path: bench_history.jsonl
+          if-no-files-found: warn

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,8 @@ node_modules/
 *.zip
 *.exe
 temp_netwrix/
+
+# Benchmark history (issue #70). Local-only — each developer / CI host
+# accumulates its own run-over-run record so regressions are visible
+# against the same hardware. Not committed.
+bench_history.jsonl

--- a/tests/bench/README.md
+++ b/tests/bench/README.md
@@ -1,0 +1,172 @@
+# Benchmark harness (issue #70)
+
+`tests/bench/` produces deterministic, run-over-run comparable
+performance numbers for the parts of FILE_ACTIVITY whose throughput
+matters: the PII regex engine, the four scanner backends, and the
+SHA-256 dedup-hashing path.
+
+The harness is **not** auto-discovered by `pytest` — the package has
+no `test_*` modules, so a normal `pytest` run skips it entirely.
+Invoke each benchmark directly via `python -m`.
+
+## Quick start
+
+```bash
+# 1. PII engine (validates the issue #66 5x speedup claim)
+python -m tests.bench.bench_pii
+
+# 2. Scanner backends (smb_parallel always; Windows backends skipped on Linux)
+python -m tests.bench.bench_scanner
+
+# 3. SHA-256 dedup hashing (probes SHA-NI availability)
+python -m tests.bench.bench_dedup
+```
+
+Every harness writes a Markdown table to stdout and appends one JSON
+object per benchmark to `bench_history.jsonl` (gitignored).
+
+## CLI reference
+
+### `bench_pii.py`
+
+```
+python -m tests.bench.bench_pii \
+    [--corpus-size MB]   # default 100
+    [--repeats N]        # default 5
+    [--warmup N]         # default 1
+    [--history PATH]     # default bench_history.jsonl, '' to disable
+    [--tmpdir DIR]       # default <tmp>/file_activity_bench_pii
+```
+
+Generates a deterministic corpus (random words seeded with
+`random.seed(42)` plus 10k emails / 5k IBANs / 2k TCKNs at known
+positions) and times `PiiEngine.scan_source` end-to-end against an
+in-memory SQLite stub. Reports MB/s and matches/sec for both `re` and
+`hyperscan` backends; if the optional `hyperscan` package isn't
+importable the harness records `pii_hyperscan` as a `skipped` row and
+continues.
+
+After the table, the harness prints a `speedup = Nx (PASS|BELOW
+TARGET)` line directly comparing the two backends against the issue
+#66 ≥ 5x claim.
+
+### `bench_scanner.py`
+
+```
+python -m tests.bench.bench_scanner \
+    [--files N]          # default 10000
+    [--fanout N]         # default 10  (children per directory)
+    [--repeats N]        # default 3
+    [--warmup N]         # default 1
+    [--workers N]        # default 16  (smb_parallel thread count)
+    [--no-shm]           # skip /dev/shm even if available
+    [--history PATH]
+```
+
+Synthesises a balanced N-ary directory tree (defaults to ~10k empty
+files arranged with fanout 10) on tmpfs (`/dev/shm` when writable on
+Linux) and times each available backend's `walk(root)` iteration.
+
+| Backend                 | Linux                        | Windows |
+|-------------------------|------------------------------|---------|
+| `smb_parallel`          | runs (default 16 workers)    | runs    |
+| `win32_find_ex`         | skipped (Windows-only ctypes)| runs    |
+| `ntfs_mft`              | skipped (NTFS + admin)       | runs    |
+| `ntfs_usn_tail`         | skipped (incremental, not enumeration) | skipped (no enumeration parity) |
+
+Reports files/sec.
+
+### `bench_dedup.py`
+
+```
+python -m tests.bench.bench_dedup \
+    [--corpus-size MB]   # default 100
+    [--files N]          # default 32
+    [--repeats N]        # default 5
+    [--warmup N]         # default 1
+    [--tmpdir DIR]
+    [--history PATH]
+```
+
+Builds N fixture files of equal size totalling `corpus-size` MB and
+streams `hashlib.sha256` over each in 1 MiB chunks. Probes for SHA-NI
+by inspecting `/proc/cpuinfo` (Linux) and `hashlib.algorithms_guaranteed`;
+the detection result is logged AND stored in the JSONL row's `extra`
+field so a regression detector can correlate throughput changes with
+hardware capability changes (e.g. moving the CI runner pool).
+
+Hashing always runs — SHA-NI absence is not fatal, just slower.
+
+## JSONL history format
+
+Each line of `bench_history.jsonl` is a single JSON object:
+
+```json
+{
+  "timestamp": "2026-04-23T18:42:11Z",
+  "git_sha": "abcd1234...",
+  "name": "pii_hyperscan",
+  "median_ms": 412.3,
+  "p95_ms": 438.1,
+  "throughput_value": 242.6,
+  "throughput_unit": "MB/s",
+  "repeats": 5,
+  "extra": {
+    "backend": "hyperscan",
+    "matches": 17000,
+    "matches_per_sec": 41245.7,
+    "scanned_bytes": 104857600
+  }
+}
+```
+
+The schema is intentionally flat-ish: every row carries enough context
+to be plotted standalone, no joining against external metadata
+required.
+
+## Consuming for regression tracking
+
+```bash
+# 1. PII MB/s over time, one line per backend:
+jq -r 'select(.name|startswith("pii_")) |
+       [.timestamp, .name, .throughput_value] | @tsv' \
+   bench_history.jsonl
+
+# 2. Quick "did anything regress >10%" check between latest two runs
+#    of pii_hyperscan:
+jq -s 'map(select(.name=="pii_hyperscan")) | sort_by(.timestamp) |
+       .[-2:] | (.[1].median_ms / .[0].median_ms - 1) * 100' \
+   bench_history.jsonl
+```
+
+Or in Python:
+
+```python
+import pandas as pd
+df = pd.read_json("bench_history.jsonl", lines=True)
+pii = df[df.name.str.startswith("pii_")]
+pii.pivot_table(
+    index="timestamp", columns="name", values="throughput_value"
+).plot()
+```
+
+## Determinism guarantees
+
+* Same hardware + same git SHA → numbers within ~5% noise (variance
+  budget for GC pauses + OS scheduler jitter).
+* Corpus generators are seeded (`random.seed(42)`); they regenerate
+  only when the requested size differs from what's already on disk.
+* Tmpfs is preferred over disk to remove cold-cache effects from the
+  scanner walk benchmark.
+
+## Adding a new benchmark
+
+1. Add `tests/bench/bench_<thing>.py`.
+2. Inside, instantiate `tests.bench._runner.Bench`, call `.run(name,
+   fn, repeats=...)` for each variant you want to time.
+3. Have `fn` return `{"throughput_value": float, "throughput_unit":
+   str, "extra": {...}}` so the runner records it.
+4. Call `print_table(bench.results)` and `append_history(bench.results)`
+   at the end.
+5. Document the harness in this file and (optionally) wire it into
+   `.github/workflows/bench.yml`.

--- a/tests/bench/__init__.py
+++ b/tests/bench/__init__.py
@@ -1,0 +1,7 @@
+"""Benchmark harness for FILE_ACTIVITY (issue #70).
+
+This package is intentionally NOT named ``test_*`` and contains no
+``test_*`` modules so ``pytest`` will not auto-discover the
+benchmarks during ordinary test runs. Invoke each harness directly
+via ``python -m tests.bench.<name>``.
+"""

--- a/tests/bench/_runner.py
+++ b/tests/bench/_runner.py
@@ -1,0 +1,285 @@
+"""Common benchmark harness used by every ``tests/bench/bench_*`` module.
+
+Three responsibilities:
+
+1. :class:`Bench` — a tiny stopwatch-style runner. ``Bench.run(name, fn)``
+   executes ``fn`` ``warmup`` times to prime caches/JIT-equivalent
+   internals, then ``repeats`` times for measurement, recording wall-clock
+   elapsed seconds via ``time.perf_counter``. The reported number is the
+   median (robust to GC pauses) plus p95 (so a tail-latency regression is
+   visible in the same row). Throughput is supplied by the caller because
+   every harness measures a different unit (MB/s for PII, files/s for
+   scanner, hashes/s for dedup).
+
+2. :func:`print_table` — emits a Markdown table to stdout. The same table
+   is what the optional ``bench.yml`` workflow appends to
+   ``$GITHUB_STEP_SUMMARY`` so a manual run gives the operator a result
+   they can paste into an issue.
+
+3. :func:`append_history` — one JSON object per benchmark per run,
+   appended to ``bench_history.jsonl`` (gitignored). Each line is fully
+   self-describing — timestamp + git SHA + result fields — so ``jq`` /
+   ``pandas.read_json(lines=True)`` can plot regressions over time
+   without joining against any external state.
+
+The harness is deliberately stdlib-only: tests/bench is a package that
+must run on a fresh checkout with nothing more than ``pip install -r
+requirements.txt`` already present.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import statistics
+import subprocess
+import sys
+import time
+from dataclasses import asdict, dataclass, field
+from typing import Callable, Optional
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Result record
+# ──────────────────────────────────────────────────────────────────────
+
+
+@dataclass
+class BenchResult:
+    """One row in the benchmark output table.
+
+    ``throughput_value`` + ``throughput_unit`` keep the schema generic so
+    the same dataclass can describe MB/s (PII), files/s (scanner) and
+    hashes/s or MB/s (dedup) without per-harness columns. ``extra`` is a
+    free-form dict for anything backend-specific (e.g. matches/sec for
+    PII, fanout for scanner) — it survives the round-trip through
+    ``bench_history.jsonl``.
+    """
+
+    name: str
+    median_ms: float
+    p95_ms: float
+    throughput_value: float
+    throughput_unit: str
+    repeats: int = 0
+    extra: dict = field(default_factory=dict)
+
+    # ──────────────────────────────────────────────────────────────────
+    # Convenience accessors so the README's documented field names
+    # ("throughput_mbps_or_kops") are still queryable from JSONL rows.
+    # ──────────────────────────────────────────────────────────────────
+
+    @property
+    def throughput_mbps_or_kops(self) -> float:
+        return self.throughput_value
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Runner
+# ──────────────────────────────────────────────────────────────────────
+
+
+class Bench:
+    """Stopwatch-style benchmark runner.
+
+    The runner deliberately does NOT try to be ``timeit``-clever: each
+    benchmarked function is expected to do real work (open a 100 MB file,
+    walk 10k inodes, hash a few MB). The variance across that scale of
+    work is dominated by I/O / GC, not by call-overhead measurement
+    error, so a simple median-of-N is the right tool.
+    """
+
+    def __init__(self) -> None:
+        self.results: list[BenchResult] = []
+
+    def run(
+        self,
+        name: str,
+        fn: Callable[[], Optional[dict]],
+        repeats: int = 5,
+        warmup: int = 1,
+        throughput_value: float = 0.0,
+        throughput_unit: str = "ops/s",
+        extra: Optional[dict] = None,
+    ) -> BenchResult:
+        """Time ``fn`` and append the result.
+
+        Parameters
+        ----------
+        name
+            Stable label for this benchmark — used in the markdown table
+            and as the ``name`` field of the JSONL history.
+        fn
+            Zero-arg callable. May return a dict; any keys present in
+            the returned dict OVERRIDE the caller-supplied ``extra`` /
+            ``throughput_value`` / ``throughput_unit`` (so a benchmark
+            can compute its own throughput from per-run measurements).
+        repeats
+            Measured iterations. Median + p95 are over these only; the
+            warmup runs are discarded.
+        warmup
+            Unmeasured iterations executed first to stabilise caches.
+        throughput_value, throughput_unit
+            Default throughput reported when ``fn`` doesn't override.
+        extra
+            Free-form metadata stored on the result.
+        """
+        extra = dict(extra or {})
+
+        for _ in range(max(0, warmup)):
+            try:
+                fn()
+            except Exception as exc:  # pragma: no cover - defensive
+                # Warmup failures are not fatal but are surfaced so the
+                # operator notices a misconfigured benchmark.
+                print(f"[warn] {name}: warmup raised {exc!r}", file=sys.stderr)
+
+        timings: list[float] = []
+        last_payload: Optional[dict] = None
+        for _ in range(max(1, repeats)):
+            t0 = time.perf_counter()
+            payload = fn()
+            elapsed = time.perf_counter() - t0
+            timings.append(elapsed)
+            if isinstance(payload, dict):
+                last_payload = payload
+
+        # Median over a small N is well-defined; p95 with N=5 falls out
+        # of statistics.quantiles using inclusive method (i.e. it picks
+        # the largest sample, which is the right semantic for "tail").
+        median_s = statistics.median(timings)
+        if len(timings) >= 2:
+            p95_s = statistics.quantiles(
+                timings, n=20, method="inclusive"
+            )[18]
+        else:
+            p95_s = timings[0]
+
+        # Allow the function to override throughput / extras based on
+        # what it actually measured (e.g. matches/sec computed from the
+        # number of regex hits at runtime).
+        if last_payload:
+            throughput_value = float(
+                last_payload.get("throughput_value", throughput_value)
+            )
+            throughput_unit = str(
+                last_payload.get("throughput_unit", throughput_unit)
+            )
+            payload_extra = last_payload.get("extra")
+            if isinstance(payload_extra, dict):
+                extra.update(payload_extra)
+
+        result = BenchResult(
+            name=name,
+            median_ms=round(median_s * 1000.0, 3),
+            p95_ms=round(p95_s * 1000.0, 3),
+            throughput_value=round(throughput_value, 3),
+            throughput_unit=throughput_unit,
+            repeats=len(timings),
+            extra=extra,
+        )
+        self.results.append(result)
+        return result
+
+    def skip(self, name: str, reason: str) -> BenchResult:
+        """Record a skipped benchmark — keeps the row visible in the
+        output table so missing backends are not silently invisible.
+        """
+        result = BenchResult(
+            name=name,
+            median_ms=0.0,
+            p95_ms=0.0,
+            throughput_value=0.0,
+            throughput_unit="skipped",
+            repeats=0,
+            extra={"skipped": True, "reason": reason},
+        )
+        self.results.append(result)
+        return result
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Output helpers
+# ──────────────────────────────────────────────────────────────────────
+
+
+def print_table(results: list[BenchResult]) -> str:
+    """Print a Markdown table summarising ``results`` and return it.
+
+    Returning the string lets the GH Actions wrapper redirect it into
+    ``$GITHUB_STEP_SUMMARY`` without re-implementing the formatter.
+    """
+    header = "| Benchmark | Median (ms) | p95 (ms) | Throughput | Unit | Notes |"
+    sep = "|---|---:|---:|---:|---|---|"
+    lines = [header, sep]
+    for r in results:
+        if r.extra.get("skipped"):
+            lines.append(
+                f"| {r.name} | — | — | — | skipped | {r.extra.get('reason', '')} |"
+            )
+            continue
+        notes_parts: list[str] = []
+        for k, v in r.extra.items():
+            if k in ("skipped", "reason"):
+                continue
+            notes_parts.append(f"{k}={v}")
+        notes = "; ".join(notes_parts)
+        lines.append(
+            f"| {r.name} | {r.median_ms:.2f} | {r.p95_ms:.2f} | "
+            f"{r.throughput_value:.2f} | {r.throughput_unit} | {notes} |"
+        )
+    rendered = "\n".join(lines)
+    print(rendered)
+    return rendered
+
+
+def _git_sha() -> Optional[str]:
+    """Best-effort git SHA lookup. ``None`` outside a git checkout."""
+    try:
+        out = subprocess.check_output(
+            ["git", "rev-parse", "HEAD"],
+            stderr=subprocess.DEVNULL,
+            timeout=2.0,
+        )
+        return out.decode("ascii", errors="replace").strip() or None
+    except Exception:
+        return None
+
+
+def append_history(
+    results: list[BenchResult],
+    path: str = "bench_history.jsonl",
+) -> int:
+    """Append one JSON object per ``BenchResult`` to ``path``.
+
+    Each line carries the timestamp and git SHA so the file is fully
+    self-describing — a regression detector can replay the file with no
+    side metadata. Returns the number of rows written.
+    """
+    if not results:
+        return 0
+
+    sha = _git_sha()
+    ts = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+
+    parent = os.path.dirname(os.path.abspath(path))
+    if parent and not os.path.isdir(parent):
+        os.makedirs(parent, exist_ok=True)
+
+    with open(path, "a", encoding="utf-8") as fh:
+        for r in results:
+            row = {
+                "timestamp": ts,
+                "git_sha": sha,
+                **asdict(r),
+            }
+            fh.write(json.dumps(row, sort_keys=True) + "\n")
+    return len(results)
+
+
+__all__ = [
+    "Bench",
+    "BenchResult",
+    "print_table",
+    "append_history",
+]

--- a/tests/bench/bench_dedup.py
+++ b/tests/bench/bench_dedup.py
@@ -1,0 +1,234 @@
+"""Benchmark the SHA-256 dedup-hashing path.
+
+The dedup pipeline (``src/storage/database.py``) hashes every audited
+event row and chains it; on a busy share that hash loop becomes the
+hot path. This harness measures pure ``hashlib.sha256`` throughput
+against a deterministic fixture corpus and reports MB/s.
+
+It also probes whether the host CPU is using SHA-NI (Intel/AMD's
+SHA-extension) by:
+
+1. Verifying ``sha256`` is in :data:`hashlib.algorithms_guaranteed`
+   (always true on CPython 3.11, but kept as a sanity check so the
+   harness fails loudly if the stdlib was somehow built without it).
+2. Reading ``/proc/cpuinfo`` on Linux for the ``sha_ni`` flag.
+
+If SHA-NI is absent we still run the benchmark — it just produces a
+slower number. The detection result is logged + recorded in the
+``extra`` block of the JSONL row so a regression report can correlate
+throughput with hardware capability.
+
+Usage::
+
+    python -m tests.bench.bench_dedup \
+        [--corpus-size 100] [--files 32] \
+        [--repeats 5] [--history bench_history.jsonl]
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import os
+import random
+import sys
+import tempfile
+import time
+from pathlib import Path
+from typing import Optional
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from tests.bench._runner import (  # noqa: E402
+    Bench,
+    append_history,
+    print_table,
+)
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Hardware probe
+# ──────────────────────────────────────────────────────────────────────
+
+
+def detect_sha_ni() -> dict:
+    """Best-effort detection of SHA-NI availability.
+
+    Returns a dict with both pieces of evidence so the operator can
+    inspect what we found. Never raises — every probe is wrapped.
+    """
+    info: dict = {
+        "sha256_in_guaranteed": "sha256" in hashlib.algorithms_guaranteed,
+        "cpuinfo_sha_ni": None,
+        "platform": sys.platform,
+    }
+
+    if sys.platform.startswith("linux"):
+        try:
+            with open("/proc/cpuinfo", "r", encoding="utf-8") as fh:
+                # Reading the first ~64 KB is enough — flag list lives
+                # within the first processor block on every kernel.
+                blob = fh.read(65536)
+            # The flag is reported as ``sha_ni`` (Intel/AMD) or
+            # occasionally ``sha`` (older kernels). Accept either.
+            tokens = set(blob.split())
+            info["cpuinfo_sha_ni"] = (
+                "sha_ni" in tokens or "sha" in tokens
+            )
+        except OSError as exc:
+            info["cpuinfo_error"] = repr(exc)
+    return info
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Corpus
+# ──────────────────────────────────────────────────────────────────────
+
+
+def synthesize_files(target_dir: Path, total_mb: int,
+                     n_files: int) -> tuple[list[Path], int]:
+    """Create ``n_files`` files in ``target_dir`` summing to ~``total_mb``.
+
+    Each file gets the same fixed-size random buffer (seeded). Hashing
+    speed is independent of payload entropy, so we don't bother
+    re-randomising per file. Idempotent — existing files are reused.
+    """
+    target_dir.mkdir(parents=True, exist_ok=True)
+    per_file = max(1, (total_mb * 1024 * 1024) // n_files)
+
+    rng = random.Random(42)
+    payload = bytes(rng.getrandbits(8) for _ in range(min(per_file, 1024 * 1024)))
+    # Stretch payload up to per_file size by tiling — the hash still
+    # processes per_file bytes, but we don't keep a 100 MB Python bytes
+    # object in RAM longer than needed.
+    paths: list[Path] = []
+    total_bytes = 0
+    for i in range(n_files):
+        p = target_dir / f"dedup_{total_mb}mb_{i:04d}.bin"
+        if p.exists() and p.stat().st_size == per_file:
+            paths.append(p)
+            total_bytes += per_file
+            continue
+        with open(p, "wb") as fh:
+            written = 0
+            while written < per_file:
+                chunk = payload[: min(len(payload), per_file - written)]
+                fh.write(chunk)
+                written += len(chunk)
+        paths.append(p)
+        total_bytes += per_file
+    return paths, total_bytes
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Hash loop
+# ──────────────────────────────────────────────────────────────────────
+
+
+def _hash_files(paths: list[Path], total_bytes: int,
+                chunk_size: int = 1 << 20) -> dict:
+    """Hash every file with sha256 streaming, return MB/s."""
+    digest_count = 0
+    t0 = time.perf_counter()
+    for p in paths:
+        h = hashlib.sha256()
+        with open(p, "rb") as fh:
+            while True:
+                buf = fh.read(chunk_size)
+                if not buf:
+                    break
+                h.update(buf)
+        h.hexdigest()
+        digest_count += 1
+    elapsed = time.perf_counter() - t0
+    mb = total_bytes / (1024 * 1024)
+    mbps = mb / elapsed if elapsed > 0 else 0.0
+    hps = digest_count / elapsed if elapsed > 0 else 0.0
+    return {
+        "throughput_value": mbps,
+        "throughput_unit": "MB/s",
+        "extra": {
+            "files": digest_count,
+            "hashes_per_sec": round(hps, 2),
+            "scanned_bytes": total_bytes,
+        },
+    }
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Main
+# ──────────────────────────────────────────────────────────────────────
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Benchmark SHA-256 dedup hashing path (issue #70)."
+    )
+    parser.add_argument("--corpus-size", type=int, default=100,
+                        help="Total fixture size in MB (default: 100)")
+    parser.add_argument("--files", type=int, default=32,
+                        help="Number of fixture files (default: 32)")
+    parser.add_argument("--repeats", type=int, default=5,
+                        help="Measured repeats (default: 5)")
+    parser.add_argument("--warmup", type=int, default=1,
+                        help="Unmeasured warmup runs (default: 1)")
+    parser.add_argument("--tmpdir", default=None,
+                        help="Override tmpdir (default: system tmp)")
+    parser.add_argument("--history", default="bench_history.jsonl",
+                        help="JSONL history file (pass '' to disable)")
+    args = parser.parse_args(argv)
+
+    sha_info = detect_sha_ni()
+    print(
+        f"[bench_dedup] sha-ni detection: cpuinfo_sha_ni={sha_info['cpuinfo_sha_ni']} "
+        f"sha256_in_guaranteed={sha_info['sha256_in_guaranteed']} "
+        f"platform={sha_info['platform']}"
+    )
+
+    tmp_root = Path(args.tmpdir) if args.tmpdir else Path(
+        tempfile.gettempdir()
+    ) / "file_activity_bench_dedup"
+
+    paths, total_bytes = synthesize_files(
+        tmp_root, args.corpus_size, args.files
+    )
+    print(
+        f"[bench_dedup] corpus files={len(paths)} total_bytes={total_bytes:,} "
+        f"per_file={total_bytes // len(paths):,} dir={tmp_root}"
+    )
+
+    bench = Bench()
+    bench.run(
+        name="dedup_sha256_streaming",
+        fn=lambda: _hash_files(paths, total_bytes),
+        repeats=args.repeats,
+        warmup=args.warmup,
+        throughput_unit="MB/s",
+        extra={
+            "sha_ni_detected": bool(sha_info.get("cpuinfo_sha_ni")),
+            "platform": sha_info["platform"],
+        },
+    )
+
+    table = print_table(bench.results)
+
+    summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
+    if summary_path:
+        try:
+            with open(summary_path, "a", encoding="utf-8") as fh:
+                fh.write("## Dedup hashing benchmark\n\n")
+                fh.write(table + "\n")
+        except OSError as exc:  # pragma: no cover - CI-only
+            print(f"[warn] could not write step summary: {exc}", file=sys.stderr)
+
+    if args.history:
+        wrote = append_history(bench.results, path=args.history)
+        print(f"[bench_dedup] appended {wrote} rows to {args.history}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/bench/bench_pii.py
+++ b/tests/bench/bench_pii.py
@@ -1,0 +1,416 @@
+"""Benchmark the PII engine — validates the issue #66 5x claim.
+
+Generates a deterministic ~``corpus_size`` MB text corpus in a tmpdir
+once per process (random words seeded with ``random.seed(42)``) with
+known fixture counts injected at known positions:
+
+* 10,000 emails
+* 5,000 TR IBANs
+* 2,000 TCKNs (Turkish national-id numbers)
+
+The PII engine is then run end-to-end via ``PiiEngine.scan_source``
+against an in-memory SQLite stub that satisfies the engine's
+``get_cursor`` contract — schema is tiny, just enough to let the
+engine select files for a fake ``source_id`` / ``scan_id`` pair and
+write findings back.
+
+We time the run with both backends (stdlib ``re`` + Hyperscan when the
+optional ``hyperscan`` package is importable). The reported throughput
+is MB/s (corpus bytes scanned divided by wall time) and matches/sec.
+
+Usage::
+
+    python -m tests.bench.bench_pii \
+        [--corpus-size 100] [--repeats 5] \
+        [--history bench_history.jsonl]
+
+The default 100 MB corpus runs in well under a minute on every backend
+on commodity hardware. Idempotent — same MB count gives the same
+content, so successive runs produce numbers comparable to the JSONL
+history.
+"""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import os
+import random
+import string
+import sys
+import sqlite3
+import tempfile
+import time
+from pathlib import Path
+from typing import Optional
+
+# Add project root to path when invoked directly so ``src.compliance...``
+# imports resolve without an editable install.
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from src.compliance._pii_backends import (  # noqa: E402
+    hyperscan_available,
+    make_backend,
+)
+from src.compliance.pii_engine import PiiEngine  # noqa: E402
+from tests.bench._runner import (  # noqa: E402
+    Bench,
+    append_history,
+    print_table,
+)
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Deterministic corpus generator
+# ──────────────────────────────────────────────────────────────────────
+
+
+# Realistic-ish TR IBAN (TR + 2 check digits + 22 digits). Values are
+# fake (no real bank prefix) but match the regex shape used by
+# ``DEFAULT_PATTERNS["iban_tr"]``. We mint them deterministically below.
+def _make_email(rng: random.Random) -> str:
+    name = "".join(rng.choices(string.ascii_lowercase, k=rng.randint(5, 10)))
+    domain = "".join(rng.choices(string.ascii_lowercase, k=rng.randint(4, 8)))
+    return f"{name}@{domain}.com"
+
+
+def _make_iban(rng: random.Random) -> str:
+    body = "".join(rng.choices(string.digits, k=24))
+    return f"TR{body}"
+
+
+def _make_tckn(rng: random.Random) -> str:
+    # 11 digits, no leading zero so the \b...\b match latches cleanly.
+    first = rng.choice("123456789")
+    rest = "".join(rng.choices(string.digits, k=10))
+    return first + rest
+
+
+def _make_word(rng: random.Random) -> str:
+    return "".join(rng.choices(string.ascii_lowercase, k=rng.randint(3, 9)))
+
+
+# Per-corpus fixture counts — kept proportional to size so a 50 MB run
+# scales down sensibly while still producing enough matches for the
+# matches/sec figure to be meaningful.
+def _fixture_counts(corpus_mb: int) -> dict[str, int]:
+    scale = max(1.0, corpus_mb / 100.0)
+    return {
+        "emails": int(10_000 * scale),
+        "ibans": int(5_000 * scale),
+        "tckns": int(2_000 * scale),
+    }
+
+
+def generate_corpus(target_dir: Path, corpus_mb: int) -> tuple[Path, dict]:
+    """Write ``target_dir / corpus.txt`` of approximately ``corpus_mb`` MB.
+
+    Returns the file path and a dict describing the fixture counts and
+    actual byte size. Idempotent: if the file already exists at the
+    requested size (within 1%), it is reused as-is — successive runs in
+    the same tmpdir do not pay the regeneration cost.
+    """
+    counts = _fixture_counts(corpus_mb)
+    corpus_path = target_dir / f"corpus_{corpus_mb}mb.txt"
+    target_bytes = corpus_mb * 1024 * 1024
+
+    if corpus_path.exists():
+        actual = corpus_path.stat().st_size
+        if abs(actual - target_bytes) <= max(1, target_bytes // 100):
+            return corpus_path, {
+                "size_bytes": actual,
+                "fixtures": counts,
+                "regenerated": False,
+            }
+
+    rng = random.Random(42)
+
+    # Pre-mint fixtures up front so we know the exact strings to inject.
+    # Stored as a flat shuffled list of (kind, value).
+    fixtures: list[tuple[str, str]] = []
+    for _ in range(counts["emails"]):
+        fixtures.append(("email", _make_email(rng)))
+    for _ in range(counts["ibans"]):
+        fixtures.append(("iban", _make_iban(rng)))
+    for _ in range(counts["tckns"]):
+        fixtures.append(("tckn", _make_tckn(rng)))
+    rng.shuffle(fixtures)
+
+    # Estimate how many lines we'll produce so fixtures sprinkle evenly
+    # across the whole corpus rather than clumping at the start. Average
+    # line is ~11 words * 6 chars + spaces ~= 80 bytes.
+    avg_line_bytes = 80
+    estimated_lines = max(len(fixtures) + 1, target_bytes // avg_line_bytes)
+    inject_every = max(1, estimated_lines // max(1, len(fixtures)))
+
+    # Write line-by-line to avoid a multi-hundred-MB Python string in
+    # RAM. Each line is ~10 random words; every ``inject_every`` lines
+    # carries one fixture so they're sprinkled evenly through the
+    # corpus, matching the realistic pattern of PII appearing inline.
+    fix_idx = 0
+    line_idx = 0
+    written = 0
+    with open(corpus_path, "w", encoding="utf-8", newline="\n") as fh:
+        while written < target_bytes:
+            words = [_make_word(rng) for _ in range(rng.randint(8, 14))]
+            if fix_idx < len(fixtures) and (line_idx % inject_every) == 0:
+                _, value = fixtures[fix_idx]
+                # Splice into the middle of the line so word boundaries
+                # are clean on both sides.
+                mid = len(words) // 2
+                words.insert(mid, value)
+                fix_idx += 1
+
+            line = " ".join(words) + "\n"
+            fh.write(line)
+            written += len(line.encode("utf-8"))
+            line_idx += 1
+
+        # Append any remaining unused fixtures so the total count is
+        # exact — guards against the case where the actual line average
+        # ran shorter than the 80-byte estimate.
+        while fix_idx < len(fixtures):
+            _, value = fixtures[fix_idx]
+            fh.write(value + "\n")
+            fix_idx += 1
+
+    actual = corpus_path.stat().st_size
+    return corpus_path, {
+        "size_bytes": actual,
+        "fixtures": counts,
+        "regenerated": True,
+    }
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Minimal in-memory DB stub satisfying PiiEngine's contract
+# ──────────────────────────────────────────────────────────────────────
+
+
+class _MiniDb:
+    """Just enough of the project ``Database`` to drive ``scan_source``.
+
+    The PII engine only touches three tables: ``scan_runs``,
+    ``scanned_files`` and ``pii_findings``. We create them in a private
+    sqlite ``:memory:`` connection and expose the project's
+    ``get_cursor`` context manager. Rows are dict-like (sqlite3.Row) so
+    ``row["id"]`` works the same way the real DB returns them.
+    """
+
+    def __init__(self) -> None:
+        self._conn = sqlite3.connect(":memory:")
+        self._conn.row_factory = sqlite3.Row
+        cur = self._conn.cursor()
+        cur.executescript(
+            """
+            CREATE TABLE scan_runs (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                source_id INTEGER NOT NULL,
+                started_at TEXT,
+                status TEXT
+            );
+            CREATE TABLE scanned_files (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                source_id INTEGER NOT NULL,
+                scan_id INTEGER NOT NULL,
+                file_path TEXT NOT NULL,
+                last_modify_time TEXT,
+                owner TEXT
+            );
+            CREATE TABLE pii_findings (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                scan_id INTEGER NOT NULL,
+                file_path TEXT NOT NULL,
+                pattern_name TEXT NOT NULL,
+                hit_count INTEGER NOT NULL,
+                sample_snippet TEXT,
+                detected_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+            );
+            """
+        )
+        self._conn.commit()
+
+    @contextlib.contextmanager
+    def get_cursor(self):
+        cur = self._conn.cursor()
+        try:
+            yield cur
+            self._conn.commit()
+        finally:
+            cur.close()
+
+    def seed(self, source_id: int, file_paths: list[str]) -> int:
+        """Insert a fresh scan_run + the given files. Returns scan_id."""
+        with self.get_cursor() as cur:
+            cur.execute(
+                "INSERT INTO scan_runs (source_id, started_at, status) "
+                "VALUES (?, ?, ?)",
+                (source_id, time.strftime("%Y-%m-%d %H:%M:%S"), "completed"),
+            )
+            scan_id = int(cur.lastrowid)
+            cur.executemany(
+                "INSERT INTO scanned_files (source_id, scan_id, file_path) "
+                "VALUES (?, ?, ?)",
+                [(source_id, scan_id, p) for p in file_paths],
+            )
+        return scan_id
+
+    def reset_findings(self) -> None:
+        with self.get_cursor() as cur:
+            cur.execute("DELETE FROM pii_findings")
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Benchmark harness
+# ──────────────────────────────────────────────────────────────────────
+
+
+def _run_backend(
+    backend_name: str,
+    corpus_path: Path,
+    corpus_bytes: int,
+) -> dict:
+    """Single benchmark iteration: scan ``corpus_path`` end-to-end.
+
+    Builds a fresh ``PiiEngine`` (which constructs the requested backend
+    via :func:`make_backend`) and a fresh in-memory DB seeded with one
+    row pointing at the corpus file. Returns throughput + match-count
+    payload consumed by ``Bench.run``.
+    """
+    db = _MiniDb()
+    scan_id = db.seed(source_id=1, file_paths=[str(corpus_path)])
+
+    config = {
+        "compliance": {
+            "pii": {
+                "enabled": True,
+                "engine": backend_name,
+                # Generous file cap so the entire corpus is scanned.
+                "max_file_bytes": corpus_bytes + 1,
+                # Allow .txt — the default allowlist already includes it
+                # but be explicit for clarity.
+                "text_extensions": ["txt"],
+            }
+        }
+    }
+    engine = PiiEngine(db, config)
+
+    t0 = time.perf_counter()
+    summary = engine.scan_source(source_id=1, scan_id=scan_id,
+                                  overwrite_existing=True)
+    elapsed = time.perf_counter() - t0
+
+    mb = corpus_bytes / (1024 * 1024)
+    throughput = mb / elapsed if elapsed > 0 else 0.0
+    matches = int(summary.get("hits_total", 0))
+    matches_per_sec = matches / elapsed if elapsed > 0 else 0.0
+
+    return {
+        "throughput_value": throughput,
+        "throughput_unit": "MB/s",
+        "extra": {
+            "backend": engine.engine_name,
+            "matches": matches,
+            "matches_per_sec": round(matches_per_sec, 1),
+            "scanned_bytes": corpus_bytes,
+        },
+    }
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Benchmark PII engine backends (issue #66 / #70)."
+    )
+    parser.add_argument("--corpus-size", type=int, default=100,
+                        help="Corpus size in MB (default: 100)")
+    parser.add_argument("--repeats", type=int, default=5,
+                        help="Measured repeats per backend (default: 5)")
+    parser.add_argument("--warmup", type=int, default=1,
+                        help="Unmeasured warmup runs (default: 1)")
+    parser.add_argument(
+        "--history", default="bench_history.jsonl",
+        help="JSONL history file to append to (default: bench_history.jsonl). "
+             "Pass '' to disable.",
+    )
+    parser.add_argument("--tmpdir", default=None,
+                        help="Override tmpdir for the corpus (default: system tmp)")
+    args = parser.parse_args(argv)
+
+    tmp_root = Path(args.tmpdir) if args.tmpdir else Path(
+        tempfile.gettempdir()
+    ) / "file_activity_bench_pii"
+    tmp_root.mkdir(parents=True, exist_ok=True)
+
+    print(f"[bench_pii] corpus_size={args.corpus_size} MB tmpdir={tmp_root}")
+    corpus_path, info = generate_corpus(tmp_root, args.corpus_size)
+    print(
+        f"[bench_pii] corpus={corpus_path} bytes={info['size_bytes']:,} "
+        f"fixtures={info['fixtures']} regenerated={info['regenerated']}"
+    )
+
+    bench = Bench()
+
+    # Always run stdlib re — that's the baseline.
+    bench.run(
+        name="pii_re",
+        fn=lambda: _run_backend("re", corpus_path, info["size_bytes"]),
+        repeats=args.repeats,
+        warmup=args.warmup,
+        throughput_unit="MB/s",
+    )
+
+    # Hyperscan is optional. Skip cleanly when the package isn't
+    # importable so the harness still works on Windows / sandbox hosts.
+    if hyperscan_available():
+        bench.run(
+            name="pii_hyperscan",
+            fn=lambda: _run_backend("hyperscan", corpus_path, info["size_bytes"]),
+            repeats=args.repeats,
+            warmup=args.warmup,
+            throughput_unit="MB/s",
+        )
+    else:
+        bench.skip(
+            "pii_hyperscan",
+            "hyperscan package not importable; run "
+            "`pip install -r requirements-accel.txt`",
+        )
+
+    # Rendered table for stdout / GH step summary.
+    table = print_table(bench.results)
+
+    # 5x speedup callout — directly validates the #66 claim.
+    re_res = next((r for r in bench.results if r.name == "pii_re"), None)
+    hs_res = next(
+        (r for r in bench.results
+         if r.name == "pii_hyperscan" and not r.extra.get("skipped")),
+        None,
+    )
+    if re_res and hs_res and hs_res.median_ms > 0:
+        speedup = re_res.median_ms / hs_res.median_ms
+        verdict = "PASS" if speedup >= 5.0 else "BELOW TARGET"
+        print(
+            f"[bench_pii] hyperscan/re speedup = {speedup:.2f}x ({verdict} vs 5x claim)"
+        )
+
+    # GH Actions step summary — same markdown table, no duplication.
+    summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
+    if summary_path:
+        try:
+            with open(summary_path, "a", encoding="utf-8") as fh:
+                fh.write("## PII engine benchmark\n\n")
+                fh.write(table + "\n")
+        except OSError as exc:  # pragma: no cover - CI-only path
+            print(f"[warn] could not write step summary: {exc}", file=sys.stderr)
+
+    if args.history:
+        wrote = append_history(bench.results, path=args.history)
+        print(f"[bench_pii] appended {wrote} rows to {args.history}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/bench/bench_scanner.py
+++ b/tests/bench/bench_scanner.py
@@ -1,0 +1,311 @@
+"""Benchmark the scanner backends side-by-side.
+
+Synthesizes a directory tree with ``(N, fanout)`` controls so each
+backend walks an identical layout. The tree lives on tmpfs
+(``/dev/shm`` on Linux) when available — that removes disk-cache
+warm-up effects, which is the dominant noise source on a cold-cache
+``/tmp`` run.
+
+Backends that are Windows-only (``win32_find_ex``, ``ntfs_mft``,
+``ntfs_usn_tail``) raise ``RuntimeError`` on construction outside of
+Windows; they are recorded as ``skipped`` rows in the result table so
+their absence is visible rather than silent.
+
+Reports files/sec — the only throughput unit that's apples-to-apples
+across the four backends since some don't return file size or
+timestamps at all (``ntfs_mft``).
+
+Usage::
+
+    python -m tests.bench.bench_scanner \
+        [--files 10000] [--fanout 10] \
+        [--repeats 3] [--history bench_history.jsonl]
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import shutil
+import sys
+import tempfile
+import time
+from pathlib import Path
+from typing import Optional
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from tests.bench._runner import (  # noqa: E402
+    Bench,
+    append_history,
+    print_table,
+)
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Tree synthesis
+# ──────────────────────────────────────────────────────────────────────
+
+
+def _pick_tmp_root(prefer_shm: bool = True) -> Path:
+    """Prefer ``/dev/shm`` (tmpfs) when writable so we measure walk
+    speed, not disk seek latency. Falls back to the system tmpdir.
+    """
+    if prefer_shm:
+        shm = Path("/dev/shm")
+        if shm.exists() and os.access(shm, os.W_OK):
+            return shm / "file_activity_bench_scanner"
+    return Path(tempfile.gettempdir()) / "file_activity_bench_scanner"
+
+
+def synthesize_tree(root: Path, files: int, fanout: int) -> dict:
+    """Create ``files`` empty regular files under ``root`` arranged so
+    each directory has at most ``fanout`` children.
+
+    The shape is a balanced N-ary tree of depth ``ceil(log_fanout(files))``
+    with leaves containing the actual files. Empty files are fine —
+    every backend we measure pays the cost of the ``stat()`` call, and
+    file-size readout is a few cycles next to the FS round-trip.
+
+    Idempotent: existing trees with the right file count are reused.
+    """
+    marker = root / f".tree_{files}_{fanout}"
+    if marker.exists():
+        return {
+            "root": str(root),
+            "files": files,
+            "fanout": fanout,
+            "regenerated": False,
+        }
+
+    if root.exists():
+        shutil.rmtree(root)
+    root.mkdir(parents=True, exist_ok=True)
+
+    # Depth needed so that fanout**depth >= files when each leaf dir
+    # holds up to ``fanout`` files. We split per level so dir count
+    # also scales with fanout (otherwise a single deep-but-narrow dir
+    # makes the SMB-parallel backend look like a serial walker).
+    fan = max(2, int(fanout))
+    depth = 1
+    while fan ** depth < files:
+        depth += 1
+        if depth > 8:  # pragma: no cover - safety net
+            break
+
+    created = 0
+
+    def _populate(dir_path: Path, level: int) -> None:
+        nonlocal created
+        if created >= files:
+            return
+        if level == depth:
+            # Leaf directory — drop up to fanout files here.
+            for i in range(fan):
+                if created >= files:
+                    return
+                p = dir_path / f"file_{created:07d}.txt"
+                p.touch()
+                created += 1
+            return
+        for i in range(fan):
+            if created >= files:
+                return
+            sub = dir_path / f"d{level}_{i}"
+            sub.mkdir(exist_ok=True)
+            _populate(sub, level + 1)
+
+    _populate(root, 1)
+
+    marker.touch()
+    return {
+        "root": str(root),
+        "files": created,
+        "fanout": fan,
+        "depth": depth,
+        "regenerated": True,
+    }
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Backend invokers
+# ──────────────────────────────────────────────────────────────────────
+
+
+def _measure_walk(walker, root: str, expected: int) -> dict:
+    """Drain a backend's ``walk(root)`` iterator and report files/sec."""
+    t0 = time.perf_counter()
+    count = 0
+    for _row in walker.walk(root):
+        count += 1
+    elapsed = time.perf_counter() - t0
+    fps = count / elapsed if elapsed > 0 else 0.0
+    return {
+        "throughput_value": fps,
+        "throughput_unit": "files/s",
+        "extra": {
+            "files_walked": count,
+            "expected_files": expected,
+            "elapsed_s": round(elapsed, 4),
+        },
+    }
+
+
+def _bench_smb_parallel(bench: Bench, root: str, expected: int,
+                        repeats: int, warmup: int, workers: int) -> None:
+    try:
+        from src.scanner.backends.smb_parallel import SmbParallelBackend
+    except Exception as exc:
+        bench.skip("scanner_smb_parallel", f"import failed: {exc}")
+        return
+
+    backend = SmbParallelBackend({
+        "scanner": {
+            "smb_workers": workers,
+            "skip_hidden": False,  # don't skip our marker file
+            "skip_system": False,
+            "read_owner": False,
+            "exclude_patterns": [],
+        }
+    })
+    bench.run(
+        name="scanner_smb_parallel",
+        fn=lambda: _measure_walk(backend, root, expected),
+        repeats=repeats,
+        warmup=warmup,
+        throughput_unit="files/s",
+        extra={"workers": workers},
+    )
+
+
+def _bench_win32_find_ex(bench: Bench, root: str, expected: int,
+                         repeats: int, warmup: int) -> None:
+    if sys.platform != "win32":
+        bench.skip(
+            "scanner_win32_find_ex",
+            "Windows-only backend; sys.platform != 'win32'",
+        )
+        return
+    try:
+        from src.scanner.backends.win32_find_ex import Win32FindExBackend
+    except Exception as exc:
+        bench.skip("scanner_win32_find_ex", f"import failed: {exc}")
+        return
+    try:
+        backend = Win32FindExBackend({"scanner": {}})
+    except Exception as exc:
+        bench.skip("scanner_win32_find_ex", f"init failed: {exc}")
+        return
+    bench.run(
+        name="scanner_win32_find_ex",
+        fn=lambda: _measure_walk(backend, root, expected),
+        repeats=repeats,
+        warmup=warmup,
+        throughput_unit="files/s",
+    )
+
+
+def _bench_ntfs_mft(bench: Bench, root: str, expected: int,
+                    repeats: int, warmup: int) -> None:
+    if sys.platform != "win32":
+        bench.skip(
+            "scanner_ntfs_mft",
+            "Windows + admin + local NTFS volume required",
+        )
+        return
+    try:
+        from src.scanner.backends.ntfs_mft import NtfsMftBackend
+    except Exception as exc:
+        bench.skip("scanner_ntfs_mft", f"import failed: {exc}")
+        return
+    try:
+        backend = NtfsMftBackend({"scanner": {}})
+    except Exception as exc:
+        bench.skip("scanner_ntfs_mft", f"init failed: {exc}")
+        return
+    bench.run(
+        name="scanner_ntfs_mft",
+        fn=lambda: _measure_walk(backend, root, expected),
+        repeats=repeats,
+        warmup=warmup,
+        throughput_unit="files/s",
+    )
+
+
+def _bench_ntfs_usn_tail(bench: Bench, root: str, expected: int,
+                         repeats: int, warmup: int) -> None:
+    # USN tail is incremental, not an enumeration backend — there's no
+    # apples-to-apples ``walk(root)`` comparison to make. Skip it
+    # explicitly so the row exists in the table for transparency.
+    bench.skip(
+        "scanner_ntfs_usn_tail",
+        "incremental backend; no enumeration comparison available",
+    )
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Main
+# ──────────────────────────────────────────────────────────────────────
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Benchmark scanner backends side-by-side (issue #70)."
+    )
+    parser.add_argument("--files", type=int, default=10_000,
+                        help="Number of files to synthesize (default: 10000)")
+    parser.add_argument("--fanout", type=int, default=10,
+                        help="Children per directory (default: 10)")
+    parser.add_argument("--repeats", type=int, default=3,
+                        help="Measured repeats per backend (default: 3)")
+    parser.add_argument("--warmup", type=int, default=1,
+                        help="Unmeasured warmup runs (default: 1)")
+    parser.add_argument("--workers", type=int, default=16,
+                        help="Thread pool size for smb_parallel (default: 16)")
+    parser.add_argument("--no-shm", action="store_true",
+                        help="Skip /dev/shm even if available")
+    parser.add_argument("--history", default="bench_history.jsonl",
+                        help="JSONL history file (pass '' to disable)")
+    args = parser.parse_args(argv)
+
+    tmp_root = _pick_tmp_root(prefer_shm=not args.no_shm)
+    print(f"[bench_scanner] tmp_root={tmp_root}")
+
+    info = synthesize_tree(tmp_root, args.files, args.fanout)
+    print(
+        f"[bench_scanner] tree files={info['files']} fanout={info['fanout']} "
+        f"depth={info.get('depth', '?')} regenerated={info['regenerated']}"
+    )
+
+    bench = Bench()
+    _bench_smb_parallel(bench, str(tmp_root), info["files"],
+                        args.repeats, args.warmup, args.workers)
+    _bench_win32_find_ex(bench, str(tmp_root), info["files"],
+                         args.repeats, args.warmup)
+    _bench_ntfs_mft(bench, str(tmp_root), info["files"],
+                    args.repeats, args.warmup)
+    _bench_ntfs_usn_tail(bench, str(tmp_root), info["files"],
+                         args.repeats, args.warmup)
+
+    table = print_table(bench.results)
+
+    summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
+    if summary_path:
+        try:
+            with open(summary_path, "a", encoding="utf-8") as fh:
+                fh.write("## Scanner backend benchmark\n\n")
+                fh.write(table + "\n")
+        except OSError as exc:  # pragma: no cover - CI-only
+            print(f"[warn] could not write step summary: {exc}", file=sys.stderr)
+
+    if args.history:
+        wrote = append_history(bench.results, path=args.history)
+        print(f"[bench_scanner] appended {wrote} rows to {args.history}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- **`tests/bench/`**: stdlib-only harness with `_runner.py` (`Bench.run` → median+p95, `print_table`, `append_history`), and three benchmarks: `bench_pii.py` (deterministic 100 MB text corpus with seeded fixtures), `bench_scanner.py` (synthesised tree on `/dev/shm`), `bench_dedup.py` (SHA-256 throughput + SHA-NI probe).
- **`.github/workflows/bench.yml`**: `workflow_dispatch` only, posts the markdown table to `$GITHUB_STEP_SUMMARY`. Won't run on every PR.
- **`tests/bench/README.md`**: how to run, JSON history schema, regression-tracking guidance.
- **`.gitignore`**: `bench_history.jsonl`.

## ⚠️ Finding: PR #66 Hyperscan claim is unverified on this hardware
Sandbox results on a 100 MB corpus, 3 repeats:

| Backend | Median ms | MB/s |
|---|---:|---:|
| pii_re | 10155.72 | 9.85 |
| pii_hyperscan | 10453.53 | 9.99 |

**Speedup = 0.97×** (i.e. parity, not 5×). Root cause: `_pii_backends.HyperscanBackend.compile()` raises `Pattern is too large` for **every** default pattern because `HS_FLAG_UTF8 | HS_FLAG_UCP | HS_FLAG_CASELESS` expands `\w` into a huge Unicode class. The per-pattern fallback then routes 5/5 patterns through stdlib `re`, so `pii_hyperscan` is effectively `pii_re` plus a tiny dispatch overhead.

The harness made this visible — exactly what it's for. Filing follow-up issue to either drop UCP for non-Unicode-sensitive patterns or restructure the compile path.

## Other findings
- **SHA-NI detected and active**: `/proc/cpuinfo` has `sha_ni`; `bench_dedup.py` measured **674 MB/s** on a 50 MB / 16-file corpus.
- Skipped on Linux: `scanner_win32_find_ex`, `scanner_ntfs_mft`, `scanner_ntfs_usn_tail` (Windows-only / incremental).

## Test plan
- [x] `python -m tests.bench.bench_pii` runs cleanly, produces results above.
- [x] Pytest collection: 220 tests collected, **zero from `tests/bench/`** (harness is not auto-discovered as tests).
- [x] `bench_history.jsonl` accumulates rows on each run.

https://claude.ai/code/session_3da9da4f-9a75-411a-8d33-57e188ae2dd7

---
_Generated by [Claude Code](https://claude.ai/code/session_01A1UzS1A4DZNk1akoP4uhZ7)_