### PR TITLE
open_folder: detect remote client, fall back to clipboard (closes #82 Bug 1)

### DIFF
--- a/src/dashboard/api.py
+++ b/src/dashboard/api.py
@@ -27,6 +27,69 @@ _export_lock = threading.Lock()
 logger = logging.getLogger("file_activity.dashboard")
 
 
+# --- Issue #82 (Bug 1): /api/system/open-folder dual-behaviour helper ---
+#
+# The dashboard is typically served from a Windows file server while users
+# browse it from their own workstations. Calling `subprocess.Popen(["explorer",
+# ...])` server-side opens a window on the *server*, which is invisible to the
+# remote user and makes the "Konuma Git" buttons look broken.
+#
+# This helper implements two modes:
+#   * Local client (127.0.0.1 / ::1 / localhost): spawn Explorer natively and
+#     return {"success": True, "mode": "native"}.
+#   * Remote client: do NOT touch subprocess. Return HTTP 200 with
+#     {"success": False, "mode": "remote_client", ...} so the frontend can
+#     copy the path to the user's clipboard and surface a friendly hint.
+#
+# Path resolution (`os.path.realpath(os.path.normpath(...))`) and the
+# `shell=False` argv-list Popen form are preserved for security. Missing paths
+# still produce HTTP 404 via HTTPException.
+
+_LOCAL_CLIENT_HOSTS = frozenset({"127.0.0.1", "::1", "localhost"})
+
+
+def open_folder_impl(body: dict, client_host: str, popen=None):
+    """Run the open-folder decision logic.
+
+    Pure-ish helper shared by the HTTP endpoint and the unit tests. Returns
+    the JSON-serialisable response dict on success, or raises HTTPException
+    for invalid input / missing paths. ``popen`` lets tests inject a stub in
+    place of ``subprocess.Popen``.
+    """
+    if popen is None:
+        import subprocess
+        popen = subprocess.Popen
+
+    folder = body.get("path", "") if isinstance(body, dict) else ""
+    if not folder or not isinstance(folder, str):
+        raise HTTPException(400, "path gerekli")
+
+    # Guvenlik: normalize + gercek yol cozumleme (symlink/junction eskape koruma)
+    folder = os.path.realpath(os.path.normpath(folder))
+    if not (os.path.isdir(folder) or os.path.isfile(folder)):
+        raise HTTPException(404, f"Dizin bulunamadi: {folder}")
+
+    is_local = client_host in _LOCAL_CLIENT_HOSTS
+    if not is_local:
+        return {
+            "success": False,
+            "mode": "remote_client",
+            "path": folder,
+            "hint": (
+                "Explorer cannot be opened on the server for a remote "
+                "client. Use the copied path on your own machine."
+            ),
+        }
+
+    # Yerel istemci: dosya/dizine gore Explorer'i acar.
+    # shell=False ile argv listesi kullanilarak komut enjeksiyonu onlenir.
+    if os.path.isdir(folder):
+        popen(["explorer", folder], shell=False)
+    else:  # os.path.isfile(folder)
+        popen(["explorer", "/select,", folder], shell=False)
+    return {"success": True, "mode": "native", "path": folder}
+
+
 # --- Pydantic Models ---
 
 class SourceCreate(BaseModel):
@@ -1864,23 +1927,10 @@ def create_app(db, config, analytics=None, ad_lookup=None, email_notifier=None):
 
     @app.post("/api/system/open-folder")
     async def open_folder(request: Request):
-        """Dizini Windows Explorer'da ac."""
-        import subprocess
+        """Dizini Windows Explorer'da ac (yalnizca yerel istemci icin)."""
         body = await request.json()
-        folder = body.get("path", "")
-        if not folder or not isinstance(folder, str):
-            raise HTTPException(400, "path gerekli")
-        # Guvenlik: normalize + gercek yol cozumleme (symlink/junction eskape koruma)
-        folder = os.path.realpath(os.path.normpath(folder))
-        if os.path.isdir(folder):
-            # shell=False ile argv listesi kullanilarak komut enjeksiyonu onlenir
-            subprocess.Popen(["explorer", folder], shell=False)
-            return {"success": True, "path": folder}
-        elif os.path.isfile(folder):
-            subprocess.Popen(["explorer", "/select,", folder], shell=False)
-            return {"success": True, "path": folder}
-        else:
-            raise HTTPException(404, f"Dizin bulunamadi: {folder}")
+        client_host = (request.client.host if request.client else "")
+        return open_folder_impl(body, client_host)
 
     @app.get("/api/system/health")
     async def health():

--- a/src/dashboard/static/index.html
+++ b/src/dashboard/static/index.html
@@ -2682,19 +2682,62 @@ function exportNamingReport() {
 }
 
 function openFolder(path) {
-    // Backend'e dizin acma istegi gonder
-    api('/system/open-folder', {
+    // Issue #82 (Bug 1): Dashboard genellikle bir dosya sunucusunda calisir;
+    // kullanici kendi PC'sinden tarayici ile acar. Backend artik istemcinin
+    // uzak olup olmadigini tespit edip "remote_client" modunu dondurur.
+    // Frontend her iki durumda da once yolu panoya kopyalar (best-effort),
+    // boylece kullanici kendi Explorer'ina yapistirabilsin.
+
+    // Panoya kopyalama yardimci fonksiyonu — API yoksa veya izin reddedilirse
+    // kullaniciya prompt ile secilebilir metin gosterir.
+    function copyPathFallback(p) {
+        try {
+            if (navigator.clipboard && navigator.clipboard.writeText) {
+                navigator.clipboard.writeText(p).catch(() => {
+                    window.prompt('Yolu kopyalamak icin Ctrl+C yapin:', p);
+                });
+                return;
+            }
+        } catch (_) { /* noop, prompt fallback below */ }
+        // Clipboard API yok (http baglam vb.) — manuel kopya icin prompt goster.
+        window.prompt('Yolu kopyalamak icin Ctrl+C yapin:', p);
+    }
+
+    // 1) Her zaman once panoya kopyalamayi dene (await etmeden).
+    copyPathFallback(path);
+
+    // 2) Endpoint'i cagir. api() helper 4xx/5xx'te throw eder — burada manuel
+    // fetch kullaniyoruz ki "remote_client" (200 + success:false) durumunu
+    // hatasiz isleyebilelim.
+    fetch(API + '/system/open-folder', {
         method: 'POST',
+        headers: {'Content-Type': 'application/json'},
         body: JSON.stringify({ path: path })
-    }).then(() => {
-        notify('Dizin aciliyor: ' + path, 'info');
-    }).catch(() => {
-        // Fallback: yolu kopyala
-        navigator.clipboard?.writeText(path).then(() => {
+    }).then(async (r) => {
+        if (!r.ok) {
+            let detail = '';
+            try { const e = await r.json(); detail = e.detail || ''; } catch (_) {}
+            notify('Dizin acilamadi (' + r.status + (detail ? ': ' + detail : '') + '). Yol panoya kopyalandi: ' + path, 'error');
+            return;
+        }
+        const data = await r.json().catch(() => ({}));
+        if (data && data.success === true && data.mode === 'native') {
+            notify('Explorer acildi: ' + path, 'success');
+        } else if (data && data.success === false && data.mode === 'remote_client') {
+            // Uzak istemci: daha gorunur ve uzun sureli bildirim.
+            const el = document.createElement('div');
+            el.className = 'notification warning';
+            el.innerHTML = `<span>⚠️</span> Yol panoya kopyalandi. Kendi Explorer'inda yapistirin: ${path}`;
+            el.onclick = () => el.remove();
+            document.getElementById('notifications').appendChild(el);
+            setTimeout(() => el.remove(), 12000);
+        } else {
+            // Beklenmeyen sekil — yine de yol kullaniciya gosterilsin.
             notify('Yol panoya kopyalandi: ' + path, 'info');
-        }).catch(() => {
-            notify('Dizin yolu: ' + path, 'info');
-        });
+        }
+    }).catch(() => {
+        // Ag hatasi / fetch basarisiz — pano fallback'i zaten tetiklenmisti.
+        notify('Sunucuya ulasilamadi. Yol panoya kopyalandi: ' + path, 'error');
     });
 }
 

--- a/tests/test_dashboard_api.py
+++ b/tests/test_dashboard_api.py
@@ -1,0 +1,178 @@
+"""Dashboard API tests (issue #82, Bug 1).
+
+Covers the dual-behaviour `/api/system/open-folder` endpoint:
+
+* Local client -> spawns Windows Explorer via subprocess.Popen and returns
+  ``{"success": True, "mode": "native"}``.
+* Remote client -> does NOT touch subprocess; returns HTTP 200 with
+  ``{"success": False, "mode": "remote_client"}`` so the frontend can copy
+  the path to the user's clipboard instead of opening a window on the
+  (invisible) server.
+* Missing path -> HTTP 404, preserving the previous behaviour.
+
+Rather than spin up the full `create_app(...)` factory (which wants a real
+Database, AnalyticsEngine, etc.), these tests exercise the module-level
+`open_folder_impl` helper directly AND mount a minimal FastAPI app that
+registers the exact endpoint handler to keep end-to-end coverage for the
+remote-vs-local branching via the `TestClient` wire path.
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+
+import pytest
+from fastapi import FastAPI, HTTPException, Request
+from fastapi.testclient import TestClient
+
+from src.dashboard.api import open_folder_impl
+
+
+# ---------------------------------------------------------------------------
+# Minimal app mirroring the real endpoint (same 3-line body as in api.py).
+# This lets us drive the endpoint through TestClient so the `request.client`
+# plumbing is real, and we can override the client host via a middleware to
+# simulate a remote caller without needing a real TCP socket.
+# ---------------------------------------------------------------------------
+
+
+def _build_app(force_client_host: str | None = None) -> FastAPI:
+    app = FastAPI()
+
+    if force_client_host is not None:
+        # Starlette lets us rewrite the ASGI scope's "client" tuple before the
+        # request is dispatched; that is exactly what `request.client.host`
+        # reads from. This avoids needing a real remote socket to test the
+        # "remote client" branch.
+        @app.middleware("http")
+        async def _override_client(request: Request, call_next):
+            request.scope["client"] = (force_client_host, 0)
+            return await call_next(request)
+
+    @app.post("/api/system/open-folder")
+    async def open_folder(request: Request):
+        body = await request.json()
+        client_host = request.client.host if request.client else ""
+        return open_folder_impl(body, client_host)
+
+    return app
+
+
+@pytest.fixture
+def tmp_folder():
+    with tempfile.TemporaryDirectory() as d:
+        # realpath so tests see the same value the endpoint will return.
+        yield os.path.realpath(d)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_open_folder_localhost_calls_subprocess(monkeypatch, tmp_folder):
+    """Local client -> subprocess.Popen is invoked, response mode=native."""
+    calls: list[tuple] = []
+
+    def fake_popen(argv, shell=False):
+        calls.append((tuple(argv), shell))
+
+        class _P:  # minimal Popen stand-in
+            pid = 1234
+
+        return _P()
+
+    import subprocess
+
+    monkeypatch.setattr(subprocess, "Popen", fake_popen)
+
+    # Starlette's TestClient defaults `request.client.host` to the literal
+    # string "testclient", so we explicitly force 127.0.0.1 to model a user
+    # browsing the dashboard from the same host as the server process.
+    app = _build_app(force_client_host="127.0.0.1")
+    client = TestClient(app)
+    resp = client.post("/api/system/open-folder", json={"path": tmp_folder})
+
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert data["success"] is True
+    assert data["mode"] == "native"
+    assert data["path"] == tmp_folder
+
+    assert len(calls) == 1, f"expected exactly one Popen call, got {calls}"
+    argv, shell = calls[0]
+    assert argv == ("explorer", tmp_folder)
+    assert shell is False
+
+
+def test_open_folder_remote_client_skips_subprocess(monkeypatch, tmp_folder):
+    """Remote client -> subprocess is NOT invoked, response mode=remote_client."""
+    calls: list[tuple] = []
+
+    def fake_popen(argv, shell=False):  # pragma: no cover - should never run
+        calls.append((tuple(argv), shell))
+
+    import subprocess
+
+    monkeypatch.setattr(subprocess, "Popen", fake_popen)
+
+    app = _build_app(force_client_host="10.0.0.5")
+    client = TestClient(app)
+    resp = client.post("/api/system/open-folder", json={"path": tmp_folder})
+
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert data["success"] is False
+    assert data["mode"] == "remote_client"
+    assert data["path"] == tmp_folder
+    assert "hint" in data and data["hint"]
+
+    assert calls == [], (
+        "subprocess.Popen MUST NOT be called for a remote client; "
+        f"got {calls}"
+    )
+
+
+def test_open_folder_404_on_missing_path(monkeypatch):
+    """Missing path -> HTTP 404, regardless of client locality."""
+    def fake_popen(argv, shell=False):  # pragma: no cover - should never run
+        raise AssertionError("Popen must not be called for a missing path")
+
+    import subprocess
+
+    monkeypatch.setattr(subprocess, "Popen", fake_popen)
+
+    missing = os.path.join(
+        tempfile.gettempdir(), "file_activity_does_not_exist_82_bug1"
+    )
+    # Make sure it really doesn't exist.
+    assert not os.path.exists(missing)
+
+    app = _build_app()
+    client = TestClient(app)
+    resp = client.post("/api/system/open-folder", json={"path": missing})
+
+    assert resp.status_code == 404, resp.text
+
+
+def test_open_folder_impl_direct_remote_client(tmp_folder):
+    """Unit-level sanity check bypassing HTTP entirely."""
+    called: list[tuple] = []
+
+    def fake_popen(argv, shell=False):  # pragma: no cover
+        called.append((tuple(argv), shell))
+
+    data = open_folder_impl(
+        {"path": tmp_folder}, client_host="192.168.1.50", popen=fake_popen
+    )
+    assert data["success"] is False
+    assert data["mode"] == "remote_client"
+    assert called == []
+
+
+def test_open_folder_impl_rejects_empty_path():
+    """Empty / missing path key -> HTTPException 400 (preserved behaviour)."""
+    with pytest.raises(HTTPException) as exc:
+        open_folder_impl({}, client_host="127.0.0.1")
+    assert exc.value.status_code == 400


### PR DESCRIPTION
## Summary
Fix Bug 1 from #82 — `/api/system/open-folder` opened Explorer on the **server**, invisible to remote browser users. Frontend got 200 OK and showed "Dizin açılıyor" while nothing actually happened. Affects every page with a "Konuma Git" / folder-jump button (duplicates, user activity, insight detail, naming compliance, drilldown).

## Changes
- **`src/dashboard/api.py`** — new module-level `open_folder_impl(body, client_host, popen=None)` helper with dual-behaviour logic + block comment. Endpoint reduces to body parse + client_host lookup. Local host set = `{"127.0.0.1", "::1", "localhost"}`. Preserves existing security (`os.path.realpath`, `shell=False`, argv list). Remote: HTTP 200 `{success: false, mode: "remote_client", path, hint}`, no subprocess call.
- **`src/dashboard/static/index.html`** — `openFolder()` rewritten: always clipboard-copy first (with `navigator.clipboard` + `window.prompt` graceful-degradation fallback), then POST. Per-branch toasts: native → "Explorer acildi", remote_client → 12s high-visibility "Yol panoya kopyalandi. Kendi Explorer'inda yapistirin", HTTP/network error → clipboard fallback + error toast.
- **`tests/test_dashboard_api.py`** (new) — 5 tests with `fastapi.testclient.TestClient`. Remote simulation via ASGI `scope["client"]` override middleware (TestClient default host is literally `"testclient"`).

## Behaviour matrix
| Client | Path valid | Result |
|---|---|---|
| 127.0.0.1 / ::1 / localhost | ✅ | Native Explorer opens + clipboard + toast |
| remote (any other IP) | ✅ | Clipboard only + long-duration info toast |
| any | ❌ (not found) | HTTP 404 preserved |
| any | fetch/network error | Clipboard fallback + error toast |

## Test plan
- [x] `pytest tests/test_dashboard_api.py` — 5/5 pass (localhost calls subprocess, remote skips subprocess, 404 preserved, unit checks)
- [x] Full suite `pytest tests/ --ignore=tests/bench` — 220 passed, 6 skipped; no regressions
- [ ] Manual: customer clicks "Konuma Git" from remote browser → toast shows + clipboard has path

## Deliberately out of scope (Bugs 2/3/4 in #82)
- Bug 2 (insight_type silent empty fallback)
- Bug 3 (export button UX / timeout)
- Bug 4 (button regression audit infrastructure)

https://claude.ai/code/session_c7bb84b1-0f5f-4b52-847e-6d43d73a964d

---
_Generated by [Claude Code](https://claude.ai/code/session_01A1UzS1A4DZNk1akoP4uhZ7)_