### PR TITLE
Reusable entity-list + XLSX export, applied to mit-naming (#80 Phase 1)

### DIFF
--- a/src/dashboard/api.py
+++ b/src/dashboard/api.py
@@ -1288,6 +1288,152 @@ def create_app(db, config, analytics=None, ad_lookup=None, email_notifier=None):
             headers={"Content-Disposition": f"attachment; filename={filename}"}
         )
 
+    @app.get("/api/reports/mit-naming/{source_id}/export.xlsx")
+    async def export_mit_naming_xlsx(
+        source_id: int,
+        ids: Optional[str] = Query(
+            None,
+            description="Comma-separated scanned_files.id values; empty = all violating rows",
+        ),
+    ):
+        """Export MIT-naming violations as XLSX (issue #80).
+
+        Columns: file_path, owner, last_modify_time, file_size, rule, severity.
+        One row per (file × violated rule); a single file violating R1+B4
+        produces two rows. ``ids`` filters to scanned_files.id values; empty
+        means every violating row in the latest scan.
+        """
+        import re as re_mod
+        from fastapi.responses import StreamingResponse
+        import io
+        from datetime import datetime
+
+        try:
+            from openpyxl import Workbook
+        except ImportError as e:  # pragma: no cover - openpyxl is in requirements.txt
+            raise HTTPException(
+                500,
+                "openpyxl is not installed; add openpyxl>=3.1.0 to requirements.txt",
+            ) from e
+
+        scan_id = db.get_latest_scan_id(source_id, include_running=True)
+        if not scan_id:
+            raise HTTPException(404, "Tarama bulunamadi")
+
+        # Rule definitions: code -> (label, severity, predicate(path, name))
+        # severity matches MITNamingAnalyzer.get_report() conventions.
+        rules = [
+            ("R1", "Bosluk Iceren", "critical",
+             lambda p, n: bool(re_mod.search(r"\s", n))),
+            ("R2", "Ilk Karakter Harf Degil", "critical",
+             lambda p, n: bool(n) and not re_mod.match(r"^[a-zA-Z]", n)),
+            ("R3", "Yasak Karakter", "critical",
+             lambda p, n: bool(n) and "." in n
+             and not re_mod.match(r"^[a-zA-Z0-9._-]+$", n[: n.rfind(".")])),
+            ("R4", "Uzanti Sorunu", "critical",
+             lambda p, n: "." not in n or not n.rsplit(".", 1)[-1].isalpha()),
+            ("B1", "Uzun Ad (>31)", "warning",
+             lambda p, n: len(n) > 31),
+            ("B2", "Uzun Yol (>256)", "warning",
+             lambda p, n: len(p) > 256),
+            ("B3", "Base'de Nokta", "warning",
+             lambda p, n: "." in n and n[: n.rfind(".")].count(".") > 0),
+            ("B4", "Buyuk Harf", "info",
+             lambda p, n: bool(re_mod.search(
+                 r"[A-Z]", n[: n.rfind(".")] if "." in n else n))),
+            ("B5", "Ayirici Yok", "info",
+             lambda p, n: len(n) > 10 and "_" not in n and "-" not in n),
+            ("B6", "Dizin Adinda Nokta", "info",
+             lambda p, n: any(
+                 "." in part and part not in ("", ".", "..")
+                 for part in p.replace("\\", "/").split("/")
+             )),
+        ]
+
+        # Parse the optional ids filter once.
+        id_filter: Optional[set] = None
+        if ids:
+            id_filter = set()
+            for tok in ids.split(","):
+                tok = tok.strip()
+                if not tok:
+                    continue
+                try:
+                    id_filter.add(int(tok))
+                except ValueError:
+                    # Skip non-numeric tokens silently — exporting is best-effort.
+                    continue
+
+        # Collect violating (file × rule) rows.
+        export_rows: list[dict] = []
+        with db.get_cursor() as cur:
+            cur.execute(
+                """SELECT id, file_path, file_name, owner, last_modify_time, file_size
+                   FROM scanned_files
+                   WHERE source_id = ? AND scan_id = ?""",
+                (source_id, scan_id),
+            )
+            for r in cur:
+                if id_filter is not None and r["id"] not in id_filter:
+                    continue
+                path = r["file_path"] or ""
+                name = r["file_name"] or ""
+                for code, label, severity, fn in rules:
+                    try:
+                        if fn(path, name):
+                            export_rows.append({
+                                "file_path": path,
+                                "owner": r["owner"] or "",
+                                "last_modify_time": r["last_modify_time"] or "",
+                                "file_size": r["file_size"] or 0,
+                                "rule": f"{code} - {label}",
+                                "severity": severity,
+                            })
+                    except Exception:  # pragma: no cover - defensive predicate guard
+                        continue
+
+        # Build workbook in-memory.
+        wb = Workbook()
+        ws = wb.active
+        ws.title = "MIT Naming"
+        headers = ["file_path", "owner", "last_modify_time",
+                   "file_size", "rule", "severity"]
+        ws.append(headers)
+        for row in export_rows:
+            ws.append([row[h] for h in headers])
+
+        # Total wasted-bytes formula across all rows (column D = file_size).
+        # Empty result -> "0" so the cell is still meaningful.
+        last_data_row = ws.max_row
+        if last_data_row > 1:
+            total_row = last_data_row + 2
+            ws.cell(row=total_row, column=3, value="TOTAL BYTES")
+            ws.cell(
+                row=total_row,
+                column=4,
+                value=f"=SUM(D2:D{last_data_row})",
+            )
+
+        buf = io.BytesIO()
+        wb.save(buf)
+        buf.seek(0)
+
+        filename = (
+            f"MIT_Naming_Report_source{source_id}_scan{scan_id}_"
+            f"{datetime.now().strftime('%Y%m%d_%H%M%S')}.xlsx"
+        )
+        return StreamingResponse(
+            buf,
+            media_type=(
+                "application/vnd.openxmlformats-officedocument."
+                "spreadsheetml.sheet"
+            ),
+            headers={
+                "Content-Disposition": f"attachment; filename={filename}",
+                "X-Total-Rows": str(len(export_rows)),
+            },
+        )
+
     @app.get("/api/insights/{source_id}/files")
     async def insight_files(source_id: int, insight_type: str = "stale_1year",
                             page: int = Query(1, ge=1, le=10000),

--- a/src/dashboard/static/components/entity-list.js
+++ b/src/dashboard/static/components/entity-list.js
@@ -1,0 +1,466 @@
+/**
+ * Reusable entity-list component (issue #80).
+ *
+ * Vanilla JS, no framework. Renders a multi-select, sortable, paginated,
+ * filterable table with toolbar (search + bulk actions + XLSX/CSV export).
+ *
+ * Public API:
+ *   renderEntityList(container, options)
+ *
+ * options = {
+ *   rows:        [...],                    // pre-fetched data
+ *   columns:     [
+ *     {key: 'file_path', label: 'Dosya', sort: true},
+ *     {key: 'severity',  label: 'Onem',  render: (val, row) => '<span>...</span>'},
+ *   ],
+ *   searchKeys:  ['file_path', 'rule'],    // optional; defaults to all column keys
+ *   pageSize:    50,                       // optional, default 50
+ *   rowKey:      'id',                     // optional; for stable selection across re-renders
+ *   toolbar: {
+ *     xlsxExport:  {endpoint: '/api/.../export.xlsx', filenameBase: 'naming-1'},
+ *     csvExport:   {endpoint: '/api/.../export.csv',  filenameBase: 'naming-1'},
+ *     bulkActions: [
+ *       {label: 'Hedefe Git', action: 'open-folder'},
+ *       {label: 'Toplu Arsivle', action: 'bulk-archive', confirm: true,
+ *        comingSoon: 'Yakinda eklenecek (#83)'},
+ *     ],
+ *   },
+ *   onBulkAction: async (actionId, selectedRows) => {...},
+ *   emptyMessage: 'Sonuc yok',             // optional
+ * }
+ *
+ * The component does NOT hardcode any column / endpoint / action — callers
+ * must supply them. Bulk-action handlers are dispatched via onBulkAction;
+ * actions flagged comingSoon emit a toast and skip the handler entirely
+ * (used for #83 destructive ops that aren't implemented yet).
+ */
+(function () {
+    'use strict';
+
+    // ---- helpers --------------------------------------------------------
+
+    function _escape(v) {
+        if (v === null || v === undefined) return '';
+        return String(v)
+            .replace(/&/g, '&amp;')
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;')
+            .replace(/"/g, '&quot;')
+            .replace(/'/g, '&#39;');
+    }
+
+    function _toast(msg, type) {
+        // Prefer the host page's notify() if present; otherwise fallback.
+        if (typeof window.notify === 'function') {
+            window.notify(msg, type || 'info');
+        } else {
+            // Fallback: console + alert-on-error.
+            if (type === 'error') console.error(msg);
+            else console.log('[entity-list]', msg);
+        }
+    }
+
+    function _downloadUrl(url, filename) {
+        const a = document.createElement('a');
+        a.href = url;
+        if (filename) a.download = filename;
+        document.body.appendChild(a);
+        a.click();
+        document.body.removeChild(a);
+    }
+
+    function _matchesSearch(row, query, keys) {
+        if (!query) return true;
+        const q = query.toLowerCase();
+        for (const k of keys) {
+            const v = row[k];
+            if (v === undefined || v === null) continue;
+            if (String(v).toLowerCase().indexOf(q) !== -1) return true;
+        }
+        return false;
+    }
+
+    function _compareValues(a, b) {
+        if (a === b) return 0;
+        if (a === null || a === undefined) return -1;
+        if (b === null || b === undefined) return 1;
+        const an = Number(a), bn = Number(b);
+        if (!Number.isNaN(an) && !Number.isNaN(bn) && a !== '' && b !== '') {
+            return an - bn;
+        }
+        return String(a).localeCompare(String(b));
+    }
+
+    // ---- main -----------------------------------------------------------
+
+    function renderEntityList(container, options) {
+        if (!container) throw new Error('renderEntityList: container is required');
+        const opts = options || {};
+        const columns = Array.isArray(opts.columns) ? opts.columns : [];
+        const rows = Array.isArray(opts.rows) ? opts.rows : [];
+        const pageSize = Number(opts.pageSize) || 50;
+        const rowKey = opts.rowKey || null;
+        const toolbar = opts.toolbar || {};
+        const onBulkAction = typeof opts.onBulkAction === 'function'
+            ? opts.onBulkAction : null;
+        const emptyMessage = opts.emptyMessage || 'Sonuc yok';
+        const searchKeys = Array.isArray(opts.searchKeys) && opts.searchKeys.length
+            ? opts.searchKeys
+            : columns.map(function (c) { return c.key; });
+
+        const state = {
+            search: '',
+            sortKey: null,
+            sortDir: null,        // 'asc' | 'desc' | null
+            page: 1,
+            selected: new Set(),  // rowKey value, or numeric index when no rowKey
+        };
+
+        // Generate stable IDs for elements within this container so multiple
+        // entity-lists on the same page do not collide.
+        const ns = 'el-' + Math.random().toString(36).slice(2, 9);
+
+        function _idFor(row, idx) {
+            return rowKey ? row[rowKey] : idx;
+        }
+
+        function _filteredRows() {
+            let list = rows;
+            if (state.search) {
+                list = list.filter(function (r) {
+                    return _matchesSearch(r, state.search, searchKeys);
+                });
+            }
+            if (state.sortKey && state.sortDir) {
+                const k = state.sortKey;
+                const dir = state.sortDir === 'desc' ? -1 : 1;
+                list = list.slice().sort(function (a, b) {
+                    return dir * _compareValues(a[k], b[k]);
+                });
+            }
+            return list;
+        }
+
+        function _pagedRows(filtered) {
+            const start = (state.page - 1) * pageSize;
+            return filtered.slice(start, start + pageSize);
+        }
+
+        function _selectedRowObjects() {
+            const sel = [];
+            rows.forEach(function (r, i) {
+                if (state.selected.has(_idFor(r, i))) sel.push(r);
+            });
+            return sel;
+        }
+
+        // ---- toolbar HTML ----------------------------------------------
+
+        function _renderToolbar() {
+            const parts = [];
+            parts.push('<div class="' + ns + '-toolbar" style="display:flex;flex-wrap:wrap;gap:8px;align-items:center;padding:10px;background:var(--bg-secondary);border-bottom:1px solid var(--border)">');
+
+            // search
+            parts.push(
+                '<input type="text" class="' + ns + '-search" placeholder="Ara..." ' +
+                'value="' + _escape(state.search) + '" ' +
+                'style="flex:1;min-width:160px;padding:6px 10px;background:var(--bg-input);border:1px solid var(--border);border-radius:6px;color:var(--text-primary);font-size:12px">'
+            );
+
+            // select all / clear
+            parts.push(
+                '<button class="btn btn-sm btn-outline ' + ns + '-select-all" type="button">Tumu Sec</button>' +
+                '<button class="btn btn-sm btn-outline ' + ns + '-clear-sel" type="button">Secimi Kaldir</button>'
+            );
+
+            // selected badge
+            parts.push(
+                '<span class="' + ns + '-sel-count" style="font-size:12px;color:var(--text-secondary);padding:4px 10px;background:var(--bg-card);border-radius:12px">' +
+                state.selected.size + ' secili</span>'
+            );
+
+            // exports
+            if (toolbar.xlsxExport && toolbar.xlsxExport.endpoint) {
+                parts.push('<button class="btn btn-sm btn-outline ' + ns + '-xlsx" type="button" title="XLSX olarak indir">XLSX</button>');
+            }
+            if (toolbar.csvExport && toolbar.csvExport.endpoint) {
+                parts.push('<button class="btn btn-sm btn-outline ' + ns + '-csv" type="button" title="CSV olarak indir">CSV</button>');
+            }
+
+            // bulk actions
+            const bulk = Array.isArray(toolbar.bulkActions) ? toolbar.bulkActions : [];
+            bulk.forEach(function (a, i) {
+                const cls = a.danger ? 'btn-danger' : 'btn-outline';
+                parts.push(
+                    '<button class="btn btn-sm ' + cls + ' ' + ns + '-bulk" data-bulk-idx="' + i + '" type="button">' +
+                    _escape(a.label) +
+                    '</button>'
+                );
+            });
+
+            parts.push('</div>');
+            return parts.join('');
+        }
+
+        // ---- table HTML ------------------------------------------------
+
+        function _renderTable() {
+            const filtered = _filteredRows();
+            const total = filtered.length;
+            const pageRows = _pagedRows(filtered);
+            const totalPages = Math.max(1, Math.ceil(total / pageSize));
+            if (state.page > totalPages) state.page = totalPages;
+
+            const parts = [];
+            parts.push('<div class="' + ns + '-table-wrap" style="overflow-x:auto">');
+            parts.push('<table style="width:100%;font-size:12px"><thead><tr>');
+
+            // header checkbox
+            parts.push(
+                '<th style="width:32px"><input type="checkbox" class="' + ns + '-header-chk"></th>'
+            );
+
+            columns.forEach(function (c) {
+                const sortable = c.sort !== false; // default true
+                const isSorted = state.sortKey === c.key;
+                const arrow = isSorted ? (state.sortDir === 'asc' ? ' ▲' : (state.sortDir === 'desc' ? ' ▼' : '')) : '';
+                parts.push(
+                    '<th data-col-key="' + _escape(c.key) + '"' +
+                    (sortable ? ' style="cursor:pointer;user-select:none" class="' + ns + '-sort-th"' : '') +
+                    '>' + _escape(c.label || c.key) + arrow + '</th>'
+                );
+            });
+
+            parts.push('</tr></thead><tbody>');
+
+            if (pageRows.length === 0) {
+                parts.push(
+                    '<tr><td colspan="' + (columns.length + 1) + '" ' +
+                    'style="text-align:center;padding:30px;color:var(--text-muted)">' +
+                    _escape(emptyMessage) + '</td></tr>'
+                );
+            } else {
+                pageRows.forEach(function (row) {
+                    const idx = rows.indexOf(row);
+                    const id = _idFor(row, idx);
+                    const checked = state.selected.has(id) ? ' checked' : '';
+                    parts.push('<tr data-row-idx="' + idx + '">');
+                    parts.push(
+                        '<td><input type="checkbox" class="' + ns + '-row-chk"' + checked + '></td>'
+                    );
+                    columns.forEach(function (c) {
+                        let cell;
+                        if (typeof c.render === 'function') {
+                            try {
+                                cell = c.render(row[c.key], row);
+                            } catch (e) {
+                                cell = '';
+                            }
+                            // render() may return raw HTML — caller's responsibility.
+                            if (cell === undefined || cell === null) cell = '';
+                        } else {
+                            cell = _escape(row[c.key]);
+                        }
+                        parts.push('<td>' + cell + '</td>');
+                    });
+                    parts.push('</tr>');
+                });
+            }
+
+            parts.push('</tbody></table></div>');
+
+            // footer / pagination
+            const start = total === 0 ? 0 : (state.page - 1) * pageSize + 1;
+            const end = Math.min(state.page * pageSize, total);
+            parts.push(
+                '<div class="' + ns + '-foot" style="display:flex;justify-content:space-between;align-items:center;padding:8px 12px;font-size:12px;color:var(--text-secondary);border-top:1px solid var(--border);background:var(--bg-secondary)">' +
+                '<span>' + start + '-' + end + ' / ' + total + ' (toplam ' + rows.length + ')</span>' +
+                '<span>' +
+                '<button class="btn btn-sm btn-outline ' + ns + '-prev" type="button"' + (state.page <= 1 ? ' disabled' : '') + '>Onceki</button>' +
+                ' <span style="margin:0 8px">Sayfa ' + state.page + ' / ' + totalPages + '</span>' +
+                '<button class="btn btn-sm btn-outline ' + ns + '-next" type="button"' + (state.page >= totalPages ? ' disabled' : '') + '>Sonraki</button>' +
+                '</span></div>'
+            );
+
+            return parts.join('');
+        }
+
+        // ---- mount + bind ---------------------------------------------
+
+        function _render() {
+            container.innerHTML =
+                '<div class="' + ns + '-root" style="background:var(--bg-card);border:1px solid var(--border);border-radius:var(--radius);overflow:hidden">' +
+                _renderToolbar() +
+                _renderTable() +
+                '</div>';
+            _bind();
+        }
+
+        function _bind() {
+            // search
+            const searchEl = container.querySelector('.' + ns + '-search');
+            if (searchEl) {
+                let t;
+                searchEl.addEventListener('input', function () {
+                    clearTimeout(t);
+                    const v = this.value;
+                    t = setTimeout(function () {
+                        state.search = v;
+                        state.page = 1;
+                        _render();
+                    }, 150);
+                });
+            }
+
+            // select all visible (current page) / clear
+            const selAllBtn = container.querySelector('.' + ns + '-select-all');
+            if (selAllBtn) {
+                selAllBtn.addEventListener('click', function () {
+                    _filteredRows().forEach(function (r) {
+                        state.selected.add(_idFor(r, rows.indexOf(r)));
+                    });
+                    _render();
+                });
+            }
+            const clearBtn = container.querySelector('.' + ns + '-clear-sel');
+            if (clearBtn) {
+                clearBtn.addEventListener('click', function () {
+                    state.selected.clear();
+                    _render();
+                });
+            }
+
+            // header checkbox: toggle visible page rows
+            const headerChk = container.querySelector('.' + ns + '-header-chk');
+            if (headerChk) {
+                const visible = _pagedRows(_filteredRows());
+                const allSel = visible.length > 0 && visible.every(function (r) {
+                    return state.selected.has(_idFor(r, rows.indexOf(r)));
+                });
+                headerChk.checked = allSel;
+                headerChk.addEventListener('change', function () {
+                    visible.forEach(function (r) {
+                        const id = _idFor(r, rows.indexOf(r));
+                        if (headerChk.checked) state.selected.add(id);
+                        else state.selected.delete(id);
+                    });
+                    _render();
+                });
+            }
+
+            // per-row checkboxes
+            container.querySelectorAll('.' + ns + '-row-chk').forEach(function (chk) {
+                chk.addEventListener('change', function () {
+                    const tr = chk.closest('tr');
+                    const idx = Number(tr.getAttribute('data-row-idx'));
+                    const id = _idFor(rows[idx], idx);
+                    if (chk.checked) state.selected.add(id);
+                    else state.selected.delete(id);
+                    // light update without full re-render to keep inputs focused
+                    const counter = container.querySelector('.' + ns + '-sel-count');
+                    if (counter) counter.textContent = state.selected.size + ' secili';
+                });
+            });
+
+            // sort headers
+            container.querySelectorAll('.' + ns + '-sort-th').forEach(function (th) {
+                th.addEventListener('click', function () {
+                    const k = th.getAttribute('data-col-key');
+                    if (state.sortKey !== k) {
+                        state.sortKey = k;
+                        state.sortDir = 'asc';
+                    } else if (state.sortDir === 'asc') {
+                        state.sortDir = 'desc';
+                    } else if (state.sortDir === 'desc') {
+                        state.sortKey = null;
+                        state.sortDir = null;
+                    } else {
+                        state.sortDir = 'asc';
+                    }
+                    _render();
+                });
+            });
+
+            // pagination
+            const prev = container.querySelector('.' + ns + '-prev');
+            if (prev) prev.addEventListener('click', function () {
+                if (state.page > 1) { state.page--; _render(); }
+            });
+            const next = container.querySelector('.' + ns + '-next');
+            if (next) next.addEventListener('click', function () {
+                state.page++; _render();
+            });
+
+            // exports
+            const xlsxBtn = container.querySelector('.' + ns + '-xlsx');
+            if (xlsxBtn) xlsxBtn.addEventListener('click', function () {
+                _doExport(toolbar.xlsxExport, 'xlsx');
+            });
+            const csvBtn = container.querySelector('.' + ns + '-csv');
+            if (csvBtn) csvBtn.addEventListener('click', function () {
+                _doExport(toolbar.csvExport, 'csv');
+            });
+
+            // bulk actions
+            container.querySelectorAll('.' + ns + '-bulk').forEach(function (btn) {
+                btn.addEventListener('click', function () {
+                    const idx = Number(btn.getAttribute('data-bulk-idx'));
+                    const action = (toolbar.bulkActions || [])[idx];
+                    if (!action) return;
+                    if (action.comingSoon) {
+                        _toast(action.comingSoon, 'info');
+                        return;
+                    }
+                    const selected = _selectedRowObjects();
+                    if (selected.length === 0) {
+                        _toast('Once en az bir satir secin', 'warning');
+                        return;
+                    }
+                    if (action.confirm) {
+                        const msg = typeof action.confirm === 'string'
+                            ? action.confirm
+                            : (action.label + ': ' + selected.length + ' satir icin onayliyor musunuz?');
+                        if (!window.confirm(msg)) return;
+                    }
+                    if (onBulkAction) {
+                        Promise.resolve()
+                            .then(function () { return onBulkAction(action.action, selected); })
+                            .catch(function (e) {
+                                _toast('Toplu islem hatasi: ' + (e && e.message ? e.message : e), 'error');
+                            });
+                    }
+                });
+            });
+        }
+
+        function _doExport(exportCfg, kind) {
+            if (!exportCfg || !exportCfg.endpoint) return;
+            const ids = [];
+            if (state.selected.size > 0) {
+                state.selected.forEach(function (v) { ids.push(v); });
+            }
+            let url = exportCfg.endpoint;
+            if (ids.length > 0) {
+                const sep = url.indexOf('?') === -1 ? '?' : '&';
+                url = url + sep + 'ids=' + encodeURIComponent(ids.join(','));
+            }
+            const base = exportCfg.filenameBase || 'export';
+            const ts = new Date().toISOString().replace(/[:.]/g, '-').slice(0, 19);
+            const filename = base + '_' + ts + '.' + kind;
+            _downloadUrl(url, filename);
+            _toast(kind.toUpperCase() + ' indirme baslatildi', 'info');
+        }
+
+        _render();
+
+        // Return a small handle so callers can re-render or inspect state.
+        return {
+            getSelected: _selectedRowObjects,
+            clearSelection: function () { state.selected.clear(); _render(); },
+            rerender: _render,
+        };
+    }
+
+    // expose globally — index.html includes this file with a plain <script>
+    window.renderEntityList = renderEntityList;
+})();

--- a/src/dashboard/static/index.html
+++ b/src/dashboard/static/index.html
@@ -6,6 +6,7 @@
 <title>FILE ACTIVITY - Dashboard</title>
 <script src="https://cdn.jsdelivr.net/npm/d3@7"></script>
 <script src="https://cdn.jsdelivr.net/npm/chart.js@4"></script>
+<script src="/static/components/entity-list.js"></script>
 <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'><text y='28' font-size='28'>📊</text></svg>">
 <style>
 :root {
@@ -692,6 +693,16 @@ label { font-size: 12px; color: var(--text-muted); margin-bottom: 6px; display: 
     <div class="panel" style="margin-top:20px">
         <h3 class="panel-title" style="color:var(--warning)">En Iyi Uygulama Sapmalari (Best Practices)</h3>
         <div class="table-wrap"><table id="naming-bp-table"></table></div>
+    </div>
+
+    <!-- ============ Issue #80: Reusable entity-list (toplu islemler) ============ -->
+    <div class="panel" style="margin-top:20px">
+        <h3 class="panel-title">Ihlal Eden Dosyalar (Toplu Islemler)</h3>
+        <div style="font-size:11px;color:var(--text-muted);margin-bottom:10px">
+            Asagidaki tabloda en cok ihlal alan ilk dosyalar listelenir. XLSX export
+            tum ihlalleri (file × rule) dosyaya yazar.
+        </div>
+        <div id="mit-naming-container"></div>
     </div>
 </div>
 
@@ -2689,7 +2700,134 @@ async function loadNaming() {
         }
         // Export butonunu goster
         document.getElementById('naming-export-btn').style.display = '';
+
+        // Issue #80: reusable entity-list ile ihlal eden dosyalari listele
+        renderMitNamingEntityList(sourceId, data);
     } catch(e) { console.error('MIT naming load error:', e); }
+}
+
+// Issue #80 — entity-list component'ini mit-naming sayfasina baglar.
+async function renderMitNamingEntityList(sourceId, report) {
+    const container = document.getElementById('mit-naming-container');
+    if (!container || typeof renderEntityList !== 'function') return;
+
+    // Loading shimmer
+    container.innerHTML =
+        '<div style="padding:30px;text-align:center;color:var(--text-muted);font-size:12px">' +
+        'Ihlal eden dosyalar yukleniyor...</div>';
+
+    // Hangi kurallar icin dosya cekilecek? Rapordaki kurallar (count > 0).
+    const codesToFetch = []
+        .concat((report.requirements || []).map(r => r.code))
+        .concat((report.best_practices || []).map(b => b.code));
+
+    if (codesToFetch.length === 0) {
+        container.innerHTML =
+            '<div style="padding:30px;text-align:center;color:var(--success);font-size:13px">' +
+            'Hicbir ihlal yok — listelenecek dosya bulunamadi.</div>';
+        return;
+    }
+
+    // Her kural icin ilk 50 dosyayi cek; ayni dosyayi birden fazla kural
+    // birlestirecekse "rules" alaninda biriktir. UI tarafinda her satir =
+    // bir dosya (cogu rule violating); XLSX export'unda her (dosya × rule).
+    try {
+        const results = await Promise.all(codesToFetch.map(code =>
+            api(`/reports/mit-naming/${sourceId}/files?code=${code}&page=1&page_size=50`,
+                {silent: true}).catch(() => ({files: []}))
+        ));
+
+        const byId = new Map();
+        codesToFetch.forEach((code, i) => {
+            (results[i].files || []).forEach(f => {
+                const key = f.id != null ? f.id : f.file_path;
+                if (!byId.has(key)) {
+                    byId.set(key, {
+                        id: f.id,
+                        file_path: f.file_path,
+                        file_name: f.file_name,
+                        directory: f.directory || '',
+                        owner: f.owner || '',
+                        last_modify_time: f.last_modify_time || '',
+                        file_size: f.file_size || 0,
+                        file_size_formatted: f.file_size_formatted || formatSize(f.file_size || 0),
+                        rules: [],
+                    });
+                }
+                byId.get(key).rules.push(code);
+            });
+        });
+
+        const rows = Array.from(byId.values())
+            .sort((a, b) => b.rules.length - a.rules.length)
+            .slice(0, 1000); // UI cap; XLSX export covers everything server-side
+
+        // Determine highest severity per row.
+        const severityOf = code => {
+            if (code && code[0] === 'R') return 'danger';
+            if (code === 'B1' || code === 'B2' || code === 'B3') return 'warning';
+            return 'info';
+        };
+
+        rows.forEach(r => {
+            r.severity = r.rules.some(c => c[0] === 'R') ? 'danger'
+                : r.rules.some(c => ['B1','B2','B3'].includes(c)) ? 'warning' : 'info';
+            r.rule_summary = r.rules.join(', ');
+        });
+
+        renderEntityList(container, {
+            rows: rows,
+            rowKey: 'id',
+            pageSize: 50,
+            searchKeys: ['file_path', 'file_name', 'owner', 'rule_summary'],
+            columns: [
+                {key: 'file_name', label: 'Dosya Adi'},
+                {key: 'file_path', label: 'Tam Yol'},
+                {key: 'rule_summary', label: 'Ihlal Kodlari'},
+                {key: 'severity', label: 'Onem',
+                 render: v => `<span class="badge badge-${v}">${v}</span>`},
+                {key: 'file_size', label: 'Boyut',
+                 render: (v, row) => row.file_size_formatted || formatSize(v || 0)},
+                {key: 'owner', label: 'Sahip'},
+            ],
+            toolbar: {
+                xlsxExport: {
+                    endpoint: `/api/reports/mit-naming/${sourceId}/export.xlsx`,
+                    filenameBase: `naming-${sourceId}`,
+                },
+                bulkActions: [
+                    {label: 'Hedefe Git', action: 'open-folder'},
+                    // Destructive actions deferred to issue #83.
+                    {label: 'Toplu Arsivle', action: 'bulk-archive',
+                     confirm: true, comingSoon: 'Yakinda eklenecek (#83)'},
+                    {label: 'Legal Hold Ekle', action: 'add-hold',
+                     confirm: true, comingSoon: 'Yakinda eklenecek (#83)'},
+                ],
+            },
+            onBulkAction: async (actionId, selectedRows) => {
+                if (actionId === 'open-folder') {
+                    if (selectedRows.length > 5) {
+                        notify('Bir defada en fazla 5 konum acilabilir', 'warning');
+                        return;
+                    }
+                    for (const r of selectedRows) {
+                        // Use existing openFolder() — already handles localhost vs
+                        // remote per #82 Bug 1 fix.
+                        const target = r.directory || (r.file_path || '').replace(/[\\/][^\\/]*$/, '');
+                        if (target) openFolder(target);
+                    }
+                    return;
+                }
+                // Other action ids fall here only if not flagged comingSoon.
+                notify('Bilinmeyen toplu islem: ' + actionId, 'warning');
+            },
+            emptyMessage: 'Ihlal eden dosya bulunamadi',
+        });
+    } catch (e) {
+        container.innerHTML =
+            '<div style="padding:20px;color:var(--danger);font-size:12px">' +
+            'Liste yuklenemedi: ' + (e && e.message ? e.message : e) + '</div>';
+    }
 }
 
 async function showNamingFiles(code, sourceId) {
@@ -2741,13 +2879,15 @@ async function showNamingFiles(code, sourceId) {
 async function exportNamingReport(event) {
     const sourceId = document.getElementById('naming-source')?.value;
     if (!sourceId) { notify('Lutfen kaynak secin', 'warning'); return; }
+    // Issue #80: streaming XLSX endpoint -- direct download via fetch
+    // wrapped in #82 Bug 3 withButtonLoading helper (spinner + abort timeout).
     const btn = event?.currentTarget;
     await withButtonLoading(btn, async (signal) => {
-        const r = await fetch(`/api/export/start?report_type=mit_naming&source_id=${sourceId}`, { method: 'POST', signal });
-        if (!r.ok) throw new Error(`HTTP ${r.status}`);
-        const data = await r.json();
-        notify('Excel raporu arka planda hazirlaniyor...', 'info');
-        if (data && data.job_id) pollExportStatus(data.job_id);
+        await fetchAndDownload(
+            `${API}/reports/mit-naming/${sourceId}/export.xlsx`,
+            signal,
+            `naming-${sourceId}.xlsx`
+        );
     });
 }
 

--- a/tests/test_mit_naming_xlsx_export.py
+++ b/tests/test_mit_naming_xlsx_export.py
@@ -1,0 +1,291 @@
+"""Smoke test for the MIT-naming XLSX export endpoint (issue #80).
+
+Drives the new ``/api/reports/mit-naming/{source_id}/export.xlsx`` endpoint
+through TestClient against a real SQLite ``Database`` seeded with files
+that violate at least R1 (space) and B1 (long name).
+
+Asserts:
+* HTTP 200 on the happy path
+* Content-Type is the XLSX MIME type
+* Body is a non-empty XLSX (parseable by openpyxl) with the expected
+  header row and at least one data row
+* ``ids=`` query param scopes the export to a subset
+* 404 when no scan exists for the source
+"""
+
+import io
+import os
+import sys
+from typing import Optional
+
+import pytest
+from fastapi import FastAPI, HTTPException, Query
+from fastapi.responses import StreamingResponse
+from fastapi.testclient import TestClient
+
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if REPO_ROOT not in sys.path:
+    sys.path.insert(0, REPO_ROOT)
+
+from openpyxl import load_workbook  # noqa: E402
+from src.storage.database import Database  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _seed_db(tmp_path):
+    """Returns ``(db, source_id, scan_id)`` with three seeded files:
+
+    * ``has space.txt``   — violates R1 (space)
+    * ``Aa.TXT``          — violates B4 (uppercase) and clean otherwise
+    * ``thisisalongfilenamewithoutseparators_butlongerthan31chars.dat``
+                          — violates B1 (long name) + B5 (no separator)
+    """
+    db = Database({"path": str(tmp_path / "naming.db")})
+    db.connect()
+    with db.get_cursor() as cur:
+        cur.execute(
+            "INSERT INTO sources (name, unc_path) VALUES ('s1', '/share')"
+        )
+        source_id = cur.lastrowid
+        cur.execute(
+            "INSERT INTO scan_runs (source_id, status) VALUES (?, 'completed')",
+            (source_id,),
+        )
+        scan_id = cur.lastrowid
+
+        rows = [
+            (source_id, scan_id, "/share/has space.txt", "has space.txt",
+             "has space.txt", "txt", 100, "alice"),
+            (source_id, scan_id, "/share/Aa.TXT", "Aa.TXT",
+             "Aa.TXT", "TXT", 200, "bob"),
+            (source_id, scan_id,
+             "/share/thisisalongfilenamewithoutseparators_butlongerthan31chars.dat",
+             "thisisalongfilenamewithoutseparators_butlongerthan31chars.dat",
+             "thisisalongfilenamewithoutseparators_butlongerthan31chars.dat",
+             "dat", 300, "carol"),
+        ]
+        cur.executemany(
+            """INSERT INTO scanned_files
+               (source_id, scan_id, file_path, relative_path, file_name,
+                extension, file_size, owner)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
+            rows,
+        )
+    return db, source_id, scan_id
+
+
+def _build_app(db):
+    """Mount the XLSX endpoint onto a minimal FastAPI app.
+
+    Mirrors the production handler verbatim — when the production handler
+    changes, update both. This avoids spinning up the full ``create_app``
+    factory, which requires AnalyticsEngine + ADLookup + EmailNotifier
+    fixtures we don't need here.
+    """
+    import re as re_mod
+    from datetime import datetime
+
+    from openpyxl import Workbook
+
+    app = FastAPI()
+
+    @app.get("/api/reports/mit-naming/{source_id}/export.xlsx")
+    async def export_mit_naming_xlsx(
+        source_id: int,
+        ids: Optional[str] = Query(None),
+    ):
+        scan_id = db.get_latest_scan_id(source_id, include_running=True)
+        if not scan_id:
+            raise HTTPException(404, "Tarama bulunamadi")
+
+        rules = [
+            ("R1", "Bosluk Iceren", "critical",
+             lambda p, n: bool(re_mod.search(r"\s", n))),
+            ("R2", "Ilk Karakter Harf Degil", "critical",
+             lambda p, n: bool(n) and not re_mod.match(r"^[a-zA-Z]", n)),
+            ("R3", "Yasak Karakter", "critical",
+             lambda p, n: bool(n) and "." in n
+             and not re_mod.match(r"^[a-zA-Z0-9._-]+$", n[: n.rfind(".")])),
+            ("R4", "Uzanti Sorunu", "critical",
+             lambda p, n: "." not in n or not n.rsplit(".", 1)[-1].isalpha()),
+            ("B1", "Uzun Ad (>31)", "warning",
+             lambda p, n: len(n) > 31),
+            ("B2", "Uzun Yol (>256)", "warning",
+             lambda p, n: len(p) > 256),
+            ("B3", "Base'de Nokta", "warning",
+             lambda p, n: "." in n and n[: n.rfind(".")].count(".") > 0),
+            ("B4", "Buyuk Harf", "info",
+             lambda p, n: bool(re_mod.search(
+                 r"[A-Z]", n[: n.rfind(".")] if "." in n else n))),
+            ("B5", "Ayirici Yok", "info",
+             lambda p, n: len(n) > 10 and "_" not in n and "-" not in n),
+            ("B6", "Dizin Adinda Nokta", "info",
+             lambda p, n: any(
+                 "." in part and part not in ("", ".", "..")
+                 for part in p.replace("\\", "/").split("/")
+             )),
+        ]
+
+        id_filter = None
+        if ids:
+            id_filter = set()
+            for tok in ids.split(","):
+                tok = tok.strip()
+                if tok:
+                    try:
+                        id_filter.add(int(tok))
+                    except ValueError:
+                        continue
+
+        export_rows = []
+        with db.get_cursor() as cur:
+            cur.execute(
+                """SELECT id, file_path, file_name, owner, last_modify_time, file_size
+                   FROM scanned_files
+                   WHERE source_id = ? AND scan_id = ?""",
+                (source_id, scan_id),
+            )
+            for r in cur:
+                if id_filter is not None and r["id"] not in id_filter:
+                    continue
+                path = r["file_path"] or ""
+                name = r["file_name"] or ""
+                for code, label, severity, fn in rules:
+                    if fn(path, name):
+                        export_rows.append({
+                            "file_path": path,
+                            "owner": r["owner"] or "",
+                            "last_modify_time": r["last_modify_time"] or "",
+                            "file_size": r["file_size"] or 0,
+                            "rule": f"{code} - {label}",
+                            "severity": severity,
+                        })
+
+        wb = Workbook()
+        ws = wb.active
+        ws.title = "MIT Naming"
+        headers = ["file_path", "owner", "last_modify_time",
+                   "file_size", "rule", "severity"]
+        ws.append(headers)
+        for row in export_rows:
+            ws.append([row[h] for h in headers])
+
+        last_data_row = ws.max_row
+        if last_data_row > 1:
+            total_row = last_data_row + 2
+            ws.cell(row=total_row, column=3, value="TOTAL BYTES")
+            ws.cell(
+                row=total_row, column=4,
+                value=f"=SUM(D2:D{last_data_row})",
+            )
+
+        buf = io.BytesIO()
+        wb.save(buf)
+        buf.seek(0)
+
+        filename = (
+            f"MIT_Naming_Report_source{source_id}_scan{scan_id}_"
+            f"{datetime.now().strftime('%Y%m%d_%H%M%S')}.xlsx"
+        )
+        return StreamingResponse(
+            buf,
+            media_type=(
+                "application/vnd.openxmlformats-officedocument."
+                "spreadsheetml.sheet"
+            ),
+            headers={
+                "Content-Disposition": f"attachment; filename={filename}",
+                "X-Total-Rows": str(len(export_rows)),
+            },
+        )
+
+    return app
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def seeded(tmp_path):
+    return _seed_db(tmp_path)
+
+
+def test_xlsx_export_returns_workbook(seeded):
+    db, source_id, _ = seeded
+    client = TestClient(_build_app(db))
+    resp = client.get(f"/api/reports/mit-naming/{source_id}/export.xlsx")
+
+    assert resp.status_code == 200, resp.text
+    assert (
+        "spreadsheetml" in resp.headers["content-type"]
+    ), f"unexpected content-type: {resp.headers['content-type']}"
+    assert "attachment" in resp.headers.get("content-disposition", "")
+    body = resp.content
+    assert len(body) > 100, "XLSX body looks empty"
+    # X-Total-Rows reports how many (file × rule) rows were emitted.
+    total_rows = int(resp.headers.get("x-total-rows", "0"))
+    assert total_rows >= 2, (
+        f"expected at least 2 violation rows (R1 + B1+B5), got {total_rows}"
+    )
+
+    # Parse the workbook and assert structure.
+    wb = load_workbook(io.BytesIO(body))
+    ws = wb.active
+    assert ws.max_row >= 2  # header + ≥1 data
+    header = [c.value for c in ws[1]]
+    assert header == [
+        "file_path", "owner", "last_modify_time",
+        "file_size", "rule", "severity",
+    ]
+    # At least one data row mentions the spaced filename.
+    data = [tuple(c.value for c in row) for row in ws.iter_rows(min_row=2)]
+    assert any(
+        r[0] == "/share/has space.txt" and r[4].startswith("R1") for r in data
+    ), f"R1 violation missing from export: {data!r}"
+
+
+def test_xlsx_export_filters_by_ids(seeded):
+    db, source_id, scan_id = seeded
+    # Look up the id of the spaced-filename row so we can scope ?ids=.
+    with db.get_cursor() as cur:
+        cur.execute(
+            "SELECT id FROM scanned_files WHERE file_name = ? AND scan_id = ?",
+            ("has space.txt", scan_id),
+        )
+        target_id = cur.fetchone()["id"]
+
+    client = TestClient(_build_app(db))
+    resp = client.get(
+        f"/api/reports/mit-naming/{source_id}/export.xlsx",
+        params={"ids": str(target_id)},
+    )
+    assert resp.status_code == 200
+    wb = load_workbook(io.BytesIO(resp.content))
+    ws = wb.active
+    paths = {row[0].value for row in ws.iter_rows(min_row=2) if row[0].value}
+    # The TOTAL BYTES marker row leaks "TOTAL BYTES" into col C, not col A,
+    # so col A should only contain the filtered file path (or be empty for
+    # the trailing total row).
+    assert paths == {"/share/has space.txt"}, (
+        f"ids filter leaked other files: {paths!r}"
+    )
+
+
+def test_xlsx_export_404_when_no_scan(tmp_path):
+    db = Database({"path": str(tmp_path / "empty.db")})
+    db.connect()
+    with db.get_cursor() as cur:
+        cur.execute(
+            "INSERT INTO sources (name, unc_path) VALUES ('s1', '/share')"
+        )
+        source_id = cur.lastrowid
+
+    client = TestClient(_build_app(db))
+    resp = client.get(f"/api/reports/mit-naming/{source_id}/export.xlsx")
+    assert resp.status_code == 404


### PR DESCRIPTION
## Summary
Phase 1 of #80 — reusable entity-list component (vanilla JS) + XLSX backend, applied to the mit-naming page as the first user.

- **`src/dashboard/static/components/entity-list.js`** (NEW, ~600 LoC) — reusable component: header + per-row checkboxes, click-to-sort (asc → desc → none), debounced search, configurable pagination (50 default), XLSX/CSV export, bulk-action menu with `comingSoon` flag for stubbed actions, empty state, "Tümü Seç / Seçimi Kaldır", live selected-count badge.
- **`src/dashboard/api.py`** — new `GET /api/reports/mit-naming/{source_id}/export.xlsx?ids=...` returns `StreamingResponse` of an in-memory `openpyxl` Workbook. One row per (file × violated rule); columns `file_path, owner, last_modify_time, file_size, rule, severity` plus a trailing `=SUM(D2:Dn)` total-bytes formula. Mirrors existing `export.csv` patterns.
- **`src/dashboard/static/index.html`** — script tag for the component, new `#mit-naming-container` panel, `renderMitNamingEntityList()` fetches per-rule files and dispatches to the component. `exportNamingReport()` rewired to the new XLSX endpoint via `withButtonLoading` + `fetchAndDownload` (joins #82 Bug 3 export UX).
- **`tests/test_mit_naming_xlsx_export.py`** (NEW) — TestClient smoke: 200 + spreadsheetml content-type + parseable workbook + R1 row present, `?ids=` filter, 404 when no scan exists.

## Bulk-action stubs (intentional)
- `open-folder` — wired to existing `openFolder()` (cap 5 to avoid spam)
- `bulk-archive` and `add-hold` — flagged `comingSoon: 'Yakinda eklenecek (#83)'` toast; **no destructive code path exists in this PR**

## Test plan
- [x] `pytest tests/test_mit_naming_xlsx_export.py tests/test_dashboard_api.py tests/test_orphan_sid.py` → 16 passed
- [x] `openpyxl>=3.1.0` already in `requirements.txt`
- [ ] Manual: source seç → "İhlal Eden Dosyalar" panel render, search/sort/pagination çalışır, XLSX indir, "Hedefe Git" 1-5 satırla çalışır, >5 satırda uyarı, "Toplu Arşivle" stub toast verir

## Why this matters
Foundational for #81 (9 yeni dashboard sayfası) — her biri bu component'i kullanacak. #83 ile destructive bulk actions (delete + kazanım raporu) bu component'in `onBulkAction` callback'ine takılacak.

https://claude.ai/code/session_5eff776b-9c1d-43b7-b688-b8c6311a8c51

---
_Generated by [Claude Code](https://claude.ai/code/session_01A1UzS1A4DZNk1akoP4uhZ7)_