### PR TITLE
AI insights: validate insight_type, surface 400 on unknown (#82 Bug 2)

### DIFF
--- a/src/analyzer/ai_insights.py
+++ b/src/analyzer/ai_insights.py
@@ -425,74 +425,91 @@ class InsightsEngine:
         return max(0, min(100, score))
 
 
-def get_insight_files(db: Database, scan_id: int, insight_type: str) -> list:
-    """Insight tipine gore dosya listesi dondur."""
-    queries = {
-        "stale_1year": """
-            SELECT id, file_path, file_name, file_size, owner, last_access_time, last_modify_time
-            FROM scanned_files WHERE scan_id=?
-            AND last_access_time < datetime('now', '-365 days')
-            ORDER BY file_size DESC
-        """,
-        "stale_3year": """
-            SELECT id, file_path, file_name, file_size, owner, last_access_time, last_modify_time
-            FROM scanned_files WHERE scan_id=?
-            AND last_access_time < datetime('now', '-1095 days')
-            ORDER BY file_size DESC
-        """,
-        "large_files": """
-            SELECT id, file_path, file_name, file_size, owner, last_access_time, last_modify_time
-            FROM scanned_files WHERE scan_id=?
-            AND file_size > 104857600
-            ORDER BY file_size DESC
-        """,
-        "temp_files": """
-            SELECT id, file_path, file_name, file_size, owner, last_access_time, last_modify_time
-            FROM scanned_files WHERE scan_id=?
-            AND (extension IN ('tmp','temp','bak','old','cache','log')
-                 OR file_name LIKE '~$%' OR file_name LIKE '%.tmp')
-            ORDER BY file_size DESC
-        """,
-        "duplicates": """
-            SELECT sf.id, sf.file_path, sf.file_name, sf.file_size, sf.owner,
-                   sf.last_access_time, sf.last_modify_time
-            FROM scanned_files sf
-            INNER JOIN (
-                SELECT file_name, file_size
-                FROM scanned_files WHERE scan_id=? AND file_size > 1048576
-                GROUP BY file_name, file_size HAVING COUNT(*) > 1
-            ) dup ON sf.file_name = dup.file_name AND sf.file_size = dup.file_size
-            WHERE sf.scan_id=?
-            ORDER BY sf.file_size DESC
-        """,
-        "empty_files": """
-            SELECT id, file_path, file_name, file_size, owner, last_access_time, last_modify_time
-            FROM scanned_files WHERE scan_id=?
-            AND file_size = 0
-            ORDER BY file_name ASC
-        """,
-        "very_large": """
-            SELECT id, file_path, file_name, file_size, owner, last_access_time, last_modify_time
-            FROM scanned_files WHERE scan_id=?
-            AND file_size > 1073741824
-            ORDER BY file_size DESC
-        """,
-        "stale_180": """
-            SELECT id, file_path, file_name, file_size, owner, last_access_time, last_modify_time
-            FROM scanned_files WHERE scan_id=?
-            AND last_access_time < datetime('now', '-180 days')
-            ORDER BY file_size DESC
-        """,
-        "all_files": """
-            SELECT id, file_path, file_name, file_size, owner, last_access_time, last_modify_time
-            FROM scanned_files WHERE scan_id=?
-            ORDER BY file_size DESC
-        """,
-    }
+# SQL queries keyed by insight_type. Defined at module level so the set of
+# valid keys (`VALID_INSIGHT_TYPES`) can be discovered without calling the
+# function — useful for the API layer's input validation and for tests.
+_INSIGHT_QUERIES: dict[str, str] = {
+    "stale_1year": """
+        SELECT id, file_path, file_name, file_size, owner, last_access_time, last_modify_time
+        FROM scanned_files WHERE scan_id=?
+        AND last_access_time < datetime('now', '-365 days')
+        ORDER BY file_size DESC
+    """,
+    "stale_3year": """
+        SELECT id, file_path, file_name, file_size, owner, last_access_time, last_modify_time
+        FROM scanned_files WHERE scan_id=?
+        AND last_access_time < datetime('now', '-1095 days')
+        ORDER BY file_size DESC
+    """,
+    "large_files": """
+        SELECT id, file_path, file_name, file_size, owner, last_access_time, last_modify_time
+        FROM scanned_files WHERE scan_id=?
+        AND file_size > 104857600
+        ORDER BY file_size DESC
+    """,
+    "temp_files": """
+        SELECT id, file_path, file_name, file_size, owner, last_access_time, last_modify_time
+        FROM scanned_files WHERE scan_id=?
+        AND (extension IN ('tmp','temp','bak','old','cache','log')
+             OR file_name LIKE '~$%' OR file_name LIKE '%.tmp')
+        ORDER BY file_size DESC
+    """,
+    "duplicates": """
+        SELECT sf.id, sf.file_path, sf.file_name, sf.file_size, sf.owner,
+               sf.last_access_time, sf.last_modify_time
+        FROM scanned_files sf
+        INNER JOIN (
+            SELECT file_name, file_size
+            FROM scanned_files WHERE scan_id=? AND file_size > 1048576
+            GROUP BY file_name, file_size HAVING COUNT(*) > 1
+        ) dup ON sf.file_name = dup.file_name AND sf.file_size = dup.file_size
+        WHERE sf.scan_id=?
+        ORDER BY sf.file_size DESC
+    """,
+    "empty_files": """
+        SELECT id, file_path, file_name, file_size, owner, last_access_time, last_modify_time
+        FROM scanned_files WHERE scan_id=?
+        AND file_size = 0
+        ORDER BY file_name ASC
+    """,
+    "very_large": """
+        SELECT id, file_path, file_name, file_size, owner, last_access_time, last_modify_time
+        FROM scanned_files WHERE scan_id=?
+        AND file_size > 1073741824
+        ORDER BY file_size DESC
+    """,
+    "stale_180": """
+        SELECT id, file_path, file_name, file_size, owner, last_access_time, last_modify_time
+        FROM scanned_files WHERE scan_id=?
+        AND last_access_time < datetime('now', '-180 days')
+        ORDER BY file_size DESC
+    """,
+    "all_files": """
+        SELECT id, file_path, file_name, file_size, owner, last_access_time, last_modify_time
+        FROM scanned_files WHERE scan_id=?
+        ORDER BY file_size DESC
+    """,
+}
 
-    query = queries.get(insight_type)
-    if not query:
-        return []
+# Public, immutable view of the supported insight types. The API layer and
+# tests can introspect this without depending on the implementation detail
+# of `_INSIGHT_QUERIES` being a dict.
+VALID_INSIGHT_TYPES: frozenset[str] = frozenset(_INSIGHT_QUERIES.keys())
+
+
+def get_insight_files(db: Database, scan_id: int, insight_type: str) -> list:
+    """Insight tipine gore dosya listesi dondur.
+
+    Bilinmeyen `insight_type` icin sessizce bos liste donmek yerine
+    `ValueError` yukseltir; cagiran katman (API) bunu HTTP 400'e cevirir
+    boylece kullanici "buton bozuk" sanmaz (issue #82, Bug 2).
+    """
+    query = _INSIGHT_QUERIES.get(insight_type)
+    if query is None:
+        raise ValueError(
+            f"Unknown insight_type: {insight_type!r}. "
+            f"Valid: {sorted(VALID_INSIGHT_TYPES)}"
+        )
 
     with db.get_cursor() as cur:
         if insight_type == "duplicates":

--- a/src/dashboard/api.py
+++ b/src/dashboard/api.py
@@ -1300,7 +1300,13 @@ def create_app(db, config, analytics=None, ad_lookup=None, email_notifier=None):
         if not scan_id:
             raise HTTPException(404, "Tarama bulunamadi")
 
-        files = get_insight_files(db, scan_id, insight_type)
+        # Bilinmeyen insight_type artik sessizce bos liste donmuyor —
+        # ValueError yukseliyor (issue #82, Bug 2). HTTP 400'e cevirip
+        # frontend'in mesaji modalda gostermesini sagliyoruz.
+        try:
+            files = get_insight_files(db, scan_id, insight_type)
+        except ValueError as e:
+            raise HTTPException(400, str(e))
         total = len(files)
         offset = (page - 1) * page_size
         page_files = files[offset:offset + page_size]

--- a/src/dashboard/static/index.html
+++ b/src/dashboard/static/index.html
@@ -1368,7 +1368,7 @@ async function loadOverview() {
                             <div style="font-size:11px;color:var(--text-secondary);margin-top:2px">${i.description}</div>
                         </div>
                         ${i.impact_size ? `<span style="font-size:12px;color:var(--text-muted);flex-shrink:0">${formatSize(i.impact_size)}</span>` : ''}
-                        <button class="btn btn-sm btn-accent" onclick="showInsightFiles('${i.insight_type || ({'stale':'stale_1year','storage':'temp_files','duplicates':'duplicates','security':'temp_files','growth':'stale_180','recommendation':'large_files','audit':'stale_1year'}[i.category] || 'all_files')}', ${sid})" style="flex-shrink:0">Incele</button>
+                        <button class="btn btn-sm btn-accent" onclick="showInsightFilesByCategory('${i.category||''}', '${i.insight_type||''}', ${sid})" style="flex-shrink:0">Incele</button>
                         ${i.action ? `<button class="btn btn-sm btn-outline" onclick="applyInsight('${i.category}', ${sid})" style="flex-shrink:0">Uygula</button>` : ''}
                     </div>
                 `).join('');
@@ -2521,7 +2521,7 @@ async function loadInsights() {
                     ${i.impact_size ? `<div style="font-size:12px;color:var(--text-muted);margin-top:6px">${formatSize(i.impact_size)}</div>` : ''}
                     ${i.file_count ? `<div style="font-size:11px;color:var(--text-muted)">${formatNum(i.file_count)} dosya</div>` : ''}
                     <div style="display:flex;gap:6px;margin-top:8px;justify-content:flex-end">
-                        <button class="btn btn-sm btn-accent" onclick="showInsightFiles('${i.insight_type || ({'stale':'stale_1year','storage':'temp_files','duplicates':'duplicates','security':'temp_files','growth':'stale_180','recommendation':'large_files','audit':'stale_1year'}[i.category] || 'all_files')}', ${sid})">Incele</button>
+                        <button class="btn btn-sm btn-accent" onclick="showInsightFilesByCategory('${i.category||''}', '${i.insight_type||''}', ${sid})">Incele</button>
                         ${i.action ? `<button class="btn btn-sm btn-outline" onclick="applyInsight('${i.category}', ${sid})">Uygula</button>` : ''}
                     </div>
                 </div>
@@ -2745,58 +2745,133 @@ function openFolder(path) {
 // AI INSIGHTS DOSYA LISTELEME
 // ═══════════════════════════════════════════════════
 
+// Insight category -> backend insight_type mapping. Centralized so callers
+// and showInsightFilesByCategory can warn on unknown categories instead of
+// silently falling back to 'all_files' (issue #82, Bug 2).
+const INSIGHT_CATEGORY_TO_TYPE = {
+    stale: 'stale_1year',
+    storage: 'temp_files',
+    duplicates: 'duplicates',
+    security: 'temp_files',
+    growth: 'stale_180',
+    recommendation: 'large_files',
+    audit: 'stale_1year'
+};
+
+// Resolve a (category, explicitInsightType) pair to a backend type string.
+// If we have to fall back to 'all_files' because the category isn't in the
+// map, warn loudly so unknown categories don't go unnoticed.
+function resolveInsightType(category, explicitInsightType) {
+    if (explicitInsightType) return explicitInsightType;
+    if (category && Object.prototype.hasOwnProperty.call(INSIGHT_CATEGORY_TO_TYPE, category)) {
+        return INSIGHT_CATEGORY_TO_TYPE[category];
+    }
+    // Mapping fell back: warn so the broken category surfaces to devs/users.
+    console.warn('Unknown insight category: %s -> falling back to all_files', category);
+    notify('Bilinmeyen insight kategorisi: ' + (category || '(bos)') + ' — tum dosyalar gosteriliyor', 'warning');
+    return 'all_files';
+}
+
+// Wrapper used from inline onclick handlers: takes the raw category +
+// optional explicit insight_type, resolves with warning on fallback, then
+// opens the modal. Kept separate from showInsightFiles so the latter can
+// still be called directly with a known-good type.
+function showInsightFilesByCategory(category, explicitInsightType, sourceId) {
+    showInsightFiles(resolveInsightType(category, explicitInsightType), sourceId);
+}
+
 async function showInsightFiles(insightType, sourceId) {
+    let data;
     try {
-        const data = await api(`/insights/${sourceId}/files?insight_type=${insightType}&page=1&page_size=200`);
-        const files = data.files || [];
-        const filesHtml = files.length ? files.map((f, i) => `
-            <tr>
-                <td>${i+1}</td>
-                <td style="max-width:200px;word-break:break-all;font-size:11px">${f.file_name}</td>
-                <td style="max-width:250px;word-break:break-all;font-size:11px" title="${f.file_path}">${f.file_path}</td>
-                <td>${f.file_size_formatted || formatSize(f.file_size)}</td>
-                <td>${f.owner || '-'}</td>
-                <td>${(f.last_access_time||'').substring(0,10)}</td>
-                <td style="white-space:nowrap"><button class="btn btn-sm btn-outline" onclick="openFolder('${(f.directory||'').replace(/\\/g,'\\\\\\\\')}')">Konuma Git</button></td>
-            </tr>
-        `).join('') : '<tr><td colspan="7" style="text-align:center;padding:20px;color:var(--text-muted)">Dosya bulunamadi</td></tr>';
+        data = await api(
+            `/insights/${sourceId}/files?insight_type=${encodeURIComponent(insightType)}&page=1&page_size=200`,
+            { silent: true }
+        );
+    } catch (e) {
+        // 400 from backend (unknown insight_type) carries a useful detail
+        // message — show it inside the modal so the user understands why
+        // the list is empty (issue #82, Bug 2).
+        notify('Dosya listesi yuklenemedi: ' + e.message, 'error');
+        showInsightFilesError(insightType, e.message);
+        return;
+    }
 
-        const typeLabels = {
-            stale_1year: '1 Yildan Eski Dosyalar',
-            stale_3year: '3+ Yillik Eski Dosyalar',
-            large_files: 'Buyuk Dosyalar (>100MB)',
-            temp_files: 'Gecici/Yedek Dosyalar',
-            duplicates: 'Kopya Dosyalar'
-        };
+    const files = data.files || [];
+    const filesHtml = files.length ? files.map((f, i) => `
+        <tr>
+            <td>${i+1}</td>
+            <td style="max-width:200px;word-break:break-all;font-size:11px">${f.file_name}</td>
+            <td style="max-width:250px;word-break:break-all;font-size:11px" title="${f.file_path}">${f.file_path}</td>
+            <td>${f.file_size_formatted || formatSize(f.file_size)}</td>
+            <td>${f.owner || '-'}</td>
+            <td>${(f.last_access_time||'').substring(0,10)}</td>
+            <td style="white-space:nowrap"><button class="btn btn-sm btn-outline" onclick="openFolder('${(f.directory||'').replace(/\\/g,'\\\\\\\\')}')">Konuma Git</button></td>
+        </tr>
+    `).join('') : '<tr><td colspan="7" style="text-align:center;padding:20px;color:var(--text-muted)">Dosya bulunamadi</td></tr>';
 
-        const modalContent = `
-            <div style="padding:20px">
-                <h3 style="margin:0 0 16px 0">${typeLabels[insightType] || insightType} - ${data.total} Dosya</h3>
-                <div style="max-height:500px;overflow-y:auto;border:1px solid var(--border);border-radius:var(--radius)">
-                    <table style="width:100%;font-size:12px">
-                        <thead style="position:sticky;top:0;background:var(--bg-secondary)"><tr><th>#</th><th>Dosya Adi</th><th>Tam Yol</th><th>Boyut</th><th>Sahip</th><th>Son Erisim</th><th>Islem</th></tr></thead>
-                        <tbody>${filesHtml}</tbody>
-                    </table>
-                </div>
-                ${data.total > 200 ? `<div style="text-align:center;padding:8px;color:var(--text-muted);font-size:11px">Ilk 200 dosya (toplam ${data.total})</div>` : ''}
-                <div style="display:flex;gap:12px;justify-content:flex-end;margin-top:16px">
-                    <button class="btn btn-outline" onclick="closeModal('modal-insight-files')">Kapat</button>
-                </div>
+    const typeLabels = {
+        stale_1year: '1 Yildan Eski Dosyalar',
+        stale_3year: '3+ Yillik Eski Dosyalar',
+        large_files: 'Buyuk Dosyalar (>100MB)',
+        temp_files: 'Gecici/Yedek Dosyalar',
+        duplicates: 'Kopya Dosyalar'
+    };
+
+    const modalContent = `
+        <div style="padding:20px">
+            <h3 style="margin:0 0 16px 0">${typeLabels[insightType] || insightType} - ${data.total} Dosya</h3>
+            <div style="max-height:500px;overflow-y:auto;border:1px solid var(--border);border-radius:var(--radius)">
+                <table style="width:100%;font-size:12px">
+                    <thead style="position:sticky;top:0;background:var(--bg-secondary)"><tr><th>#</th><th>Dosya Adi</th><th>Tam Yol</th><th>Boyut</th><th>Sahip</th><th>Son Erisim</th><th>Islem</th></tr></thead>
+                    <tbody>${filesHtml}</tbody>
+                </table>
             </div>
-        `;
+            ${data.total > 200 ? `<div style="text-align:center;padding:8px;color:var(--text-muted);font-size:11px">Ilk 200 dosya (toplam ${data.total})</div>` : ''}
+            <div style="display:flex;gap:12px;justify-content:flex-end;margin-top:16px">
+                <button class="btn btn-outline" onclick="closeModal('modal-insight-files')">Kapat</button>
+            </div>
+        </div>
+    `;
 
-        let modal = document.getElementById('modal-insight-files');
-        if (!modal) {
-            modal = document.createElement('div');
-            modal.id = 'modal-insight-files';
-            modal.className = 'modal-overlay';
-            modal.onclick = (e) => { if(e.target===modal) modal.classList.remove('active'); };
-            modal.innerHTML = '<div class="modal" style="max-width:1100px;width:95%"></div>';
-            document.body.appendChild(modal);
-        }
-        modal.querySelector('.modal').innerHTML = modalContent;
-        modal.classList.add('active');
-    } catch(e) { notify('Dosya listesi yuklenemedi: ' + e.message, 'error'); }
+    _renderInsightFilesModal(modalContent);
+}
+
+// Render an error state inside the same modal we'd use for results, so the
+// user sees *why* the list is empty rather than a phantom "broken button".
+function showInsightFilesError(insightType, detail) {
+    const safeDetail = String(detail || 'Bilinmeyen hata')
+        .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+    const safeType = String(insightType || '')
+        .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+    const modalContent = `
+        <div style="padding:20px">
+            <h3 style="margin:0 0 12px 0;color:var(--danger,#dc2626)">Dosya listesi alinamadi</h3>
+            <div style="font-size:12px;color:var(--text-secondary);margin-bottom:8px">
+                Insight tipi: <code>${safeType}</code>
+            </div>
+            <div style="font-size:13px;color:var(--text-primary);background:var(--bg-secondary);padding:12px;border-radius:var(--radius);border:1px solid var(--border);white-space:pre-wrap;word-break:break-word">
+                ${safeDetail}
+            </div>
+            <div style="display:flex;gap:12px;justify-content:flex-end;margin-top:16px">
+                <button class="btn btn-outline" onclick="closeModal('modal-insight-files')">Kapat</button>
+            </div>
+        </div>
+    `;
+    _renderInsightFilesModal(modalContent);
+}
+
+function _renderInsightFilesModal(html) {
+    let modal = document.getElementById('modal-insight-files');
+    if (!modal) {
+        modal = document.createElement('div');
+        modal.id = 'modal-insight-files';
+        modal.className = 'modal-overlay';
+        modal.onclick = (e) => { if(e.target===modal) modal.classList.remove('active'); };
+        modal.innerHTML = '<div class="modal" style="max-width:1100px;width:95%"></div>';
+        document.body.appendChild(modal);
+    }
+    modal.querySelector('.modal').innerHTML = html;
+    modal.classList.add('active');
 }
 
 // ═══════════════════════════════════════════════════

--- a/tests/test_ai_insights.py
+++ b/tests/test_ai_insights.py
@@ -1,0 +1,229 @@
+"""Tests for issue #82, Bug 2: ai_insights.get_insight_files() should
+loudly reject unknown insight_type values instead of silently returning
+an empty list (which makes the "Incele" button look broken).
+
+Covers:
+* Every key in `VALID_INSIGHT_TYPES` returns data when matching rows
+  exist.
+* An unknown `insight_type` raises `ValueError` with a helpful message
+  listing the valid types.
+* The `/api/insights/{source_id}/files` endpoint translates that
+  `ValueError` into HTTP 400 with the same detail string.
+
+These tests deliberately avoid spinning up the full `create_app(...)`
+factory — instead, we mount a minimal FastAPI app that mirrors just the
+endpoint under test. Same approach `test_dashboard_api.py` uses for the
+Bug 1 endpoint.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from datetime import datetime, timedelta
+
+import pytest
+from fastapi import FastAPI, HTTPException, Query
+from fastapi.testclient import TestClient
+
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if REPO_ROOT not in sys.path:
+    sys.path.insert(0, REPO_ROOT)
+
+from src.analyzer.ai_insights import (  # noqa: E402
+    VALID_INSIGHT_TYPES,
+    get_insight_files,
+)
+from src.storage.database import Database  # noqa: E402
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Fixtures
+# ──────────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def seeded_db(tmp_path):
+    """Database with a single source + scan and a handful of files
+    chosen so that every `VALID_INSIGHT_TYPES` query matches at least
+    one row (so we can assert non-empty results across the board).
+    """
+    db_path = tmp_path / "insights.db"
+    db = Database({"path": str(db_path)})
+    db.connect()
+
+    with db.get_cursor() as cur:
+        cur.execute(
+            "INSERT INTO sources (name, unc_path) VALUES ('s', '/x')"
+        )
+        cur.execute("INSERT INTO scan_runs (source_id) VALUES (1)")
+
+    now = datetime.now()
+    very_old = (now - timedelta(days=1500)).strftime("%Y-%m-%d %H:%M:%S")
+    old_1y = (now - timedelta(days=400)).strftime("%Y-%m-%d %H:%M:%S")
+    recent = now.strftime("%Y-%m-%d %H:%M:%S")
+
+    rows = [
+        # very_old: matches stale_1year, stale_3year, stale_180, all_files
+        ("/a/old.bin", "old.bin", "bin", 500, very_old),
+        # >100MB: large_files, all_files
+        ("/a/big.iso", "big.iso", "iso", 200 * 1024 * 1024, recent),
+        # >1GB: large_files, very_large, all_files
+        ("/a/huge.iso", "huge.iso", "iso", 2 * 1024 * 1024 * 1024, recent),
+        # tmp ext: temp_files, all_files
+        ("/a/scratch.tmp", "scratch.tmp", "tmp", 1024, recent),
+        # empty: empty_files, all_files
+        ("/a/empty.txt", "empty.txt", "txt", 0, recent),
+        # 180-day stale (not 1y): stale_180, all_files
+        ("/a/midstale.doc", "midstale.doc", "doc", 1234, old_1y),
+        # Duplicate pair (same name+size, >1MB) for "duplicates" query
+        ("/a/dup.dat", "dup.dat", "dat", 5 * 1024 * 1024, recent),
+        ("/b/dup.dat", "dup.dat", "dat", 5 * 1024 * 1024, recent),
+    ]
+    with db.get_cursor() as cur:
+        for path, name, ext, size, atime in rows:
+            cur.execute(
+                """INSERT INTO scanned_files
+                   (source_id, scan_id, file_path, relative_path, file_name,
+                    extension, file_size, last_access_time, last_modify_time,
+                    owner)
+                   VALUES (1, 1, ?, ?, ?, ?, ?, ?, ?, 'alice')""",
+                (path, name, name, ext, size, atime, atime),
+            )
+    return db
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Module-level invariants
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_valid_insight_types_is_non_empty_frozenset():
+    """The public set of valid types must be discoverable and immutable."""
+    assert isinstance(VALID_INSIGHT_TYPES, frozenset)
+    assert len(VALID_INSIGHT_TYPES) > 0
+    # The historic core types we care about must remain supported so we
+    # don't accidentally break the existing dashboard buttons.
+    for must_have in (
+        "stale_1year", "stale_3year", "stale_180", "large_files",
+        "very_large", "temp_files", "duplicates", "empty_files",
+        "all_files",
+    ):
+        assert must_have in VALID_INSIGHT_TYPES
+
+
+# ──────────────────────────────────────────────────────────────────────
+# get_insight_files: happy path
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_get_insight_files_known_types_return_data(seeded_db):
+    """Every documented insight_type returns a list (not raise) and the
+    seed data is chosen so every type matches at least one row."""
+    for itype in sorted(VALID_INSIGHT_TYPES):
+        files = get_insight_files(seeded_db, scan_id=1, insight_type=itype)
+        assert isinstance(files, list), f"{itype} did not return a list"
+        assert files, (
+            f"{itype} returned an empty list — seed data should match "
+            f"every supported insight_type"
+        )
+        # Sanity: rows are dicts with expected columns.
+        assert "file_path" in files[0]
+        assert "file_size" in files[0]
+
+
+# ──────────────────────────────────────────────────────────────────────
+# get_insight_files: unknown type
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_get_insight_files_unknown_type_raises(seeded_db):
+    """Unknown insight_type must raise ValueError, NOT silently return []
+    (issue #82, Bug 2). The message should mention the bad value and the
+    valid set so callers / users can self-correct."""
+    with pytest.raises(ValueError) as excinfo:
+        get_insight_files(seeded_db, scan_id=1, insight_type="bogus_type")
+
+    msg = str(excinfo.value)
+    assert "bogus_type" in msg
+    assert "Valid" in msg
+    # Spot-check that the message advertises at least one real type.
+    assert "all_files" in msg
+
+
+def test_get_insight_files_empty_string_raises(seeded_db):
+    """Empty string is also not a valid type."""
+    with pytest.raises(ValueError):
+        get_insight_files(seeded_db, scan_id=1, insight_type="")
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Endpoint: /api/insights/{source_id}/files
+# ──────────────────────────────────────────────────────────────────────
+
+
+def _build_endpoint_app(db: Database) -> FastAPI:
+    """Mirror the real endpoint body so we can exercise the
+    ValueError-to-HTTP-400 translation through TestClient. Mirrors the
+    pattern already used in test_dashboard_api.py for Bug 1."""
+    from src.utils.size_formatter import format_size
+
+    app = FastAPI()
+
+    @app.get("/api/insights/{source_id}/files")
+    async def insight_files(
+        source_id: int,
+        insight_type: str = "stale_1year",
+        page: int = Query(1, ge=1, le=10000),
+        page_size: int = Query(100, ge=1, le=500),
+    ):
+        scan_id = db.get_latest_scan_id(source_id, include_running=True)
+        if not scan_id:
+            raise HTTPException(404, "Tarama bulunamadi")
+        try:
+            files = get_insight_files(db, scan_id, insight_type)
+        except ValueError as e:
+            raise HTTPException(400, str(e))
+        total = len(files)
+        offset = (page - 1) * page_size
+        page_files = files[offset:offset + page_size]
+        for f in page_files:
+            f["file_size_formatted"] = format_size(f.get("file_size", 0))
+            sep = "\\" if "\\" in f["file_path"] else "/"
+            f["directory"] = f["file_path"].rsplit(sep, 1)[0]
+        return {
+            "insight_type": insight_type,
+            "total": total,
+            "page": page,
+            "page_size": page_size,
+            "total_pages": max(1, -(-total // page_size)),
+            "files": page_files,
+        }
+
+    return app
+
+
+def test_endpoint_unknown_insight_type_returns_400(seeded_db):
+    """Hitting the endpoint with `?insight_type=bogus` should yield a
+    400 (not 200 + empty list, not 500). The detail string should carry
+    the same explanation get_insight_files raises so the frontend can
+    show it directly in the modal."""
+    client = TestClient(_build_endpoint_app(seeded_db))
+    r = client.get("/api/insights/1/files", params={"insight_type": "bogus"})
+    assert r.status_code == 400, r.text
+    body = r.json()
+    assert "bogus" in body["detail"]
+    assert "Valid" in body["detail"]
+
+
+def test_endpoint_known_insight_type_returns_200(seeded_db):
+    """Sanity check: a known type still works through the endpoint."""
+    client = TestClient(_build_endpoint_app(seeded_db))
+    r = client.get(
+        "/api/insights/1/files", params={"insight_type": "all_files"}
+    )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["insight_type"] == "all_files"
+    assert body["total"] >= 1
+    assert len(body["files"]) == body["total"] or body["total"] > body["page_size"]


### PR DESCRIPTION
## Summary
Bug 2 from #82 — `get_insight_files()` returned `[]` for unknown `insight_type`, frontend mapping fell back to `'all_files'` silently. User clicks "Incele" → empty list → "broken".

- `src/analyzer/ai_insights.py`: `queries` lifted to module-level `_INSIGHT_QUERIES`, public `VALID_INSIGHT_TYPES = frozenset(...)`. `get_insight_files()` now raises `ValueError(f"Unknown insight_type: {insight_type!r}. Valid: {sorted(VALID_INSIGHT_TYPES)}")` for unknown types.
- `src/dashboard/api.py`: `/api/insights/{source_id}/files` catches `ValueError` and raises `HTTPException(400, str(e))`.
- `src/dashboard/static/index.html`:
  - Mapping centralised into `INSIGHT_CATEGORY_TO_TYPE`
  - New `resolveInsightType(category, explicitInsightType)` — emits `console.warn` + user notification when falling back to `all_files`
  - New `showInsightFilesByCategory(...)` wrapper replaces duplicated inline mapping at the two onclick sites (lines ~1371, ~2524)
  - New `showInsightFilesError(...)` modal renderer; 400 responses routed through it with the backend detail string
- `tests/test_ai_insights.py` (new) — 6 tests covering every valid type, unknown type, empty string, endpoint 400/200, and `VALID_INSIGHT_TYPES` invariants

## Test plan
- [x] `pytest tests/test_ai_insights.py tests/test_dashboard_api.py -v` → 11 passed
- [x] Bug 1's existing `test_dashboard_api.py` still green
- [ ] Manual: click "Incele" with a category that's now properly mapped → list renders; force a bogus type via URL → 400 toast

## Out of scope
- Bug 1 (already fixed in PR #85)
- Bug 3 (parallel PR #95 — export UX)
- Bug 4 (button regression audit infrastructure)

https://claude.ai/code/session_5eff776b-9c1d-43b7-b688-b8c6311a8c51

---
_Generated by [Claude Code](https://claude.ai/code/session_01A1UzS1A4DZNk1akoP4uhZ7)_