### PR TITLE
SQLite auto-restore on corruption — opt-in (closes #77 Phase 2)

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -17,9 +17,11 @@ backup:
   daily_snapshot_hour: 2          # 24h, 0-23 (cron "0 H * * *")
   snapshot_on_update: true        # update.cmd takes a snapshot before reinstall
   snapshot_on_apply: true         # ArchiveEngine + RetentionEngine snapshot before non-dry-run
-  # Phase 2 placeholder — DO NOT enable. Auto-restore on corruption is
-  # not implemented yet; the field exists so config parses cleanly when
-  # Phase 2 lands. See issue #77.
+  # Phase 2 (#77): if true and the dashboard bootstrap detects DB
+  # corruption (PRAGMA integrity_check fail OR critical tables missing),
+  # the broken DB is forensic-renamed to file_activity.db.broken-<ts>
+  # and replaced from the latest snapshot. Default false — opt-in only;
+  # operators should review and consciously enable.
   auto_restore_on_corruption: false
 
 database:

--- a/src/dashboard/api.py
+++ b/src/dashboard/api.py
@@ -242,6 +242,69 @@ def create_app(db, config, analytics=None, ad_lookup=None, email_notifier=None):
     olusturulur; smtp.enabled=false ise available=False ile doner ve
     e-posta endpoint'leri {"skipped": true} doner.
     """
+    # ─────────────────────────────────────────────────────────────────
+    # Issue #77 Phase 2 — auto-restore on SQLite corruption.
+    #
+    # Run BEFORE any heavy DB init (analytics ATTACH, scheduler boot,
+    # backfill jobs). The probe is read-only via a transient
+    # connection; if corruption is detected AND
+    # ``backup.auto_restore_on_corruption`` is true we forensic-rename
+    # the broken file and copy the latest snapshot in its place.
+    #
+    # main.py already called ``db.connect()`` before handing us the
+    # Database, so we must close it first — the restore step needs the
+    # WAL file unowned. After a successful restore we re-call connect()
+    # so downstream init talks to the salvaged DB.
+    # ─────────────────────────────────────────────────────────────────
+    last_restore_result = None
+    backup_cfg = (config or {}).get("backup") or {}
+    if backup_cfg.get("enabled", True):
+        try:
+            from src.storage.backup_manager import BackupManager
+            backup_mgr = BackupManager(db.db_path, config or {})
+            # Drop any live thread-local connection so the broken/snap
+            # swap below is safe. Database.close() is idempotent.
+            try:
+                db.close()
+            except Exception:
+                pass
+            last_restore_result = backup_mgr.auto_restore_if_needed()
+            if last_restore_result and last_restore_result.restored:
+                logger.critical(
+                    "DB auto-restored at startup: snapshot=%s broken=%s",
+                    last_restore_result.snapshot_id,
+                    last_restore_result.broken_path,
+                )
+            elif (
+                last_restore_result
+                and not last_restore_result.restored
+                and last_restore_result.reason == "disabled_in_config"
+            ):
+                logger.critical(
+                    "DB corruption detected but "
+                    "auto_restore_on_corruption=false. Manual "
+                    "intervention required. details=%s",
+                    last_restore_result.details,
+                )
+            # Reopen the DB regardless of restore outcome — for the
+            # not-corrupted path we just need the connection back; for
+            # the restored path we want the salvaged file initialised
+            # (table creation / WAL setup runs idempotently).
+            try:
+                db.connect()
+            except Exception as e:
+                logger.error(
+                    "Post-auto-restore db.connect() failed: %s", e,
+                )
+        except Exception as e:  # pragma: no cover - defensive only
+            logger.error("auto-restore probe failed: %s", e)
+            # Make sure the DB is open even if we crashed mid-probe.
+            try:
+                if not getattr(db, "connected", False):
+                    db.connect()
+            except Exception:
+                pass
+
     if analytics is None:
         from src.storage.analytics import AnalyticsEngine
         analytics = AnalyticsEngine(db.db_path, config.get("analytics", {}))
@@ -256,6 +319,12 @@ def create_app(db, config, analytics=None, ad_lookup=None, email_notifier=None):
     app.state.analytics = analytics
     app.state.ad_lookup = ad_lookup
     app.state.email_notifier = email_notifier
+    # Phase 2 banner state — frontend reads via /api/system/last-restore.
+    app.state.last_auto_restore = (
+        last_restore_result
+        if (last_restore_result and last_restore_result.restored)
+        else None
+    )
 
     # Ransomware detector (#37) — watcher pushes events here. Construction is
     # cheap; safe to do unconditionally. The detector pulls its own config
@@ -3371,6 +3440,27 @@ def create_app(db, config, analytics=None, ad_lookup=None, email_notifier=None):
             "transports": ["stdio"],
             "install_command":
                 "claude mcp add file-activity -- python -m src.mcp_server",
+        }
+
+    # ─────────────────────────────────────────────────────────────────
+    # Issue #77 Phase 2 — last-auto-restore banner state
+    # ─────────────────────────────────────────────────────────────────
+    @app.get("/api/system/last-restore")
+    async def last_restore():
+        """Returns the most recent auto-restore event for the current
+        process, or ``{"restored": false}`` if no restore happened at
+        startup. Frontend uses this to decide whether to draw the
+        yellow forensic-preserved banner.
+        """
+        info = getattr(app.state, "last_auto_restore", None)
+        if not info or not getattr(info, "restored", False):
+            return {"restored": False}
+        return {
+            "restored": True,
+            "snapshot_id": info.snapshot_id,
+            "broken_path": info.broken_path,
+            "ts": info.ts,
+            "audit_event_id": info.audit_event_id,
         }
 
     # ─────────────────────────────────────────────────────────────────

--- a/src/dashboard/static/index.html
+++ b/src/dashboard/static/index.html
@@ -355,6 +355,15 @@ label { font-size: 12px; color: var(--text-muted); margin-bottom: 6px; display: 
     </div>
 </div>
 
+<!-- Issue #77 Phase 2: persistent banner shown when the dashboard
+     bootstrap auto-restored the DB from a snapshot. -->
+<div id="auto-restore-banner" style="display:none;position:sticky;top:0;z-index:9000;background:var(--warning,#f59e0b);color:#000;padding:12px 20px;border-bottom:2px solid #b45309;font-size:14px;font-weight:500">
+    <span style="margin-right:8px">⚠️</span>
+    <span id="auto-restore-banner-text"></span>
+    <button id="auto-restore-banner-detail" type="button" style="margin-left:12px;padding:4px 10px;background:#000;color:#f59e0b;border:none;border-radius:4px;cursor:pointer;font-size:12px;font-weight:600">Detay</button>
+    <button id="auto-restore-banner-close" type="button" style="margin-left:6px;padding:4px 10px;background:transparent;color:#000;border:1px solid #000;border-radius:4px;cursor:pointer;font-size:12px;font-weight:600">Kapat</button>
+</div>
+
 <!-- SIDEBAR -->
 <nav class="sidebar">
     <div class="sidebar-header">
@@ -5112,6 +5121,40 @@ async function exportBackupsXlsx(ev) {
 // INIT
 // ═══════════════════════════════════════════════════
 (async function init() {
+    // Issue #77 Phase 2 — auto-restore banner. If the dashboard
+    // bootstrap salvaged the DB from a snapshot, surface a persistent
+    // yellow banner so the operator knows BEFORE they look at any data.
+    fetch('/api/system/last-restore')
+        .then(r => r.ok ? r.json() : null)
+        .then(d => {
+            if (!d || !d.restored) return;
+            const banner = document.getElementById('auto-restore-banner');
+            const text = document.getElementById('auto-restore-banner-text');
+            const detail = document.getElementById('auto-restore-banner-detail');
+            const closeBtn = document.getElementById('auto-restore-banner-close');
+            if (!banner || !text) return;
+            const sid = d.snapshot_id || '?';
+            const broken = d.broken_path || '?';
+            text.textContent =
+                'Veritabani otomatik geri yuklendi (snapshot: ' + sid +
+                '). Bozuk DB: ' + broken + '. Lutfen kontrol edin.';
+            banner.style.display = 'block';
+            if (detail) detail.onclick = () => {
+                alert(
+                    'Otomatik geri yukleme detaylari:\n\n' +
+                    'Snapshot ID: ' + sid + '\n' +
+                    'Bozuk DB yolu: ' + broken + '\n' +
+                    'Zaman: ' + (d.ts || '?') + '\n' +
+                    'Audit event ID: ' + (d.audit_event_id || '-') + '\n\n' +
+                    'Bozuk DB silinmedi — adli inceleme icin korunuyor.'
+                );
+            };
+            if (closeBtn) closeBtn.onclick = () => {
+                banner.style.display = 'none';
+            };
+        })
+        .catch(() => {}); // Endpoint yoksa sessizce atla
+
     // Sidebar sürümünü dinamik cek (VERSION dosyasindan)
     fetch('/api/system/version')
         .then(r => r.ok ? r.json() : null)

--- a/src/storage/backup_manager.py
+++ b/src/storage/backup_manager.py
@@ -48,6 +48,38 @@ logger = logging.getLogger("file_activity.storage.backup_manager")
 
 
 @dataclass
+class RestoreResult:
+    """Outcome of an :meth:`BackupManager.auto_restore_if_needed` call.
+
+    ``restored=True`` means the live DB was replaced from a snapshot;
+    the broken file lives on at ``broken_path`` for forensics. When
+    ``restored=False`` the ``reason`` carries one of:
+
+      * ``"not_corrupted"`` — probe said the DB is fine, no action taken.
+      * ``"disabled_in_config"`` — corruption detected but
+        ``backup.auto_restore_on_corruption`` is False. Caller should
+        log CRITICAL.
+      * ``"corruption_detected"`` — alias used at the API layer for the
+        disabled-in-config path so the dashboard can surface a banner.
+      * ``"no_snapshot"`` — corruption detected, config flag true, but
+        no snapshot is available to restore from.
+      * ``"restore_failed"`` — corruption detected, attempted restore,
+        but the salvage step itself raised. Broken DB is preserved.
+    """
+
+    restored: bool
+    reason: str
+    snapshot_id: Optional[str] = None
+    broken_path: Optional[str] = None
+    audit_event_id: Optional[int] = None
+    ts: Optional[str] = None
+    details: str = ""
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+
+@dataclass
 class SnapshotMeta:
     """Metadata for one backup snapshot.
 
@@ -97,7 +129,10 @@ class BackupManager:
         self.backup_dir: str = str(backup_cfg.get("dir", "data/backups"))
         self.keep_last_n: int = int(backup_cfg.get("keep_last_n", 10) or 0)
         self.keep_weekly: int = int(backup_cfg.get("keep_weekly", 4) or 0)
-        # Phase 2 placeholder — read but never acted on this round.
+        # Phase 2 (#77): when True and the dashboard bootstrap probe
+        # finds the live DB corrupted, ``auto_restore_if_needed`` will
+        # forensic-rename the broken file and copy the newest snapshot
+        # over ``db_path``. Default False — opt-in only.
         self.auto_restore_on_corruption: bool = bool(
             backup_cfg.get("auto_restore_on_corruption", False)
         )
@@ -388,9 +423,10 @@ class BackupManager:
         for stopping the dashboard / scheduler first; this method
         refuses to run if it detects a live connection.
 
-        NOTE (Phase 1): never auto-called. Phase 2 will wire this from
-        the startup corruption probe when
-        ``backup.auto_restore_on_corruption`` is True.
+        NOTE: this is the manual-restore path. Phase 2 (#77) auto-restore
+        on corruption goes through :meth:`auto_restore_if_needed`, which
+        runs *before* any live connection is opened so the live-lock
+        check below is automatically satisfied.
         """
         metas = {m.id: m for m in self.list_snapshots()}
         meta = metas.get(snapshot_id)
@@ -452,6 +488,305 @@ class BackupManager:
             "restore ok: id=%s -> %s (size=%d)",
             meta.id, self.db_path, meta.size_bytes,
         )
+
+    # ──────────────────────────────────────────────
+    # Phase 2 — auto-restore on corruption (#77)
+    # ──────────────────────────────────────────────
+
+    def auto_restore_if_needed(self) -> Optional["RestoreResult"]:
+        """Probe the live DB; if corrupted, salvage from latest snapshot.
+
+        Called once at dashboard bootstrap, BEFORE the main ``Database``
+        instance opens its long-lived connection. By then the DB is
+        unowned (no other connection holds the WAL lock), so we can
+        safely move the broken file aside and drop the snapshot in its
+        place.
+
+        Behaviour matrix:
+
+          * Not corrupted → returns ``RestoreResult(restored=False,
+            reason="not_corrupted")``. No I/O.
+          * Corrupted + ``auto_restore_on_corruption=False`` → returns
+            ``RestoreResult(restored=False, reason="disabled_in_config",
+            details=<probe details>)``. Caller logs CRITICAL.
+          * Corrupted + flag true + no snapshot → returns
+            ``RestoreResult(restored=False, reason="no_snapshot")``.
+            The broken DB is left untouched.
+          * Corrupted + flag true + snapshot found → forensic-renames
+            the broken DB, copies the snapshot over, wipes -wal/-shm,
+            writes an ``auto_restore`` audit event and (if SMTP is on)
+            emails the admin. Returns ``RestoreResult(restored=True,
+            ...)``.
+
+        Never raises on the corruption-detection path; restore-step
+        failures bubble out as ``reason="restore_failed"`` with the
+        traceback summarised in ``details``.
+        """
+        # Local import to avoid circular import at module load time.
+        from src.storage.corruption_detector import is_corrupted
+
+        probe = is_corrupted(self.db_path)
+        if not probe.is_corrupted:
+            return RestoreResult(
+                restored=False,
+                reason="not_corrupted",
+                details=probe.details,
+            )
+
+        logger.critical(
+            "DB CORRUPTION DETECTED: db=%s reason=%s details=%s",
+            self.db_path, probe.reason, probe.details,
+        )
+
+        if not self.auto_restore_on_corruption:
+            return RestoreResult(
+                restored=False,
+                reason="disabled_in_config",
+                details=f"{probe.reason}: {probe.details}",
+            )
+
+        # Locate the newest snapshot. ``list_snapshots`` returns
+        # ascending-by-id so the tail is freshest.
+        try:
+            metas = self.list_snapshots()
+        except Exception as e:
+            logger.error("auto-restore: cannot read manifest: %s", e)
+            return RestoreResult(
+                restored=False,
+                reason="restore_failed",
+                details=f"manifest read failed: {e}",
+            )
+
+        # Walk newest-first, skip any whose .bak file is gone from disk.
+        chosen: Optional[SnapshotMeta] = None
+        for meta in reversed(metas):
+            if meta.path and os.path.exists(meta.path):
+                chosen = meta
+                break
+        if chosen is None:
+            logger.error(
+                "auto-restore: no usable snapshot (manifest=%d entries)",
+                len(metas),
+            )
+            return RestoreResult(
+                restored=False,
+                reason="no_snapshot",
+                details=f"manifest_entries={len(metas)}",
+            )
+
+        # 1. Forensic-rename the broken DB. NEVER delete it.
+        ts = self._now().strftime("%Y%m%d_%H%M%S")
+        broken_path = f"{self.db_path}.broken-{ts}"
+        try:
+            os.replace(self.db_path, broken_path)
+        except OSError as e:
+            logger.error(
+                "auto-restore: cannot rename broken DB %s -> %s: %s",
+                self.db_path, broken_path, e,
+            )
+            return RestoreResult(
+                restored=False,
+                reason="restore_failed",
+                details=f"rename broken DB failed: {e}",
+            )
+
+        # 2. Copy the snapshot over db_path. ``shutil.copy2`` preserves
+        # mtime so the file looks freshly minted to ops tooling.
+        try:
+            shutil.copy2(chosen.path, self.db_path)
+        except OSError as e:
+            # Try to restore the broken file so we don't leave the
+            # caller with no DB at all.
+            try:
+                os.replace(broken_path, self.db_path)
+            except OSError:
+                pass
+            logger.error(
+                "auto-restore: snapshot copy failed: %s", e,
+            )
+            return RestoreResult(
+                restored=False,
+                reason="restore_failed",
+                details=f"copy snapshot failed: {e}",
+            )
+
+        # 3. Wipe -wal/-shm siblings — they belong to the broken DB.
+        for sibling in (self.db_path + "-wal", self.db_path + "-shm"):
+            try:
+                if os.path.exists(sibling):
+                    os.remove(sibling)
+            except OSError as e:
+                logger.warning(
+                    "auto-restore: failed to remove %s: %s", sibling, e,
+                )
+
+        logger.critical(
+            "auto-restore OK: snapshot=%s -> %s (broken preserved at %s)",
+            chosen.id, self.db_path, broken_path,
+        )
+
+        # 4. Write audit event + 5. send admin email. Both best-effort —
+        # neither failure should mask the successful restore.
+        audit_event_id = self._write_auto_restore_audit(
+            snapshot_id=chosen.id,
+            broken_path=broken_path,
+            corruption_reason=probe.reason,
+            corruption_details=probe.details,
+        )
+        self._send_auto_restore_email(
+            snapshot_id=chosen.id,
+            broken_path=broken_path,
+            corruption_reason=probe.reason,
+            corruption_details=probe.details,
+        )
+
+        return RestoreResult(
+            restored=True,
+            reason="auto_restored",
+            snapshot_id=chosen.id,
+            broken_path=broken_path,
+            audit_event_id=audit_event_id,
+            ts=self._now().isoformat(timespec="seconds"),
+            details=f"{probe.reason}: {probe.details}",
+        )
+
+    def _write_auto_restore_audit(
+        self,
+        snapshot_id: str,
+        broken_path: str,
+        corruption_reason: str,
+        corruption_details: str,
+    ) -> Optional[int]:
+        """Append an ``auto_restore`` row to ``file_audit_events`` in the
+        freshly-restored DB.
+
+        We deliberately bypass the full ``Database`` constructor here:
+        the dashboard's ``create_app`` will call ``db.connect()`` right
+        after we return, and that path runs the whole table+index
+        initialisation. Doing it twice (once here, once there) is both
+        wasteful and brittle — instead we open a raw stdlib sqlite3
+        connection, perform a single INSERT against ``file_audit_events``
+        (which is one of the critical tables the corruption detector
+        verified to exist on the snapshot we just restored from), and
+        close. Mirrors ``insert_audit_event_simple`` row-shape.
+        """
+        try:
+            conn = sqlite3.connect(self.db_path, timeout=10)
+            try:
+                now = self._now().strftime("%Y-%m-%d %H:%M:%S")
+                file_name = os.path.basename(self.db_path)
+                details = json.dumps({
+                    "snapshot_id": snapshot_id,
+                    "broken_path": broken_path,
+                    "corruption_reason": corruption_reason,
+                    "corruption_details": corruption_details[:500],
+                }, sort_keys=True)
+                cur = conn.execute(
+                    "INSERT INTO file_audit_events "
+                    "(source_id, event_time, event_type, username, "
+                    " file_path, file_name, details, detected_by) "
+                    "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+                    (None, now, "auto_restore", "system",
+                     self.db_path, file_name, details,
+                     "backup_manager"),
+                )
+                event_id = cur.lastrowid
+                conn.commit()
+                logger.info(
+                    "auto-restore: audit event %s written", event_id,
+                )
+                return event_id
+            finally:
+                conn.close()
+        except Exception as e:
+            logger.warning(
+                "auto-restore: audit event write failed: %s", e,
+            )
+            return None
+
+    def _send_auto_restore_email(
+        self,
+        snapshot_id: str,
+        broken_path: str,
+        corruption_reason: str,
+        corruption_details: str,
+    ) -> None:
+        """Best-effort admin notification. Skipped silently when SMTP
+        isn't configured (``smtp.enabled=false`` or fields missing).
+        """
+        smtp_cfg = (self.config or {}).get("smtp") or {}
+        if not smtp_cfg.get("enabled", False):
+            return
+        notif_cfg = (self.config or {}).get("notifications") or {}
+        admin = (notif_cfg.get("admin_cc_email") or "").strip()
+        if not admin:
+            return
+
+        try:  # pragma: no cover - SMTP path is integration-tested elsewhere
+            import smtplib
+            import ssl
+            from email.mime.text import MIMEText
+
+            host = smtp_cfg.get("host", "").strip()
+            port = int(smtp_cfg.get("port", 587))
+            from_addr = smtp_cfg.get("from_address", "")
+            if not host or not from_addr:
+                return
+
+            subject_prefix = (
+                notif_cfg.get("subject_prefix") or "[File Activity]"
+            ).strip()
+            subject = (
+                f"{subject_prefix} DB auto-restored from snapshot "
+                f"{snapshot_id}"
+            )
+            body = (
+                f"FILE ACTIVITY detected SQLite corruption at startup "
+                f"and auto-restored the database.\n\n"
+                f"  db_path:     {self.db_path}\n"
+                f"  snapshot:    {snapshot_id}\n"
+                f"  broken_path: {broken_path}\n"
+                f"  reason:      {corruption_reason}\n"
+                f"  details:     {corruption_details[:500]}\n\n"
+                f"The broken DB has been preserved for forensics. "
+                f"Please investigate."
+            )
+            msg = MIMEText(body, "plain", "utf-8")
+            msg["Subject"] = subject
+            msg["From"] = from_addr
+            msg["To"] = admin
+
+            timeout = int(smtp_cfg.get("timeout_seconds", 10))
+            if smtp_cfg.get("use_ssl", False):
+                ctx = ssl.create_default_context()
+                client = smtplib.SMTP_SSL(host, port,
+                                          timeout=timeout, context=ctx)
+            else:
+                client = smtplib.SMTP(host, port, timeout=timeout)
+                client.ehlo()
+                if smtp_cfg.get("use_tls", True):
+                    ctx = ssl.create_default_context()
+                    client.starttls(context=ctx)
+                    client.ehlo()
+            try:
+                username = smtp_cfg.get("username", "")
+                password = (
+                    os.environ.get("SMTP_PASSWORD")
+                    or smtp_cfg.get("password", "")
+                )
+                if username and password:
+                    client.login(username, password)
+                client.sendmail(from_addr, [admin], msg.as_string())
+            finally:
+                try:
+                    client.quit()
+                except Exception:
+                    pass
+            logger.info("auto-restore: admin notification sent to %s", admin)
+        except Exception as e:
+            logger.warning(
+                "auto-restore: admin email failed (non-fatal): %s", e,
+            )
 
 
 # ──────────────────────────────────────────────

--- a/src/storage/corruption_detector.py
+++ b/src/storage/corruption_detector.py
@@ -1,0 +1,179 @@
+"""SQLite corruption detection (issue #77 Phase 2).
+
+Probe used by the dashboard bootstrap to decide whether the live DB is
+salvageable or whether ``BackupManager.auto_restore_if_needed`` should
+take over.
+
+Design rules
+------------
+* Read-only — never write, never even hold a transaction. We open a
+  fresh transient connection, run two checks, close it. No side effects.
+* Stdlib only (``sqlite3`` + dataclasses). No SQLAlchemy / ORMs.
+* Two signals, both deliberately conservative:
+    1. ``PRAGMA integrity_check`` — SQLite's own consistency probe; the
+       result is the literal string ``ok`` when the file's b-trees /
+       checksums are coherent. Anything else (multi-line error report,
+       ``database disk image is malformed``, ``file is not a database``)
+       counts as ``integrity_fail``.
+    2. Critical-table presence — ``scan_runs``, ``scanned_files`` and
+       ``file_audit_events``. Missing any of these = ``missing_tables``.
+       We never auto-restore on transient errors (locked file, network
+       blip, permission); those raise ``OperationalError`` from the
+       ``connect`` call itself and bubble out as ``is_corrupted=False``
+       with ``reason="probe_error"`` so the caller can log + continue.
+
+The detector intentionally does not consult the manifest or any backup
+state. It only answers the question "is this file usable right now?"
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import sqlite3
+from dataclasses import dataclass
+
+logger = logging.getLogger("file_activity.storage.corruption_detector")
+
+# Tables the application cannot function without. If any one of these
+# is missing we treat the DB as corrupted — typically the file is
+# either fresh-zero-byte, truncated mid-format, or someone restored
+# the wrong file over it.
+CRITICAL_TABLES: tuple[str, ...] = (
+    "scan_runs",
+    "scanned_files",
+    "file_audit_events",
+)
+
+
+@dataclass
+class CorruptionResult:
+    """Outcome of one corruption probe.
+
+    ``reason`` is one of:
+      * ``"none"`` — file passes both checks (``is_corrupted=False``)
+      * ``"integrity_fail"`` — ``PRAGMA integrity_check`` returned
+        anything other than ``ok``
+      * ``"missing_tables"`` — at least one critical table absent
+      * ``"probe_error"`` — could not even open the file (locked,
+        permission denied, etc.). Treated as **not** corrupted so we
+        do NOT auto-restore on transient noise.
+
+    ``details`` carries the human-readable evidence (raw integrity
+    output, comma-separated missing-table names, or the OSError text).
+    """
+
+    is_corrupted: bool
+    reason: str
+    details: str
+
+
+def is_corrupted(db_path: str) -> CorruptionResult:
+    """Run the two checks against ``db_path`` in a transient connection.
+
+    The connection is opened with a short ``timeout`` so a busy WAL
+    doesn't make us wait — corruption probes must be fast and never
+    block the dashboard bootstrap. The connection is always closed,
+    even on exception.
+    """
+    if not os.path.exists(db_path):
+        # No file at all — caller's responsibility (Database.connect
+        # will create one). Not corrupted.
+        return CorruptionResult(
+            is_corrupted=False,
+            reason="none",
+            details=f"db_path does not exist: {db_path}",
+        )
+
+    # Zero-byte file is a special case sqlite3.connect() accepts (it
+    # would create an empty-but-valid DB on first write). Treat it as
+    # missing tables — the application cannot run against an empty
+    # schema and we'd rather salvage from backup if one exists.
+    try:
+        if os.path.getsize(db_path) == 0:
+            return CorruptionResult(
+                is_corrupted=True,
+                reason="missing_tables",
+                details="db file is zero bytes",
+            )
+    except OSError as e:
+        return CorruptionResult(
+            is_corrupted=False,
+            reason="probe_error",
+            details=f"stat failed: {e}",
+        )
+
+    conn: sqlite3.Connection | None = None
+    try:
+        # ``timeout=2`` keeps us from sitting on a busy WAL during
+        # startup. Read-only-ish: we never BEGIN a write transaction.
+        conn = sqlite3.connect(db_path, timeout=2)
+        # Check 1: integrity_check. Returns one row per problem; a
+        # healthy DB returns exactly one row whose only column is the
+        # literal string "ok".
+        rows = conn.execute("PRAGMA integrity_check").fetchall()
+        flat = [str(r[0]) if isinstance(r, tuple) else str(r) for r in rows]
+        if flat != ["ok"]:
+            details = "; ".join(flat)[:500] or "<no output>"
+            return CorruptionResult(
+                is_corrupted=True,
+                reason="integrity_fail",
+                details=details,
+            )
+
+        # Check 2: critical tables present.
+        cur = conn.execute(
+            "SELECT name FROM sqlite_master "
+            "WHERE type='table' AND name IN (?,?,?)",
+            CRITICAL_TABLES,
+        )
+        present = {row[0] for row in cur.fetchall()}
+        missing = [t for t in CRITICAL_TABLES if t not in present]
+        if missing:
+            return CorruptionResult(
+                is_corrupted=True,
+                reason="missing_tables",
+                details=",".join(missing),
+            )
+
+        return CorruptionResult(
+            is_corrupted=False,
+            reason="none",
+            details="ok",
+        )
+    except sqlite3.DatabaseError as e:
+        # ``file is not a database`` / ``database disk image is
+        # malformed`` are explicit corruption signals — they're a
+        # subclass of DatabaseError, not OperationalError. SQLite raises
+        # these from the very first PRAGMA we run.
+        return CorruptionResult(
+            is_corrupted=True,
+            reason="integrity_fail",
+            details=str(e)[:500],
+        )
+    except sqlite3.OperationalError as e:
+        # Transient: file locked, OS busy, etc. NOT corrupted.
+        logger.warning(
+            "corruption probe transient error on %s: %s", db_path, e
+        )
+        return CorruptionResult(
+            is_corrupted=False,
+            reason="probe_error",
+            details=str(e)[:500],
+        )
+    except OSError as e:
+        # Permission denied / IO error reaching the file.
+        logger.warning(
+            "corruption probe OS error on %s: %s", db_path, e
+        )
+        return CorruptionResult(
+            is_corrupted=False,
+            reason="probe_error",
+            details=str(e)[:500],
+        )
+    finally:
+        if conn is not None:
+            try:
+                conn.close()
+            except sqlite3.Error:
+                pass

--- a/tests/test_backup_manager.py
+++ b/tests/test_backup_manager.py
@@ -26,7 +26,11 @@ REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 if REPO_ROOT not in sys.path:
     sys.path.insert(0, REPO_ROOT)
 
-from src.storage.backup_manager import BackupManager, SnapshotMeta  # noqa: E402
+from src.storage.backup_manager import (  # noqa: E402
+    BackupManager,
+    RestoreResult,
+    SnapshotMeta,
+)
 
 
 def _make_db(path: Path) -> None:
@@ -292,3 +296,192 @@ def test_cli_snapshot_writes_jsonl_to_stdout(tmp_path: Path):
     assert payload["size_bytes"] > 0
     # And the .bak file actually landed
     assert os.path.exists(payload["path"])
+
+
+# ─────────────────────────────────────────────────────────────
+# Phase 2 (#77) — auto_restore_if_needed
+# ─────────────────────────────────────────────────────────────
+
+def _corrupt_db(path: Path) -> None:
+    """Replace the DB file with garbage so PRAGMA integrity_check
+    will raise ``file is not a database``.
+    """
+    path.write_bytes(b"NOT A REAL DB" * 128)
+
+
+def _make_app_shaped_db(path: Path) -> None:
+    """Like _make_db but also creates the three critical tables the
+    corruption detector probes, so the freshly-restored DB passes the
+    detector and Database.connect() boots cleanly.
+    """
+    conn = sqlite3.connect(str(path))
+    try:
+        conn.execute(
+            "CREATE TABLE scan_runs (id INTEGER PRIMARY KEY)"
+        )
+        conn.execute(
+            "CREATE TABLE scanned_files (id INTEGER PRIMARY KEY)"
+        )
+        conn.execute(
+            "CREATE TABLE file_audit_events ("
+            "id INTEGER PRIMARY KEY AUTOINCREMENT,"
+            "source_id INTEGER,"
+            "event_time TEXT,"
+            "event_type TEXT,"
+            "username TEXT,"
+            "file_path TEXT,"
+            "file_name TEXT,"
+            "details TEXT,"
+            "detected_by TEXT)"
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def _make_app_shaped_mgr(tmp_path: Path, **overrides) -> BackupManager:
+    db_path = tmp_path / "live.db"
+    _make_app_shaped_db(db_path)
+    cfg = {
+        "backup": {
+            "enabled": True,
+            "dir": str(tmp_path / "backups"),
+            "keep_last_n": 10,
+            "keep_weekly": 4,
+            "auto_restore_on_corruption": False,
+        },
+        "smtp": {"enabled": False},
+    }
+    cfg["backup"].update(overrides)
+    return BackupManager(str(db_path), cfg)
+
+
+def test_auto_restore_disabled_in_config_no_restore(tmp_path: Path):
+    """Corruption is detected but the config flag is false. No
+    restore, no rename — the broken DB stays exactly where it is so
+    the operator can investigate. Result must report
+    ``reason='disabled_in_config'``.
+    """
+    mgr = _make_app_shaped_mgr(tmp_path)
+    # Take a snapshot first so a viable target exists — we want to
+    # prove the gate is config, not snapshot availability.
+    mgr.snapshot(reason="seed")
+
+    # Corrupt the live DB
+    _corrupt_db(Path(mgr.db_path))
+    pre_size = os.path.getsize(mgr.db_path)
+    pre_bytes = Path(mgr.db_path).read_bytes()
+
+    assert mgr.auto_restore_on_corruption is False
+    result = mgr.auto_restore_if_needed()
+
+    assert isinstance(result, RestoreResult)
+    assert result.restored is False
+    assert result.reason == "disabled_in_config"
+
+    # Live DB untouched — same size, same bytes, no broken-* sibling.
+    assert os.path.getsize(mgr.db_path) == pre_size
+    assert Path(mgr.db_path).read_bytes() == pre_bytes
+    siblings = [p.name for p in Path(mgr.db_path).parent.iterdir()
+                if "broken" in p.name]
+    assert siblings == []
+
+
+def test_auto_restore_enabled_performs_salvage(tmp_path: Path):
+    """Flag true + corrupted DB + valid snapshot:
+       * the broken file is preserved at <db>.broken-<ts>
+       * the snapshot is copied to db_path
+       * the restored db_path passes integrity_check
+       * an audit event is written into the restored DB
+    """
+    mgr = _make_app_shaped_mgr(
+        tmp_path,
+        auto_restore_on_corruption=True,
+    )
+    snap = mgr.snapshot(reason="pre-corrupt")
+
+    # Now corrupt the live DB.
+    _corrupt_db(Path(mgr.db_path))
+
+    result = mgr.auto_restore_if_needed()
+    assert result is not None
+    assert result.restored is True
+    assert result.reason == "auto_restored"
+    assert result.snapshot_id == snap.id
+
+    # Broken file preserved
+    assert result.broken_path is not None
+    assert os.path.exists(result.broken_path), "broken DB must be kept for forensics"
+    # Forensic name format: <db_path>.broken-YYYYMMDD_HHMMSS
+    assert result.broken_path.startswith(mgr.db_path + ".broken-")
+
+    # The restored DB passes integrity_check (we don't compare
+    # byte-for-byte against the snapshot because the auto_restore
+    # audit insert intentionally mutates the live file).
+    assert os.path.exists(mgr.db_path)
+    assert os.path.getsize(mgr.db_path) > 0
+
+    # And it passes integrity_check now.
+    conn = sqlite3.connect(mgr.db_path)
+    try:
+        rows = conn.execute("PRAGMA integrity_check").fetchall()
+        assert [r[0] for r in rows] == ["ok"]
+        # The audit event the manager wrote during salvage must be
+        # visible on the restored DB.
+        cur = conn.execute(
+            "SELECT event_type, detected_by FROM file_audit_events "
+            "WHERE event_type='auto_restore'"
+        )
+        rows = cur.fetchall()
+        assert len(rows) == 1
+        assert rows[0][0] == "auto_restore"
+        assert rows[0][1] == "backup_manager"
+    finally:
+        conn.close()
+    # And the manager reports the audit_event_id it inserted.
+    assert result.audit_event_id is not None
+
+
+def test_auto_restore_no_snapshot_available(tmp_path: Path):
+    """Flag true + corrupted DB + zero snapshots → no salvage,
+    broken file untouched, ``reason='no_snapshot'``.
+    """
+    mgr = _make_app_shaped_mgr(
+        tmp_path,
+        auto_restore_on_corruption=True,
+    )
+    # Don't take any snapshots
+    assert mgr.list_snapshots() == []
+
+    _corrupt_db(Path(mgr.db_path))
+    pre_bytes = Path(mgr.db_path).read_bytes()
+
+    result = mgr.auto_restore_if_needed()
+    assert result is not None
+    assert result.restored is False
+    assert result.reason == "no_snapshot"
+
+    # Broken file is left in place — the application should refuse to
+    # boot rather than silently delete the only copy.
+    assert Path(mgr.db_path).read_bytes() == pre_bytes
+    siblings = [p.name for p in Path(mgr.db_path).parent.iterdir()
+                if ".broken-" in p.name]
+    assert siblings == []
+
+
+def test_auto_restore_passes_when_db_is_healthy(tmp_path: Path):
+    """No corruption, no action — result must say not_corrupted and
+    leave the DB completely alone.
+    """
+    mgr = _make_app_shaped_mgr(
+        tmp_path,
+        auto_restore_on_corruption=True,
+    )
+    mgr.snapshot(reason="seed")
+
+    pre_bytes = Path(mgr.db_path).read_bytes()
+    result = mgr.auto_restore_if_needed()
+    assert result is not None
+    assert result.restored is False
+    assert result.reason == "not_corrupted"
+    assert Path(mgr.db_path).read_bytes() == pre_bytes

--- a/tests/test_corruption_detector.py
+++ b/tests/test_corruption_detector.py
@@ -1,0 +1,151 @@
+"""Tests for issue #77 Phase 2: SQLite corruption detector.
+
+Covers the three signals from src.storage.corruption_detector.is_corrupted:
+  * test_corruption_detector_detects_truncated_db
+  * test_corruption_detector_detects_missing_tables
+  * test_corruption_detector_passes_valid_db
+
+The detector is intentionally read-only — every test verifies the input
+file is unchanged after the probe runs (no side effects).
+"""
+
+from __future__ import annotations
+
+import os
+import sqlite3
+import sys
+from pathlib import Path
+
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if REPO_ROOT not in sys.path:
+    sys.path.insert(0, REPO_ROOT)
+
+from src.storage.corruption_detector import (  # noqa: E402
+    CorruptionResult,
+    CRITICAL_TABLES,
+    is_corrupted,
+)
+
+
+def _make_valid_db(path: Path) -> None:
+    """Build a minimal but app-shaped DB with all critical tables.
+
+    The detector only checks for table presence by name + the
+    integrity_check pragma — schema columns are irrelevant here, so
+    we keep these tiny.
+    """
+    conn = sqlite3.connect(str(path))
+    try:
+        for tbl in CRITICAL_TABLES:
+            conn.execute(f"CREATE TABLE {tbl} (id INTEGER PRIMARY KEY)")
+        conn.commit()
+    finally:
+        conn.close()
+
+
+# ── 1. truncated / non-database file ────────────────────────
+
+
+def test_corruption_detector_detects_truncated_db(tmp_path: Path):
+    """A file that pretends to be SQLite but is truncated/garbage must
+    be reported as ``integrity_fail`` — that's what SQLite raises when
+    the header doesn't parse or pages don't checksum.
+    """
+    target = tmp_path / "broken.db"
+    # Write enough bytes that os.path.getsize > 0, but the contents
+    # are not a valid SQLite header — sqlite3 will raise
+    # ``DatabaseError: file is not a database`` from the first PRAGMA.
+    target.write_bytes(b"NOT A REAL DB" * 64)
+
+    result = is_corrupted(str(target))
+    assert isinstance(result, CorruptionResult)
+    assert result.is_corrupted is True
+    assert result.reason == "integrity_fail"
+    assert result.details  # non-empty
+
+
+# ── 2. missing tables on an otherwise valid SQLite file ─────
+
+
+def test_corruption_detector_detects_missing_tables(tmp_path: Path):
+    """A pristine sqlite3.connect with no schema is structurally
+    valid (integrity_check returns ``ok``) but missing every critical
+    table — the second check must catch this and report
+    ``missing_tables`` with all three names in the details string.
+    """
+    target = tmp_path / "empty.db"
+    conn = sqlite3.connect(str(target))
+    try:
+        # Create *some* table so the file actually has a SQLite header
+        # on disk (otherwise sqlite3.connect leaves a zero-byte file
+        # which the detector short-circuits as missing_tables on a
+        # different code path — we want to exercise the real
+        # sqlite_master scan here).
+        conn.execute(
+            "CREATE TABLE unrelated (id INTEGER PRIMARY KEY)"
+        )
+        conn.commit()
+    finally:
+        conn.close()
+    assert target.stat().st_size > 0
+
+    result = is_corrupted(str(target))
+    assert result.is_corrupted is True
+    assert result.reason == "missing_tables"
+    # All critical tables should be listed in the details.
+    for tbl in CRITICAL_TABLES:
+        assert tbl in result.details
+
+
+# ── 3. healthy DB passes both checks ────────────────────────
+
+
+def test_corruption_detector_passes_valid_db(tmp_path: Path):
+    target = tmp_path / "healthy.db"
+    _make_valid_db(target)
+
+    # Snapshot the file bytes so we can confirm the probe is read-only.
+    pre = target.read_bytes()
+
+    result = is_corrupted(str(target))
+    assert result.is_corrupted is False
+    assert result.reason == "none"
+
+    # Read-only invariant: probe must not mutate the file. (sqlite3
+    # may touch the access time but the byte content stays put.)
+    post = target.read_bytes()
+    assert pre == post
+
+
+# ── 4. zero-byte file is treated as missing-tables ──────────
+
+
+def test_corruption_detector_zero_byte_file(tmp_path: Path):
+    """Edge case: a freshly-created empty file. ``sqlite3.connect``
+    happily accepts it, but the app cannot run against an empty
+    schema — the detector short-circuits to ``missing_tables`` so
+    the bootstrap can fall back to a snapshot if available.
+    """
+    target = tmp_path / "zero.db"
+    target.touch()
+    assert target.stat().st_size == 0
+
+    result = is_corrupted(str(target))
+    assert result.is_corrupted is True
+    assert result.reason == "missing_tables"
+
+
+# ── 5. nonexistent path returns ``not corrupted`` ───────────
+
+
+def test_corruption_detector_nonexistent_path(tmp_path: Path):
+    """If the DB file isn't there at all the detector defers to the
+    caller — Database.connect will create one. NOT a corruption
+    signal.
+    """
+    target = tmp_path / "does-not-exist.db"
+    assert not target.exists()
+
+    result = is_corrupted(str(target))
+    assert result.is_corrupted is False
+    assert result.reason == "none"


### PR DESCRIPTION
## Summary
Phase 2 of #77 — opt-in auto-restore on SQLite corruption. The config field `backup.auto_restore_on_corruption: false` (already shipped in #78) now actually does something when flipped to `true`.

- **`src/storage/corruption_detector.py`** (NEW) — `is_corrupted(db_path) -> CorruptionResult` runs in a transient read-only sqlite3 connection; checks `PRAGMA integrity_check` (any non-`ok` = `integrity_fail`) and presence of critical tables `scan_runs / scanned_files / file_audit_events` (missing any = `missing_tables`).
- **`src/storage/backup_manager.py`** — `RestoreResult` dataclass + `auto_restore_if_needed()` orchestrator. Sequence:
  1. Detect corruption
  2. Find latest valid snapshot
  3. Move broken DB to `data/file_activity.db.broken-YYYYMMDD_HHMMSS` (forensic preservation, never deleted)
  4. Copy snapshot to `db_path`, wipe `-wal`/`-shm` siblings
  5. Write `auto_restore` audit event (raw sqlite3 INSERT)
  6. Best-effort email to `notifications.admin_cc_email` if smtp.enabled
  7. Return `RestoreResult` with snapshot_id + broken_path
- **`src/dashboard/api.py`** — early-bootstrap probe (close db, run auto_restore_if_needed, reopen db) before any heavy DB init. New `GET /api/system/last-restore` endpoint exposes `app.state.last_auto_restore`.
- **`src/dashboard/static/index.html`** — sticky yellow banner (with Detay / Kapat buttons) shown on load if `restored: true`.
- 9 new tests; full sweep 173 passed (excluding platform-specific suites).

## Manual verification
End-to-end: snapshot → corrupt DB with garbage → `is_corrupted` returns `integrity_fail` → broken DB renamed → snapshot copied over `db_path` → post-restore probe `is_corrupted=False` → audit event row written → `scan_runs` rows from snapshot recovered. Disabled-in-config rerun left the broken file untouched.

## Default behaviour preserved
- `config.yaml` retains `auto_restore_on_corruption: false`
- `BackupManager.__init__` default also `False`
- Disabled flag → log CRITICAL, no restore, broken DB untouched

## Test plan
- [x] `pytest tests/test_corruption_detector.py tests/test_backup_manager.py` → 15 passed
- [x] Full sweep: 173 passed
- [ ] Manual: flip flag to `true` in a test deployment, simulate corruption, observe banner

https://claude.ai/code/session_5eff776b-9c1d-43b7-b688-b8c6311a8c51

---
_Generated by [Claude Code](https://claude.ai/code/session_01A1UzS1A4DZNk1akoP4uhZ7)_