### PR TITLE
SQLite auto-backup Phase 1 (closes #77 Phase 1)

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -6,6 +6,22 @@ general:
   log_level: "INFO"
   log_file: "logs/file_activity.log"
 
+backup:
+  # Issue #77 — auto-backup for the SQLite DB.
+  # Snapshots use VACUUM INTO so they're safe under WAL (no exclusive
+  # lock). Daily snapshot job + pre-archive/retention/update hooks.
+  enabled: true
+  dir: "data/backups"
+  keep_last_n: 10                 # Daily-rotation budget
+  keep_weekly: 4                  # Plus the first snapshot of each of the last N ISO weeks
+  daily_snapshot_hour: 2          # 24h, 0-23 (cron "0 H * * *")
+  snapshot_on_update: true        # update.cmd takes a snapshot before reinstall
+  snapshot_on_apply: true         # ArchiveEngine + RetentionEngine snapshot before non-dry-run
+  # Phase 2 placeholder — DO NOT enable. Auto-restore on corruption is
+  # not implemented yet; the field exists so config parses cleanly when
+  # Phase 2 lands. See issue #77.
+  auto_restore_on_corruption: false
+
 database:
   path: "data/file_activity.db"    # SQLite veritabani dosyasi
   retention:

--- a/deploy/setup-source.ps1
+++ b/deploy/setup-source.ps1
@@ -276,9 +276,17 @@ Set-Content "$InstallDir\start_dashboard.cmd" $dashCmd
 
 # Update launcher: ayni script'i tekrar cagirir (guncelleme)
 # Eski PowerShell'lerde TLS 1.2'yi onceden set etmek zorunlu (irm basarisiz olmasin)
+# Issue #77: update'ten ONCE SQLite snapshot al — guncelleme bozulursa
+# operator hizlica geri donebilir. Snapshot basarisiz olsa bile update
+# devam eder (snapshot olmadan da olabilir, ama update durmamali).
 $updateCmd = @"
 @echo off
 echo FILE ACTIVITY guncelleniyor (master branch)...
+echo  - Pre-update SQLite snapshot aliniyor...
+"%LOCALAPPDATA%\FileActivity\.venv\Scripts\python.exe" -m src.storage.backup_manager snapshot --reason "update" 2>NUL
+if errorlevel 1 (
+    echo  [!] Snapshot basarisiz - update yine de devam ediyor
+)
 powershell -ExecutionPolicy Bypass -Command "[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; irm https://raw.githubusercontent.com/$RepoOwner/$RepoName/$Branch/deploy/setup-source.ps1 | iex"
 "@
 Set-Content "$InstallDir\update.cmd" $updateCmd

--- a/src/archiver/archive_engine.py
+++ b/src/archiver/archive_engine.py
@@ -51,6 +51,14 @@ class ArchiveEngine:
         """
         is_dry_run = dry_run if dry_run is not None else self.dry_run
 
+        # Issue #77: pre-apply SQLite snapshot. Runs only on real
+        # (non-dry-run) operations and only if backup.snapshot_on_apply
+        # is true. Failure NEVER aborts the archive — we log + continue
+        # because losing a backup is much less bad than blocking the
+        # operator's archive batch on a transient backup error.
+        if not is_dry_run:
+            self._maybe_pre_apply_snapshot(reason="pre-archive")
+
         # Arsiv islemi kaydi olustur
         op_id = None
         if not is_dry_run:
@@ -288,6 +296,31 @@ class ArchiveEngine:
             self._cleanup_empty_parents(os.path.dirname(src_path), source_unc)
 
         return True
+
+    def _maybe_pre_apply_snapshot(self, reason: str) -> None:
+        """Issue #77: take a SQLite snapshot before a real archive run.
+
+        Honours ``config.backup.snapshot_on_apply`` (default true). All
+        failures are caught + logged — the archive operation must
+        proceed even if backup is unavailable.
+        """
+        backup_cfg = (self.config or {}).get("backup") or {}
+        if not backup_cfg.get("snapshot_on_apply", True):
+            return
+        if not backup_cfg.get("enabled", True):
+            return
+        try:
+            db_path = (
+                (self.config or {}).get("database", {}).get("path")
+                or "data/file_activity.db"
+            )
+            from src.storage.backup_manager import BackupManager
+            BackupManager(db_path, self.config).snapshot(reason=reason)
+        except Exception as e:
+            logger.error(
+                "pre-apply snapshot failed (%s) — continuing archive: %s",
+                reason, e, exc_info=True,
+            )
 
     def _sha256(self, path: str) -> str:
         """SHA-256 checksum hesapla."""

--- a/src/compliance/retention.py
+++ b/src/compliance/retention.py
@@ -41,6 +41,9 @@ class RetentionEngine:
     def __init__(self, db, config: dict, archive_engine=None):
         self.db = db
         self.archive_engine = archive_engine
+        # Issue #77: keep the full config so we can drive the backup
+        # snapshot hook from ``apply()``.
+        self._full_config = config or {}
         cfg = ((config or {}).get("compliance", {}) or {}).get("retention", {}) or {}
         self.enabled = bool(cfg.get("enabled", False))
         # Default destination if a policy doesn't carry its own (rare).
@@ -236,6 +239,11 @@ class RetentionEngine:
                 "elapsed_seconds": round(elapsed, 3),
             }
 
+        # Issue #77: pre-apply SQLite snapshot (real run only). Failure
+        # logs ERROR but never aborts the retention sweep — we never
+        # want backup-system trouble to block GDPR-driven purges.
+        self._maybe_pre_apply_snapshot(reason=f"pre-retention:{policy_name}")
+
         # Real run.
         if action == "archive":
             if self.archive_engine is None:
@@ -295,6 +303,35 @@ class RetentionEngine:
             "dry_run": False,
             "elapsed_seconds": round(elapsed, 3),
         }
+
+    # ──────────────────────────────────────────────
+    # Issue #77: pre-apply SQLite backup hook
+    # ──────────────────────────────────────────────
+
+    def _maybe_pre_apply_snapshot(self, reason: str) -> None:
+        """Take a SQLite snapshot before mutating retention runs.
+
+        Honours ``config.backup.snapshot_on_apply`` (default True). All
+        failures are caught + logged so retention proceeds on best
+        effort.
+        """
+        backup_cfg = (self._full_config or {}).get("backup") or {}
+        if not backup_cfg.get("snapshot_on_apply", True):
+            return
+        if not backup_cfg.get("enabled", True):
+            return
+        try:
+            db_path = (
+                (self._full_config or {}).get("database", {}).get("path")
+                or "data/file_activity.db"
+            )
+            from src.storage.backup_manager import BackupManager
+            BackupManager(db_path, self._full_config).snapshot(reason=reason)
+        except Exception as e:
+            logger.error(
+                "pre-retention snapshot failed (%s) — continuing: %s",
+                reason, e, exc_info=True,
+            )
 
     # ──────────────────────────────────────────────
     # Attestation

--- a/src/scheduler/task_scheduler.py
+++ b/src/scheduler/task_scheduler.py
@@ -28,6 +28,10 @@ class TaskScheduler:
     def start(self):
         """Scheduler'ı başlat ve veritabanındaki görevleri yükle."""
         self._load_tasks()
+        # Issue #77: register the daily SQLite backup job from config.
+        # This is config-driven (not stored in scheduled_tasks) so it
+        # works on fresh installs without a manual setup step.
+        self._register_daily_backup_job()
         self.scheduler.start()
         logger.info("TaskScheduler başlatıldı")
 
@@ -92,6 +96,9 @@ class TaskScheduler:
             elif task_type == "audit_export":
                 # Issue #38: WORM export of hash-chained audit log.
                 result = self._run_audit_export(task)
+            elif task_type == "daily_backup":
+                # Issue #77: SQLite snapshot + prune.
+                result = self._run_daily_backup(task)
             else:
                 result = {"status": "error", "message": f"Bilinmeyen görev türü: {task_type}"}
 
@@ -311,6 +318,77 @@ class TaskScheduler:
         except Exception as e:
             logger.error("audit_export task failed: %s", e)
             return {"status": "error", "message": str(e)}
+
+    def _run_daily_backup(self, task=None):
+        """Issue #77: scheduled SQLite snapshot + prune.
+
+        Snapshot failures are caught + reported as ``status=error`` but
+        never raised — the scheduler will retry tomorrow.
+        """
+        try:
+            from src.storage.backup_manager import BackupManager
+        except Exception as e:
+            return {"status": "error", "message": f"backup_manager import failed: {e}"}
+
+        backup_cfg = (self.config or {}).get("backup") or {}
+        if not backup_cfg.get("enabled", True):
+            return {"status": "skipped", "message": "backup.enabled=false"}
+
+        db_path = (
+            (self.config or {}).get("database", {}).get("path")
+            or "data/file_activity.db"
+        )
+        try:
+            mgr = BackupManager(db_path, self.config)
+            meta = mgr.snapshot(reason="scheduled-daily")
+            deleted = 0
+            try:
+                deleted = mgr.prune()
+            except Exception as e:
+                # Prune failure shouldn't fail the whole job — the
+                # snapshot itself succeeded, which is what matters.
+                logger.error("daily_backup prune failed: %s", e, exc_info=True)
+            return {
+                "status": "completed",
+                "snapshot_id": meta.id,
+                "size_bytes": meta.size_bytes,
+                "sha256": meta.sha256,
+                "pruned": deleted,
+            }
+        except Exception as e:
+            logger.error("daily_backup snapshot failed: %s", e, exc_info=True)
+            return {"status": "error", "message": str(e)}
+
+    def _register_daily_backup_job(self):
+        """Register the config-driven daily backup job (issue #77)."""
+        backup_cfg = (self.config or {}).get("backup") or {}
+        if not backup_cfg.get("enabled", True):
+            logger.info("daily_backup not registered: backup.enabled=false")
+            return
+        try:
+            hour = int(backup_cfg.get("daily_snapshot_hour", 2))
+        except (TypeError, ValueError):
+            hour = 2
+        # Clamp to valid CronTrigger range; default to 2 if nonsense.
+        if hour < 0 or hour > 23:
+            logger.warning(
+                "daily_snapshot_hour=%r out of range — defaulting to 2", hour
+            )
+            hour = 2
+        try:
+            trigger = CronTrigger(minute="0", hour=str(hour))
+            self.scheduler.add_job(
+                self._run_daily_backup,
+                trigger=trigger,
+                id="daily_backup",
+                name="daily_backup:sqlite",
+                replace_existing=True,
+            )
+            logger.info(
+                "daily_backup job registered (cron: 0 %d * * *)", hour
+            )
+        except Exception as e:
+            logger.error("Failed to register daily_backup: %s", e)
 
     def reload_tasks(self):
         """Görevleri yeniden yükle."""

--- a/src/storage/backup_manager.py
+++ b/src/storage/backup_manager.py
@@ -1,0 +1,558 @@
+"""SQLite auto-backup manager (issue #77 Phase 1).
+
+Provides safe, lock-free SQLite snapshots using ``VACUUM INTO`` (works under
+WAL without exclusive locks), SHA-256 verification, an atomic JSON manifest,
+and a retention policy combining last-N + weekly survivors.
+
+Design notes
+------------
+* ``VACUUM INTO 'path'`` is the single supported snapshot primitive — it
+  produces a defragmented, internally-consistent copy without holding an
+  exclusive lock on the live DB. We deliberately do NOT use ``shutil.copy``
+  (would race with WAL writes) or ``sqlite3.Connection.backup`` (extra
+  complexity, no upside here).
+* ``manifest.json`` is rewritten atomically (tempfile + ``os.replace``).
+* ``restore()`` is provided as a Phase-1 utility but never auto-called this
+  round. Phase 2 (``auto_restore_on_corruption``) will wire it from the
+  startup probe — the config field exists today but the value must stay
+  ``False`` until that work lands.
+* Snapshot failures must NEVER abort the calling operation — callers wrap
+  ``snapshot()`` defensively and continue.
+
+CLI
+---
+``python -m src.storage.backup_manager {snapshot|list|restore|prune}``
+
+Reuses :func:`src.utils.config_loader.load_config` so behaviour matches
+``main.py``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import hashlib
+import json
+import logging
+import os
+import shutil
+import sqlite3
+import sys
+import tempfile
+import traceback
+from dataclasses import asdict, dataclass
+from datetime import datetime
+from typing import Optional
+
+logger = logging.getLogger("file_activity.storage.backup_manager")
+
+
+@dataclass
+class SnapshotMeta:
+    """Metadata for one backup snapshot.
+
+    ``id`` is the timestamp string used in the file name
+    (``YYYYMMDD_HHMMSS``). It is also the primary key in the manifest.
+    """
+
+    id: str
+    path: str
+    size_bytes: int
+    sha256: str
+    created_at: str  # ISO 8601
+    reason: str
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "SnapshotMeta":
+        # Be liberal in what we accept — older manifest rows may be
+        # missing fields; treat absent values as empty/zero.
+        return cls(
+            id=str(data.get("id", "")),
+            path=str(data.get("path", "")),
+            size_bytes=int(data.get("size_bytes", 0) or 0),
+            sha256=str(data.get("sha256", "")),
+            created_at=str(data.get("created_at", "")),
+            reason=str(data.get("reason", "")),
+        )
+
+
+class BackupManager:
+    """Owns the snapshot/manifest/prune lifecycle for one SQLite DB."""
+
+    MANIFEST_NAME = "manifest.json"
+
+    def __init__(self, db_path: str, config: dict):
+        """``config`` is the **whole** loaded config dict, the same shape
+        ``main.py`` passes around. Backup-specific options live under
+        ``config['backup']``.
+        """
+        self.db_path = str(db_path)
+        self.config = config or {}
+        backup_cfg = (self.config.get("backup") or {}) if isinstance(self.config, dict) else {}
+
+        self.enabled: bool = bool(backup_cfg.get("enabled", True))
+        self.backup_dir: str = str(backup_cfg.get("dir", "data/backups"))
+        self.keep_last_n: int = int(backup_cfg.get("keep_last_n", 10) or 0)
+        self.keep_weekly: int = int(backup_cfg.get("keep_weekly", 4) or 0)
+        # Phase 2 placeholder — read but never acted on this round.
+        self.auto_restore_on_corruption: bool = bool(
+            backup_cfg.get("auto_restore_on_corruption", False)
+        )
+
+    # ──────────────────────────────────────────────
+    # Paths
+    # ──────────────────────────────────────────────
+
+    @property
+    def manifest_path(self) -> str:
+        return os.path.join(self.backup_dir, self.MANIFEST_NAME)
+
+    def _snapshot_filename(self, snap_id: str) -> str:
+        base = os.path.basename(self.db_path) or "file_activity.db"
+        return f"{base}.{snap_id}.bak"
+
+    def _ensure_dir(self) -> None:
+        os.makedirs(self.backup_dir, exist_ok=True)
+
+    # ──────────────────────────────────────────────
+    # Manifest IO
+    # ──────────────────────────────────────────────
+
+    def _read_manifest(self) -> list[dict]:
+        try:
+            with open(self.manifest_path, "r", encoding="utf-8") as f:
+                data = json.load(f)
+        except FileNotFoundError:
+            return []
+        except (OSError, ValueError) as e:
+            # Corrupt manifest is recoverable — we log + start fresh
+            # rather than crash the snapshot run. The .bak files on disk
+            # are still valid; they just lose their metadata until next
+            # snapshot rebuilds the manifest.
+            logger.error("manifest unreadable (%s) — starting fresh", e)
+            return []
+        if not isinstance(data, list):
+            logger.error("manifest is not a list — starting fresh")
+            return []
+        return data
+
+    def _write_manifest_atomic(self, entries: list[dict]) -> None:
+        """Write manifest via tempfile + os.replace so a crash mid-write
+        cannot leave a half-written file.
+        """
+        self._ensure_dir()
+        fd, tmp_path = tempfile.mkstemp(
+            prefix=".manifest.", suffix=".tmp", dir=self.backup_dir,
+        )
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as f:
+                json.dump(entries, f, indent=2, sort_keys=True)
+                f.flush()
+                try:
+                    os.fsync(f.fileno())
+                except OSError:
+                    # Some filesystems (tmpfs in CI) don't support fsync;
+                    # the replace below is still atomic.
+                    pass
+            os.replace(tmp_path, self.manifest_path)
+        except Exception:
+            # Best-effort cleanup of the tempfile if we never replaced.
+            try:
+                if os.path.exists(tmp_path):
+                    os.remove(tmp_path)
+            except OSError:
+                pass
+            raise
+
+    # ──────────────────────────────────────────────
+    # Snapshot
+    # ──────────────────────────────────────────────
+
+    @staticmethod
+    def _sha256_file(path: str) -> str:
+        h = hashlib.sha256()
+        with open(path, "rb") as f:
+            for chunk in iter(lambda: f.read(1024 * 1024), b""):
+                h.update(chunk)
+        return h.hexdigest()
+
+    @staticmethod
+    def _now() -> datetime:
+        # Indirection so tests can monkeypatch ``BackupManager._now``.
+        return datetime.now()
+
+    def snapshot(self, reason: str) -> SnapshotMeta:
+        """Take a snapshot via ``VACUUM INTO``.
+
+        Returns the SnapshotMeta on success. Raises on failure — callers
+        that want best-effort behaviour must wrap this in try/except (the
+        archive + retention hooks do).
+        """
+        if not os.path.exists(self.db_path):
+            raise FileNotFoundError(
+                f"source DB not found: {self.db_path}"
+            )
+
+        self._ensure_dir()
+        now = self._now()
+        snap_id = now.strftime("%Y%m%d_%H%M%S")
+        out_path = os.path.join(
+            self.backup_dir, self._snapshot_filename(snap_id)
+        )
+
+        # If a snapshot in the same second exists (rare in tests), suffix
+        # a counter so VACUUM INTO doesn't fail with "file exists".
+        if os.path.exists(out_path):
+            i = 1
+            while True:
+                cand = os.path.join(
+                    self.backup_dir,
+                    self._snapshot_filename(f"{snap_id}_{i}"),
+                )
+                if not os.path.exists(cand):
+                    out_path = cand
+                    snap_id = f"{snap_id}_{i}"
+                    break
+                i += 1
+
+        logger.info(
+            "snapshot starting: db=%s -> %s (reason=%s)",
+            self.db_path, out_path, reason,
+        )
+
+        # VACUUM INTO requires a fresh connection (no open transaction)
+        # and refuses to overwrite an existing path — both already
+        # guaranteed above.
+        conn = sqlite3.connect(self.db_path, timeout=30)
+        try:
+            # Quote the path safely — VACUUM INTO uses string literal
+            # syntax; double single-quotes inside the literal.
+            quoted = out_path.replace("'", "''")
+            conn.execute(f"VACUUM INTO '{quoted}'")
+        finally:
+            conn.close()
+
+        size = os.path.getsize(out_path)
+        sha = self._sha256_file(out_path)
+        meta = SnapshotMeta(
+            id=snap_id,
+            path=out_path,
+            size_bytes=size,
+            sha256=sha,
+            created_at=now.isoformat(timespec="seconds"),
+            reason=str(reason or ""),
+        )
+
+        # Append to manifest (atomic).
+        entries = self._read_manifest()
+        entries.append(meta.to_dict())
+        self._write_manifest_atomic(entries)
+
+        logger.info(
+            "snapshot ok: id=%s size=%d sha256=%s reason=%s",
+            meta.id, meta.size_bytes, meta.sha256[:12], meta.reason,
+        )
+        return meta
+
+    # ──────────────────────────────────────────────
+    # List / Prune / Restore
+    # ──────────────────────────────────────────────
+
+    def list_snapshots(self) -> list[SnapshotMeta]:
+        """Return snapshot metas sorted by id ascending (oldest first)."""
+        entries = self._read_manifest()
+        metas = [SnapshotMeta.from_dict(e) for e in entries]
+        metas.sort(key=lambda m: m.id)
+        return metas
+
+    def _iso_week_key(self, snap_id: str) -> Optional[tuple[int, int]]:
+        """Parse ``YYYYMMDD_HHMMSS`` -> (iso_year, iso_week). Returns
+        ``None`` for unparsable ids (which are then treated as not
+        contributing a weekly survivor).
+        """
+        try:
+            dt = datetime.strptime(snap_id[:15], "%Y%m%d_%H%M%S")
+        except ValueError:
+            return None
+        iso = dt.isocalendar()
+        return (iso[0], iso[1])
+
+    def prune(self) -> int:
+        """Delete snapshots beyond the retention budget. Returns the
+        count removed.
+
+        Retention rules:
+          * Always keep the ``keep_last_n`` newest snapshots.
+          * In addition, keep the oldest snapshot of each of the
+            ``keep_weekly`` most recent ISO weeks (the "weekly anchor").
+            A weekly anchor is preserved even if the daily window would
+            otherwise drop it.
+          * Anything not in either survivor set is deleted.
+        """
+        metas = self.list_snapshots()
+        if not metas:
+            return 0
+
+        # Keep the last N (newest) — list is sorted ascending, so take
+        # the tail.
+        keep_ids: set[str] = set()
+        if self.keep_last_n > 0:
+            for m in metas[-self.keep_last_n:]:
+                keep_ids.add(m.id)
+
+        # Weekly anchors: walk newest-first, pick the *first* (= oldest
+        # we encounter when iterating reversed) snapshot per ISO week,
+        # but only for the most recent ``keep_weekly`` distinct weeks.
+        # Spec: "Weekly = first snapshot of each ISO week (kept;
+        # daily-rotation doesn't delete it)." We implement that as the
+        # earliest snapshot in chronological order whose ISO week falls
+        # in the most recent ``keep_weekly`` weeks.
+        if self.keep_weekly > 0:
+            # Collect distinct weeks newest -> oldest
+            seen_weeks: list[tuple[int, int]] = []
+            for m in reversed(metas):
+                wk = self._iso_week_key(m.id)
+                if wk is None:
+                    continue
+                if wk not in seen_weeks:
+                    seen_weeks.append(wk)
+                if len(seen_weeks) >= self.keep_weekly:
+                    break
+            target_weeks = set(seen_weeks)
+
+            # For each target week, pick the earliest snapshot (chrono
+            # order) — that's the "first snapshot of the week".
+            week_first: dict[tuple[int, int], str] = {}
+            for m in metas:  # ascending
+                wk = self._iso_week_key(m.id)
+                if wk is None or wk not in target_weeks:
+                    continue
+                if wk not in week_first:
+                    week_first[wk] = m.id
+            keep_ids.update(week_first.values())
+
+        deleted = 0
+        survivors: list[dict] = []
+        for m in metas:
+            if m.id in keep_ids:
+                survivors.append(m.to_dict())
+                continue
+            try:
+                if m.path and os.path.exists(m.path):
+                    os.remove(m.path)
+                deleted += 1
+                logger.info("pruned snapshot: id=%s path=%s", m.id, m.path)
+            except OSError as e:
+                # File deletion failed — keep the manifest entry so we
+                # can retry next prune. Log but don't crash.
+                logger.error(
+                    "prune failed to delete %s: %s", m.path, e,
+                )
+                survivors.append(m.to_dict())
+
+        if deleted:
+            self._write_manifest_atomic(survivors)
+        return deleted
+
+    def _detect_live_connection(self) -> bool:
+        """Best-effort check that no other process holds the DB open.
+
+        We open a fresh connection and run ``PRAGMA database_list`` just
+        to confirm the DB is reachable; the real signal is whether we
+        can acquire an exclusive write lock immediately. If we cannot,
+        someone else (likely the dashboard) is connected.
+        """
+        if not os.path.exists(self.db_path):
+            return False
+        conn = sqlite3.connect(self.db_path, timeout=0.5)
+        try:
+            conn.execute("PRAGMA database_list").fetchall()
+            try:
+                # BEGIN EXCLUSIVE will fail fast if any other connection
+                # holds a lock on the WAL. We immediately roll back —
+                # we never want to mutate during a "is it safe to
+                # restore?" probe.
+                conn.execute("BEGIN EXCLUSIVE")
+                conn.execute("ROLLBACK")
+                return False
+            except sqlite3.OperationalError:
+                return True
+        finally:
+            conn.close()
+
+    def restore(self, snapshot_id: str) -> None:
+        """Copy a snapshot file over ``db_path``. Caller is responsible
+        for stopping the dashboard / scheduler first; this method
+        refuses to run if it detects a live connection.
+
+        NOTE (Phase 1): never auto-called. Phase 2 will wire this from
+        the startup corruption probe when
+        ``backup.auto_restore_on_corruption`` is True.
+        """
+        metas = {m.id: m for m in self.list_snapshots()}
+        meta = metas.get(snapshot_id)
+        if meta is None:
+            raise KeyError(f"unknown snapshot id: {snapshot_id}")
+        if not os.path.exists(meta.path):
+            raise FileNotFoundError(
+                f"snapshot file missing on disk: {meta.path}"
+            )
+
+        if self._detect_live_connection():
+            raise RuntimeError(
+                "refusing to restore: a live connection holds the "
+                f"database lock on {self.db_path}. Stop the dashboard / "
+                "service first."
+            )
+
+        # Verify integrity of the snapshot file before clobbering the
+        # live DB. SHA-256 from manifest must match disk.
+        actual = self._sha256_file(meta.path)
+        if meta.sha256 and actual != meta.sha256:
+            raise RuntimeError(
+                f"snapshot {snapshot_id} sha256 mismatch — refusing "
+                f"to restore (manifest={meta.sha256[:12]}, "
+                f"disk={actual[:12]})"
+            )
+
+        # Atomic-ish swap: copy to a sibling tempfile, then rename over
+        # the live DB. Also remove WAL/SHM siblings — they belong to the
+        # *old* DB and would corrupt the restored copy if SQLite
+        # re-attached them.
+        db_dir = os.path.dirname(self.db_path) or "."
+        os.makedirs(db_dir, exist_ok=True)
+        fd, tmp = tempfile.mkstemp(
+            prefix=".restore.", suffix=".db", dir=db_dir,
+        )
+        os.close(fd)
+        try:
+            shutil.copy2(meta.path, tmp)
+            os.replace(tmp, self.db_path)
+        except Exception:
+            try:
+                if os.path.exists(tmp):
+                    os.remove(tmp)
+            except OSError:
+                pass
+            raise
+
+        for sibling in (self.db_path + "-wal", self.db_path + "-shm"):
+            try:
+                if os.path.exists(sibling):
+                    os.remove(sibling)
+            except OSError as e:
+                logger.warning(
+                    "restore: failed to remove %s: %s", sibling, e
+                )
+
+        logger.info(
+            "restore ok: id=%s -> %s (size=%d)",
+            meta.id, self.db_path, meta.size_bytes,
+        )
+
+
+# ──────────────────────────────────────────────
+# CLI
+# ──────────────────────────────────────────────
+
+def _resolve_db_path_and_manager(config_path: str) -> BackupManager:
+    """Load config the same way main.py does and build a manager."""
+    # Local import so importing this module never pulls yaml in.
+    from src.utils.config_loader import load_config
+
+    cfg = load_config(config_path)
+    db_path = ((cfg.get("database") or {}).get("path")
+               or "data/file_activity.db")
+    return BackupManager(db_path, cfg)
+
+
+def _cmd_snapshot(mgr: BackupManager, reason: str) -> int:
+    try:
+        meta = mgr.snapshot(reason=reason)
+    except Exception as e:
+        logger.error("snapshot failed: %s\n%s", e, traceback.format_exc())
+        print(json.dumps({"ok": False, "error": str(e)}))
+        return 1
+    print(json.dumps({"ok": True, **meta.to_dict()}))
+    return 0
+
+
+def _cmd_list(mgr: BackupManager) -> int:
+    metas = mgr.list_snapshots()
+    for m in metas:
+        print(json.dumps(m.to_dict()))
+    return 0
+
+
+def _cmd_restore(mgr: BackupManager, snap_id: str) -> int:
+    try:
+        mgr.restore(snap_id)
+    except Exception as e:
+        logger.error("restore failed: %s\n%s", e, traceback.format_exc())
+        print(json.dumps({"ok": False, "error": str(e)}))
+        return 1
+    print(json.dumps({"ok": True, "restored": snap_id}))
+    return 0
+
+
+def _cmd_prune(mgr: BackupManager) -> int:
+    try:
+        deleted = mgr.prune()
+    except Exception as e:
+        logger.error("prune failed: %s\n%s", e, traceback.format_exc())
+        print(json.dumps({"ok": False, "error": str(e)}))
+        return 1
+    print(json.dumps({"ok": True, "deleted": deleted}))
+    return 0
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    # Make sure the CLI emits at least INFO logs to stderr so the
+    # operator sees what happened even if the JSON line on stdout is
+    # piped away.
+    if not logging.getLogger().handlers:
+        logging.basicConfig(
+            level=logging.INFO,
+            format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+        )
+
+    parser = argparse.ArgumentParser(
+        prog="python -m src.storage.backup_manager",
+        description="FILE ACTIVITY SQLite backup manager (issue #77).",
+    )
+    parser.add_argument(
+        "--config", "-c", default="config.yaml",
+        help="Path to config.yaml (same default as main.py).",
+    )
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    p_snap = sub.add_parser("snapshot", help="Take a snapshot now.")
+    p_snap.add_argument("--reason", default="manual",
+                        help="Free-text reason for the manifest entry.")
+
+    sub.add_parser("list", help="List known snapshots from the manifest.")
+
+    p_rest = sub.add_parser("restore", help="Restore a snapshot over the live DB.")
+    p_rest.add_argument("--id", required=True, help="Snapshot id (YYYYMMDD_HHMMSS).")
+
+    sub.add_parser("prune", help="Apply retention: keep_last_n + keep_weekly.")
+
+    args = parser.parse_args(argv)
+    mgr = _resolve_db_path_and_manager(args.config)
+
+    if args.cmd == "snapshot":
+        return _cmd_snapshot(mgr, args.reason)
+    if args.cmd == "list":
+        return _cmd_list(mgr)
+    if args.cmd == "restore":
+        return _cmd_restore(mgr, args.id)
+    if args.cmd == "prune":
+        return _cmd_prune(mgr)
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/utils/config_loader.py
+++ b/src/utils/config_loader.py
@@ -29,6 +29,19 @@ DEFAULT_CONFIG = {
         "verify_checksum": True, "dry_run": False, "cleanup_empty_dirs": True,
     },
     "dashboard": {"host": "0.0.0.0", "port": 8085},
+    # Issue #77: auto-backup defaults. Match config.yaml. The Phase 2
+    # auto_restore_on_corruption field is already here so older
+    # configs parse cleanly once Phase 2 lands.
+    "backup": {
+        "enabled": True,
+        "dir": "data/backups",
+        "keep_last_n": 10,
+        "keep_weekly": 4,
+        "daily_snapshot_hour": 2,
+        "snapshot_on_update": True,
+        "snapshot_on_apply": True,
+        "auto_restore_on_corruption": False,
+    },
 }
 
 

--- a/tests/test_backup_manager.py
+++ b/tests/test_backup_manager.py
@@ -1,0 +1,294 @@
+"""Tests for issue #77 Phase 1: SQLite auto-backup.
+
+Coverage:
+  * test_snapshot_creates_file_and_manifest
+  * test_snapshot_sha256_matches_file_content
+  * test_prune_keeps_last_n_plus_weekly
+  * test_restore_refuses_on_live_connection
+  * test_restore_writes_db_atomically
+  * test_cli_snapshot_writes_jsonl_to_stdout
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import sqlite3
+import subprocess
+import sys
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if REPO_ROOT not in sys.path:
+    sys.path.insert(0, REPO_ROOT)
+
+from src.storage.backup_manager import BackupManager, SnapshotMeta  # noqa: E402
+
+
+def _make_db(path: Path) -> None:
+    """Create a tiny SQLite DB with a few rows so snapshots are
+    non-trivial and the restored copy is byte-comparable."""
+    conn = sqlite3.connect(str(path))
+    try:
+        conn.execute("CREATE TABLE t (id INTEGER PRIMARY KEY, payload TEXT)")
+        conn.executemany(
+            "INSERT INTO t (payload) VALUES (?)",
+            [(f"row-{i}",) for i in range(50)],
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def _make_mgr(tmp_path: Path, **overrides) -> BackupManager:
+    db_path = tmp_path / "live.db"
+    _make_db(db_path)
+    cfg = {
+        "backup": {
+            "enabled": True,
+            "dir": str(tmp_path / "backups"),
+            "keep_last_n": 10,
+            "keep_weekly": 4,
+        }
+    }
+    cfg["backup"].update(overrides)
+    return BackupManager(str(db_path), cfg)
+
+
+# ── 1. snapshot creates file + manifest ─────────────────────
+
+
+def test_snapshot_creates_file_and_manifest(tmp_path: Path):
+    mgr = _make_mgr(tmp_path)
+    meta = mgr.snapshot(reason="test-create")
+
+    # File on disk
+    assert os.path.exists(meta.path), "snapshot .bak file must exist"
+    assert meta.size_bytes == os.path.getsize(meta.path)
+
+    # Manifest exists, parses to JSON, contains the entry
+    manifest = json.loads(Path(mgr.manifest_path).read_text("utf-8"))
+    assert isinstance(manifest, list)
+    assert len(manifest) == 1
+    entry = manifest[0]
+    assert entry["id"] == meta.id
+    assert entry["reason"] == "test-create"
+    assert entry["sha256"] == meta.sha256
+    # The snapshot itself must be a valid SQLite DB
+    conn = sqlite3.connect(meta.path)
+    try:
+        rows = conn.execute("SELECT COUNT(*) FROM t").fetchone()
+        assert rows[0] == 50
+    finally:
+        conn.close()
+
+
+# ── 2. SHA-256 in manifest matches file ─────────────────────
+
+
+def test_snapshot_sha256_matches_file_content(tmp_path: Path):
+    mgr = _make_mgr(tmp_path)
+    meta = mgr.snapshot(reason="checksum-test")
+
+    h = hashlib.sha256()
+    with open(meta.path, "rb") as f:
+        for chunk in iter(lambda: f.read(65536), b""):
+            h.update(chunk)
+    assert meta.sha256 == h.hexdigest()
+
+    # And that's also what's in the manifest
+    manifest = json.loads(Path(mgr.manifest_path).read_text("utf-8"))
+    assert manifest[0]["sha256"] == h.hexdigest()
+
+
+# ── 3. prune keeps last N + weekly anchors ──────────────────
+
+
+def test_prune_keeps_last_n_plus_weekly(tmp_path: Path, monkeypatch):
+    """30 snapshots across 4 weeks -> prune to keep_last_n=5 +
+    keep_weekly=4. Survivors must be the 5 newest snapshots PLUS the
+    earliest snapshot of each of the 4 most recent ISO weeks (those
+    not already in the daily window)."""
+    mgr = _make_mgr(
+        tmp_path,
+        keep_last_n=5,
+        keep_weekly=4,
+    )
+
+    # Build 30 deterministic snapshot timestamps spanning 30 days, one
+    # per day at 03:00, starting 2026-03-15. We monkeypatch
+    # BackupManager._now to return them in turn.
+    from datetime import timedelta
+    base = datetime(2026, 3, 15, 3, 0, 0)
+    times: list[datetime] = [base + timedelta(days=d) for d in range(30)]
+
+    counter = {"i": 0}
+
+    def fake_now(self=None):
+        # bound or unbound — we monkeypatch as staticmethod
+        i = counter["i"]
+        counter["i"] += 1
+        return times[i]
+
+    monkeypatch.setattr(BackupManager, "_now", staticmethod(fake_now))
+
+    created: list[SnapshotMeta] = []
+    for _ in range(30):
+        created.append(mgr.snapshot(reason="seed"))
+    assert len(created) == 30
+
+    deleted = mgr.prune()
+
+    survivors = mgr.list_snapshots()
+    survivor_ids = {m.id for m in survivors}
+
+    # Daily survivors: the 5 newest by id
+    expected_daily = {m.id for m in sorted(created, key=lambda m: m.id)[-5:]}
+
+    # Weekly survivors: for each of the 4 most recent ISO weeks
+    # represented in `created`, take the earliest snapshot.
+    by_week: dict[tuple[int, int], list[SnapshotMeta]] = {}
+    for m in created:
+        dt = datetime.strptime(m.id[:15], "%Y%m%d_%H%M%S")
+        wk = (dt.isocalendar()[0], dt.isocalendar()[1])
+        by_week.setdefault(wk, []).append(m)
+    # Most recent 4 weeks
+    recent_weeks = sorted(by_week.keys(), reverse=True)[:4]
+    expected_weekly = {
+        sorted(by_week[wk], key=lambda m: m.id)[0].id for wk in recent_weeks
+    }
+
+    expected_survivors = expected_daily | expected_weekly
+    assert survivor_ids == expected_survivors, (
+        f"Mismatch.\nGot: {sorted(survivor_ids)}\n"
+        f"Expected: {sorted(expected_survivors)}"
+    )
+    assert deleted == 30 - len(expected_survivors)
+
+    # And every survivor still has a real file on disk
+    for m in survivors:
+        assert os.path.exists(m.path)
+
+
+# ── 4. restore refuses while a live connection holds the DB ─
+
+
+def test_restore_refuses_on_live_connection(tmp_path: Path):
+    mgr = _make_mgr(tmp_path)
+    meta = mgr.snapshot(reason="for-restore")
+
+    # Open + actively hold a write lock so VACUUM-INTO-style locks fail
+    conn = sqlite3.connect(mgr.db_path, isolation_level=None)
+    try:
+        conn.execute("BEGIN EXCLUSIVE")
+        with pytest.raises(RuntimeError, match="live connection"):
+            mgr.restore(meta.id)
+    finally:
+        try:
+            conn.execute("ROLLBACK")
+        except sqlite3.Error:
+            pass
+        conn.close()
+
+
+# ── 5. restore writes db atomically (byte-equal) ────────────
+
+
+def test_restore_writes_db_atomically(tmp_path: Path):
+    mgr = _make_mgr(tmp_path)
+    meta = mgr.snapshot(reason="for-roundtrip")
+
+    # Mutate the live DB after the snapshot
+    conn = sqlite3.connect(mgr.db_path)
+    try:
+        conn.execute("INSERT INTO t (payload) VALUES ('post-snapshot')")
+        conn.commit()
+    finally:
+        conn.close()
+
+    # Force-close any WAL by checkpointing then deleting siblings —
+    # restore() does that internally too, but the test wants a clean
+    # baseline.
+    conn = sqlite3.connect(mgr.db_path)
+    try:
+        conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+    finally:
+        conn.close()
+
+    mgr.restore(meta.id)
+
+    # The live DB should now be byte-equal to the snapshot
+    with open(mgr.db_path, "rb") as f:
+        live_bytes = f.read()
+    with open(meta.path, "rb") as f:
+        snap_bytes = f.read()
+    assert live_bytes == snap_bytes
+
+    # And the post-snapshot row must be gone
+    conn = sqlite3.connect(mgr.db_path)
+    try:
+        rows = conn.execute(
+            "SELECT COUNT(*) FROM t WHERE payload='post-snapshot'"
+        ).fetchone()
+        assert rows[0] == 0
+    finally:
+        conn.close()
+
+
+# ── 6. CLI snapshot writes JSONL to stdout ──────────────────
+
+
+def test_cli_snapshot_writes_jsonl_to_stdout(tmp_path: Path):
+    """Run `python -m src.storage.backup_manager snapshot` against a
+    fixture DB + config, verify exit 0 and that stdout contains the
+    SnapshotMeta as JSON.
+    """
+    db_path = tmp_path / "fixture.db"
+    _make_db(db_path)
+
+    # Minimal config.yaml the CLI can find via load_config
+    cfg_path = tmp_path / "config.yaml"
+    cfg_path.write_text(
+        "database:\n"
+        f"  path: \"{db_path}\"\n"
+        "backup:\n"
+        "  enabled: true\n"
+        f"  dir: \"{tmp_path / 'backups'}\"\n"
+        "  keep_last_n: 5\n"
+        "  keep_weekly: 2\n",
+        encoding="utf-8",
+    )
+
+    env = os.environ.copy()
+    env["PYTHONPATH"] = REPO_ROOT + os.pathsep + env.get("PYTHONPATH", "")
+
+    proc = subprocess.run(
+        [
+            sys.executable, "-m", "src.storage.backup_manager",
+            "--config", str(cfg_path),
+            "snapshot", "--reason", "test",
+        ],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=60,
+    )
+
+    assert proc.returncode == 0, (
+        f"CLI exited non-zero.\nstdout={proc.stdout!r}\n"
+        f"stderr={proc.stderr!r}"
+    )
+    # Stdout must be parseable JSON describing the snapshot
+    last_line = proc.stdout.strip().splitlines()[-1]
+    payload = json.loads(last_line)
+    assert payload["ok"] is True
+    assert payload["reason"] == "test"
+    assert payload["sha256"]
+    assert payload["size_bytes"] > 0
+    # And the .bak file actually landed
+    assert os.path.exists(payload["path"])


### PR DESCRIPTION
## Summary
Phase 1 of #77 — auto-backup before risky operations + scheduled daily snapshots. Phase 2 (auto-restore on corruption) is a follow-up; the config field exists but is never read this round.

- **New `src/storage/backup_manager.py`**: `BackupManager` + `SnapshotMeta` dataclass, CLI (`snapshot` / `list` / `restore` / `prune`). Uses `VACUUM INTO 'data/backups/file_activity.db.YYYYMMDD_HHMMSS.bak'` — safe with WAL, no exclusive lock. Manifest at `data/backups/manifest.json` written atomically (tmp + os.replace). SHA-256 + size per snapshot.
- **Pre-archive snapshot**: `src/archiver/archive_engine.py` — when `dry_run=False` AND `backup.snapshot_on_apply=true`, snapshot before any file moves. Snapshot failure logs ERROR + continues (never aborts archive).
- **Pre-retention snapshot**: `src/compliance/retention.py` — same hook in real-run branch of `apply()`.
- **Daily APScheduler job**: `src/scheduler/task_scheduler.py` — `daily_backup` job auto-registered in `start()` at `backup.daily_snapshot_hour` (default 02:00). Snapshot then `prune()`. DB-driven schedules supported via `_execute_task`.
- **`update.cmd` integration**: `deploy/setup-source.ps1` heredoc now snapshots before `irm | iex`. Snapshot failure prints warning, update continues.
- **`config.yaml`**: new top-level `backup:` block with the spec'd fields, including `auto_restore_on_corruption: false` Phase 2 placeholder.

## Decisions
- `restore()` refuses if it can acquire-then-fail an `EXCLUSIVE` transaction probe; wipes `-wal` / `-shm` siblings post-restore.
- Prune keeps newest `keep_last_n` (10) plus the **earliest** snapshot of each of the most recent `keep_weekly` (4) ISO weeks. Failed file deletes keep the manifest entry so retry next prune works.
- All snapshot failures from archive/retention hooks are caught + logged at ERROR with traceback — never abort the calling op.

## Test plan
- [x] `tests/test_backup_manager.py` — 6/6 pass (snapshot creates file + manifest, sha256 matches, prune keeps last_n + weekly, restore refuses live conn, restore writes atomically, CLI returns valid JSON).
- [x] Full suite (excl. bench + MCP): 163 passed, 6 skipped — no regressions.
- [x] Manual: `python -m src.storage.backup_manager --config /tmp/fa_smoke/config.yaml snapshot --reason test` → exit 0, JSON stdout `ok=true`, sha256, `.bak` + `manifest.json` written.

## Phase 2/3 deliberately deferred
- Auto-restore on corruption (config field exists, never read; `restore()` callable but never auto-invoked).
- Dashboard endpoints, PowerShell cmdlet, MCP tool — Phase 3.

https://claude.ai/code/session_3da9da4f-9a75-411a-8d33-57e188ae2dd7

---
_Generated by [Claude Code](https://claude.ai/code/session_01A1UzS1A4DZNk1akoP4uhZ7)_