### PR TITLE
loadFolderBrowser: server-side folder picker (closes last #82 audit orphan)

### DIFF
--- a/src/dashboard/api.py
+++ b/src/dashboard/api.py
@@ -90,6 +90,185 @@ def open_folder_impl(body: dict, client_host: str, popen=None):
     return {"success": True, "mode": "native", "path": folder}
 
 
+# --- Issue #82 (Bug 4) / Issue #105: /api/system/list-dir folder browser ---
+#
+# Powers the "loadFolderBrowser" modal in the dashboard so admins can pick a
+# source / archive destination by clicking through the server's filesystem
+# instead of typing UNC paths from memory. Localhost-only (mirrors the
+# /api/system/open-folder pattern from PR #85): a remote client must NEVER be
+# able to enumerate the file server's contents, so we return HTTP 403 in
+# that case rather than leaking the directory structure.
+#
+# Performance / safety:
+#   * scandir for one-syscall-per-entry traversal,
+#   * 5000-entry cap (LIST_DIR_MAX_ENTRIES) to bound response size,
+#   * hidden / system files filtered unless ?show_hidden=true,
+#   * sort: directories first (alphabetical), then files (alphabetical),
+#   * realpath + normpath path resolution to defeat symlink/junction tricks,
+#   * empty `path` returns the logical roots (drives on Windows, "/" on Unix)
+#     so the UI can boot the browser without knowing the platform.
+
+LIST_DIR_MAX_ENTRIES = 5000
+
+
+def _list_dir_logical_roots() -> list[dict]:
+    """Return the platform-appropriate logical roots for the browser.
+
+    On Windows we enumerate fixed drive letters that actually have a
+    filesystem mounted (so we don't include phantom A:/B: floppy entries).
+    On POSIX we return a single "/" root, which is enough for admins to
+    navigate to /mnt, /media, /srv, etc.
+    """
+    import string
+
+    roots: list[dict] = []
+    if os.name == "nt":
+        for letter in string.ascii_uppercase:
+            drive = f"{letter}:\\"
+            if os.path.isdir(drive):
+                roots.append({
+                    "name": drive,
+                    "type": "dir",
+                    "size": None,
+                    "mtime": None,
+                })
+    else:
+        roots.append({
+            "name": "/",
+            "type": "dir",
+            "size": None,
+            "mtime": None,
+        })
+    return roots
+
+
+def _list_dir_is_hidden(name: str, full_path: str) -> bool:
+    """Best-effort hidden / system flag detection.
+
+    POSIX: dotfile convention.
+    Windows: FILE_ATTRIBUTE_HIDDEN / FILE_ATTRIBUTE_SYSTEM via GetFileAttributesW
+    when available; we do not raise on failure — a stat error simply means
+    the entry is included (better to show it than hide it silently).
+    """
+    if name.startswith("."):
+        return True
+    if os.name == "nt":
+        try:
+            import ctypes
+
+            attrs = ctypes.windll.kernel32.GetFileAttributesW(full_path)
+            if attrs != -1:
+                # FILE_ATTRIBUTE_HIDDEN = 0x2, FILE_ATTRIBUTE_SYSTEM = 0x4
+                if attrs & 0x2 or attrs & 0x4:
+                    return True
+        except Exception:  # pragma: no cover - kernel32 absent / sandbox
+            pass
+    return False
+
+
+def list_dir_impl(
+    path: str,
+    client_host: str,
+    show_hidden: bool = False,
+    max_entries: int = LIST_DIR_MAX_ENTRIES,
+):
+    """Pure helper backing the /api/system/list-dir endpoint.
+
+    Returns ``{path, parent, entries}``; raises HTTPException(403) for a
+    remote client and HTTPException(404) for a path that doesn't exist
+    or isn't a directory.
+    """
+    if client_host not in _LOCAL_CLIENT_HOSTS:
+        raise HTTPException(
+            403,
+            "Klasor tarayici sadece sunucudan calisirken kullanilabilir. "
+            "Yolu manuel girin.",
+        )
+
+    # Empty path -> logical roots (drives on Windows, "/" on POSIX). We
+    # surface ``parent=None`` so the UI hides the "up one level" affordance.
+    if not path:
+        return {
+            "path": "",
+            "parent": None,
+            "entries": _list_dir_logical_roots(),
+        }
+
+    # Path resolution: normpath to collapse ``..``, then realpath to defeat
+    # symlink/junction escape attempts. We don't bind to a specific allow-
+    # list of roots because the operator legitimately needs to pick any
+    # local or mounted UNC path; the localhost-only check above is what
+    # keeps remote clients from walking the filesystem.
+    resolved = os.path.realpath(os.path.normpath(path))
+    if not os.path.isdir(resolved):
+        raise HTTPException(404, f"Yol bulunamadi: {resolved}")
+
+    entries: list[dict] = []
+    truncated = False
+    try:
+        with os.scandir(resolved) as it:
+            for entry in it:
+                if not show_hidden and _list_dir_is_hidden(
+                    entry.name, entry.path
+                ):
+                    continue
+                try:
+                    is_dir = entry.is_dir(follow_symlinks=False)
+                except OSError:
+                    is_dir = False
+                size: int | None = None
+                mtime: float | None = None
+                if not is_dir:
+                    try:
+                        st = entry.stat(follow_symlinks=False)
+                        size = st.st_size
+                        mtime = st.st_mtime
+                    except OSError:
+                        size = None
+                        mtime = None
+                else:
+                    try:
+                        st = entry.stat(follow_symlinks=False)
+                        mtime = st.st_mtime
+                    except OSError:
+                        mtime = None
+                entries.append({
+                    "name": entry.name,
+                    "type": "dir" if is_dir else "file",
+                    "size": size,
+                    "mtime": mtime,
+                })
+                if len(entries) >= max_entries:
+                    truncated = True
+                    break
+    except PermissionError:
+        raise HTTPException(403, f"Erisim engellendi: {resolved}")
+    except OSError as e:  # pragma: no cover - rare FS errors
+        raise HTTPException(500, f"Dizin okunamadi: {e}")
+
+    # Sort: dirs first (alphabetical, case-insensitive), then files.
+    entries.sort(key=lambda e: (e["type"] != "dir", e["name"].lower()))
+
+    # Compute parent. For a drive root ("C:\\") os.path.dirname returns
+    # itself, so we surface ``parent=""`` to mean "go back to the logical
+    # roots list". Same for POSIX "/".
+    parent_raw = os.path.dirname(resolved.rstrip(os.sep) or resolved)
+    if parent_raw == resolved or not parent_raw:
+        parent: str | None = ""
+    else:
+        parent = parent_raw
+
+    out = {
+        "path": resolved,
+        "parent": parent,
+        "entries": entries,
+    }
+    if truncated:
+        out["truncated"] = True
+        out["max_entries"] = max_entries
+    return out
+
+
 # --- Pydantic Models ---
 
 class SourceCreate(BaseModel):
@@ -2197,6 +2376,21 @@ def create_app(db, config, analytics=None, ad_lookup=None, email_notifier=None):
         body = await request.json()
         client_host = (request.client.host if request.client else "")
         return open_folder_impl(body, client_host)
+
+    @app.get("/api/system/list-dir")
+    async def list_dir(
+        request: Request,
+        path: str = "",
+        show_hidden: bool = False,
+    ):
+        """Klasor tarayici icin dizin icerigini listele (sadece localhost).
+
+        Bos ``path`` -> mantiksal kokleri dondurur (Windows surucu harfleri
+        veya POSIX "/"). 5000 girisle sinirlanmis, 'dir'>'file' siralanmis.
+        Uzaktan istemci icin 403; var olmayan yol icin 404.
+        """
+        client_host = (request.client.host if request.client else "")
+        return list_dir_impl(path, client_host, show_hidden=show_hidden)
 
     @app.get("/api/system/health")
     async def health():

--- a/src/dashboard/static/index.html
+++ b/src/dashboard/static/index.html
@@ -1459,6 +1459,26 @@ label { font-size: 12px; color: var(--text-muted); margin-bottom: 6px; display: 
 </div>
 </div>
 
+<!-- Folder Browser Modal (Issue #82 Bug 4 / Issue #105) -->
+<div class="modal-overlay" id="modal-folder-browser">
+<div class="modal" style="max-width:760px;width:90%">
+    <h3>📁 Klasor Sec</h3>
+    <div class="folder-path" style="border-radius:6px;border:1px solid var(--border);margin-bottom:10px">
+        <input id="fb-path-input" placeholder="Yol girin (orn: C:\\ veya \\\\sunucu\\paylasim)" onkeydown="if(event.key==='Enter'){event.preventDefault();folderBrowserGo();}">
+        <button class="btn btn-sm btn-outline" onclick="folderBrowserUp()" title="Ust dizin">⬆</button>
+        <button class="btn btn-sm btn-outline" onclick="folderBrowserGo()">Git</button>
+    </div>
+    <div id="fb-error" style="display:none;background:#7f1d1d;color:#fca5a5;border:1px solid #ef4444;padding:10px 12px;border-radius:6px;margin-bottom:10px;font-size:12px"></div>
+    <div class="folder-browser" id="fb-list" style="min-height:300px;max-height:420px">
+        <div style="padding:20px;text-align:center;color:var(--text-muted)">Yukleniyor...</div>
+    </div>
+    <div class="modal-actions">
+        <button class="btn btn-outline" onclick="closeModal('modal-folder-browser')">Iptal</button>
+        <button class="btn btn-primary" onclick="folderBrowserConfirm()">Sec</button>
+    </div>
+</div>
+</div>
+
 <script>
 // ═══════════════════════════════════════════════════
 // GLOBAL STATE
@@ -2008,6 +2028,178 @@ function browsePath() {
 function selectBrowsePath(path) {
     document.getElementById('src-path').value = path;
     document.getElementById('folder-browser-wrap').style.display = 'none';
+}
+
+// ═══════════════════════════════════════════════════
+// FOLDER BROWSER MODAL (Issue #82 Bug 4 / #105)
+// ─── Generic folder picker backed by /api/system/list-dir.
+// Opens #modal-folder-browser, lets the user click into directories,
+// returns the chosen path to the original input (default: src-path).
+// Localhost-only on the backend; remote callers see a friendly message.
+// ═══════════════════════════════════════════════════
+let folderBrowserState = {
+    targetInputId: 'src-path',
+    currentPath: '',
+};
+
+function loadFolderBrowser(targetInputId) {
+    folderBrowserState.targetInputId = targetInputId || 'src-path';
+    folderBrowserState.currentPath = '';
+    // Seed the path input with whatever's already in the target field, if
+    // any — saves the user navigating from "/" when they're refining a
+    // path they typed earlier.
+    const target = document.getElementById(folderBrowserState.targetInputId);
+    const seed = (target && target.value) ? target.value.trim() : '';
+    document.getElementById('fb-path-input').value = seed;
+    folderBrowserHideError();
+    openModal('modal-folder-browser');
+    folderBrowserLoad(seed);
+}
+
+function folderBrowserHideError() {
+    const err = document.getElementById('fb-error');
+    err.style.display = 'none';
+    err.textContent = '';
+}
+
+function folderBrowserShowError(msg) {
+    const err = document.getElementById('fb-error');
+    err.textContent = msg;
+    err.style.display = 'block';
+    document.getElementById('fb-list').innerHTML =
+        '<div style="padding:20px;text-align:center;color:var(--text-muted)">—</div>';
+}
+
+async function folderBrowserLoad(path) {
+    folderBrowserHideError();
+    const list = document.getElementById('fb-list');
+    list.innerHTML = '<div style="padding:20px;text-align:center;color:var(--text-muted)">Yukleniyor...</div>';
+    let resp;
+    try {
+        resp = await fetch(`${API}/system/list-dir?path=${encodeURIComponent(path || '')}`);
+    } catch (e) {
+        folderBrowserShowError('Ag hatasi: ' + (e && e.message ? e.message : e));
+        return;
+    }
+    if (resp.status === 403) {
+        folderBrowserShowError(
+            'Klasor tarayici sadece sunucudan calisirken kullanilabilir. Yolu manuel girin.'
+        );
+        return;
+    }
+    if (resp.status === 404) {
+        folderBrowserShowError('Yol bulunamadi');
+        return;
+    }
+    if (!resp.ok) {
+        folderBrowserShowError('Hata: HTTP ' + resp.status);
+        return;
+    }
+    const data = await resp.json();
+    folderBrowserState.currentPath = data.path || '';
+    document.getElementById('fb-path-input').value = data.path || '';
+    folderBrowserRender(data);
+}
+
+function folderBrowserRender(data) {
+    const list = document.getElementById('fb-list');
+    const rows = [];
+    // Up-one-level row when we're not at the logical roots.
+    if (data.parent !== null && data.parent !== undefined) {
+        const parentArg = JSON.stringify(data.parent);
+        rows.push(
+            `<div class="folder-item" onclick='folderBrowserLoad(${parentArg})'>`
+            + `<span class="icon">⬆</span><span class="name">.. (Ust dizin)</span></div>`
+        );
+    }
+    if (!data.entries || data.entries.length === 0) {
+        rows.push(
+            '<div style="padding:20px;text-align:center;color:var(--text-muted)">(Bos dizin)</div>'
+        );
+    } else {
+        for (const e of data.entries) {
+            const name = (e.name || '').replace(/[<>&"']/g, c => ({
+                '<': '&lt;', '>': '&gt;', '&': '&amp;', '"': '&quot;', "'": '&#39;'
+            }[c]));
+            if (e.type === 'dir') {
+                // Compose absolute path. Empty data.path means "we're at
+                // the logical roots view" so the entry name IS the path.
+                const childPath = data.path
+                    ? joinPathForBrowser(data.path, e.name)
+                    : e.name;
+                const arg = JSON.stringify(childPath);
+                rows.push(
+                    `<div class="folder-item" onclick='folderBrowserLoad(${arg})'>`
+                    + `<span class="icon">📁</span><span class="name">${name}</span></div>`
+                );
+            } else {
+                const sizeStr = (e.size != null) ? formatBrowserSize(e.size) : '';
+                rows.push(
+                    `<div class="folder-item" style="cursor:default;opacity:0.65">`
+                    + `<span class="icon">📄</span><span class="name">${name}</span>`
+                    + `<span class="size">${sizeStr}</span></div>`
+                );
+            }
+        }
+    }
+    if (data.truncated) {
+        rows.push(
+            `<div style="padding:10px;text-align:center;color:var(--warning,#f59e0b);font-size:12px">`
+            + `Liste ${data.max_entries} girise kirpildi.</div>`
+        );
+    }
+    list.innerHTML = rows.join('');
+}
+
+function joinPathForBrowser(parent, child) {
+    // Pick the right separator. Backslash if the parent already uses it
+    // (Windows / UNC), forward slash otherwise. We avoid os-style joins
+    // here — the server will normalise on the next list-dir round trip.
+    if (parent.indexOf('\\') >= 0) {
+        return parent.endsWith('\\') ? parent + child : parent + '\\' + child;
+    }
+    return parent.endsWith('/') ? parent + child : parent + '/' + child;
+}
+
+function formatBrowserSize(bytes) {
+    if (bytes < 1024) return bytes + ' B';
+    if (bytes < 1024 * 1024) return (bytes / 1024).toFixed(1) + ' KB';
+    if (bytes < 1024 * 1024 * 1024) return (bytes / (1024 * 1024)).toFixed(1) + ' MB';
+    return (bytes / (1024 * 1024 * 1024)).toFixed(2) + ' GB';
+}
+
+function folderBrowserGo() {
+    const v = document.getElementById('fb-path-input').value.trim();
+    folderBrowserLoad(v);
+}
+
+function folderBrowserUp() {
+    const cur = folderBrowserState.currentPath;
+    if (!cur) return;  // already at logical roots
+    // Strip trailing separator(s), then drop the last segment.
+    let p = cur.replace(/[\\/]+$/, '');
+    const lastBack = p.lastIndexOf('\\');
+    const lastFwd = p.lastIndexOf('/');
+    const cut = Math.max(lastBack, lastFwd);
+    if (cut <= 0) {
+        folderBrowserLoad('');
+    } else {
+        folderBrowserLoad(p.substring(0, cut));
+    }
+}
+
+function folderBrowserConfirm() {
+    // Prefer the (possibly hand-edited) path input over currentPath so a
+    // power user can paste a UNC and just hit Sec without browsing into it.
+    const chosen = document.getElementById('fb-path-input').value.trim()
+        || folderBrowserState.currentPath;
+    if (!chosen) {
+        folderBrowserShowError('Lutfen bir yol secin veya girin.');
+        return;
+    }
+    const target = document.getElementById(folderBrowserState.targetInputId);
+    if (target) target.value = chosen;
+    closeModal('modal-folder-browser');
 }
 
 // ═══════════════════════════════════════════════════

--- a/tests/test_button_audit.py
+++ b/tests/test_button_audit.py
@@ -52,11 +52,13 @@ MIN_HANDLERS = 150
 # entry is a known-broken handler the test tolerates so we don't block
 # the audit infrastructure on fixing the underlying features. New orphans
 # (anything not in this set) MUST fail the test.
-KNOWN_ORPHAN_BASELINE: frozenset[str] = frozenset({
-    # loadFolderBrowser is the only remaining placeholder — separate scope
-    # (generic folder picker for source / archive destination dialogs).
-    "loadFolderBrowser",
-})
+#
+# As of issue #82 (Bug 4) / issue #105 the baseline is empty: every onclick
+# in index.html resolves to a real top-level function. The last placeholder
+# (``loadFolderBrowser``) shipped alongside ``/api/system/list-dir``. Keep
+# this set EMPTY going forward — any new orphan should be implemented or
+# spelled correctly, not added back to the baseline.
+KNOWN_ORPHAN_BASELINE: frozenset[str] = frozenset()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_list_dir_endpoint.py
+++ b/tests/test_list_dir_endpoint.py
@@ -1,0 +1,194 @@
+"""Tests for the /api/system/list-dir folder-browser endpoint.
+
+Issue #82 (Bug 4) / Issue #105 — backs the in-dashboard folder picker
+modal. Mirrors the test pattern used for /api/system/open-folder
+(``test_dashboard_api.py``): unit-tests the pure ``list_dir_impl`` helper
+AND drives the FastAPI endpoint through ``TestClient`` with a middleware
+that rewrites the ASGI scope's client tuple so we can simulate a remote
+caller without a real socket.
+
+Coverage:
+
+* Localhost client lists entries with the documented shape.
+* Remote client gets HTTP 403 with an explanatory message (per PR #85's
+  localhost-only lesson).
+* Non-existent path -> HTTP 404.
+* Entry list capped at ``LIST_DIR_MAX_ENTRIES`` (5000) -> ``truncated`` flag.
+* Hidden / dotfile entries skipped by default; ``show_hidden=true`` returns
+  them.
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+
+import pytest
+from fastapi import FastAPI, Request
+from fastapi.testclient import TestClient
+
+from src.dashboard.api import LIST_DIR_MAX_ENTRIES, list_dir_impl
+
+
+def _build_app(force_client_host: str | None = None) -> FastAPI:
+    """Minimal FastAPI app exposing only /api/system/list-dir.
+
+    The middleware below rewrites ``request.scope["client"]`` before the
+    handler runs, which is what ``request.client.host`` reads. Lets us
+    assert the localhost-only branch end-to-end without a real socket.
+    """
+    app = FastAPI()
+
+    if force_client_host is not None:
+        @app.middleware("http")
+        async def _override_client(request: Request, call_next):
+            request.scope["client"] = (force_client_host, 0)
+            return await call_next(request)
+
+    @app.get("/api/system/list-dir")
+    async def list_dir(
+        request: Request, path: str = "", show_hidden: bool = False
+    ):
+        client_host = request.client.host if request.client else ""
+        return list_dir_impl(path, client_host, show_hidden=show_hidden)
+
+    return app
+
+
+@pytest.fixture
+def tmp_folder_with_entries():
+    """Temp dir with two files + two subdirs + one dotfile + one dotdir."""
+    with tempfile.TemporaryDirectory() as d:
+        d = os.path.realpath(d)
+        os.makedirs(os.path.join(d, "alpha_dir"))
+        os.makedirs(os.path.join(d, "beta_dir"))
+        os.makedirs(os.path.join(d, ".hidden_dir"))
+        with open(os.path.join(d, "file_a.txt"), "w") as f:
+            f.write("hello")
+        with open(os.path.join(d, "file_b.txt"), "w") as f:
+            f.write("world!")
+        with open(os.path.join(d, ".hidden_file"), "w") as f:
+            f.write("x")
+        yield d
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_list_dir_localhost_lists_entries(tmp_folder_with_entries):
+    """Localhost call returns 200 with the documented response shape."""
+    app = _build_app(force_client_host="127.0.0.1")
+    client = TestClient(app)
+    resp = client.get(
+        "/api/system/list-dir", params={"path": tmp_folder_with_entries}
+    )
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert data["path"] == tmp_folder_with_entries
+    assert "parent" in data
+    assert isinstance(data["entries"], list)
+
+    # Dirs sort before files (case-insensitive). Hidden entries excluded
+    # by default. 4 visible entries: alpha_dir, beta_dir, file_a.txt, file_b.txt.
+    names = [e["name"] for e in data["entries"]]
+    assert names == ["alpha_dir", "beta_dir", "file_a.txt", "file_b.txt"]
+    types = [e["type"] for e in data["entries"]]
+    assert types == ["dir", "dir", "file", "file"]
+    # Files carry size + mtime.
+    file_a = next(e for e in data["entries"] if e["name"] == "file_a.txt")
+    assert file_a["size"] == 5  # len("hello")
+    assert isinstance(file_a["mtime"], (int, float))
+
+
+def test_list_dir_remote_returns_403(tmp_folder_with_entries):
+    """A remote client must NOT be allowed to walk the server filesystem."""
+    app = _build_app(force_client_host="10.0.0.5")
+    client = TestClient(app)
+    resp = client.get(
+        "/api/system/list-dir", params={"path": tmp_folder_with_entries}
+    )
+    assert resp.status_code == 403, resp.text
+    body = resp.json()
+    # Explanatory message for the operator (the JS surfaces this verbatim).
+    assert "sunucudan" in body.get("detail", "").lower() or \
+           "manuel" in body.get("detail", "").lower()
+
+
+def test_list_dir_nonexistent_returns_404():
+    """Non-existent path -> 404, not 500 / not a leaked stack trace."""
+    missing = os.path.join(
+        tempfile.gettempdir(), "file_activity_does_not_exist_82_bug4"
+    )
+    assert not os.path.exists(missing)
+
+    app = _build_app(force_client_host="127.0.0.1")
+    client = TestClient(app)
+    resp = client.get("/api/system/list-dir", params={"path": missing})
+    assert resp.status_code == 404, resp.text
+
+
+def test_list_dir_caps_entries_at_5000(tmp_path):
+    """A directory with more than 5000 entries is truncated.
+
+    Use a small ``max_entries`` against the ``list_dir_impl`` helper rather
+    than create 5001 files on disk — the cap parameter is what we want to
+    verify, not the literal value 5000.
+    """
+    # Create 12 entries.
+    for i in range(12):
+        (tmp_path / f"file_{i:02d}.txt").write_text("x")
+
+    out = list_dir_impl(
+        str(tmp_path),
+        client_host="127.0.0.1",
+        show_hidden=False,
+        max_entries=10,
+    )
+    assert len(out["entries"]) == 10
+    assert out.get("truncated") is True
+    assert out.get("max_entries") == 10
+
+    # And the production cap is the documented 5000.
+    assert LIST_DIR_MAX_ENTRIES == 5000
+
+
+def test_list_dir_skips_hidden_by_default(tmp_folder_with_entries):
+    """Dotfiles / dotdirs are excluded unless ``show_hidden=true``."""
+    app = _build_app(force_client_host="127.0.0.1")
+    client = TestClient(app)
+
+    # Default: hidden entries excluded.
+    resp = client.get(
+        "/api/system/list-dir",
+        params={"path": tmp_folder_with_entries},
+    )
+    names = [e["name"] for e in resp.json()["entries"]]
+    assert ".hidden_dir" not in names
+    assert ".hidden_file" not in names
+
+    # Opt-in: hidden entries returned.
+    resp2 = client.get(
+        "/api/system/list-dir",
+        params={"path": tmp_folder_with_entries, "show_hidden": "true"},
+    )
+    names2 = [e["name"] for e in resp2.json()["entries"]]
+    assert ".hidden_dir" in names2
+    assert ".hidden_file" in names2
+
+
+def test_list_dir_empty_path_returns_logical_roots():
+    """Empty path -> logical roots (drives on Windows, '/' on POSIX).
+
+    Exercises the platform-conditional branch of ``list_dir_impl`` with a
+    real syscall: at least one root must exist on every supported OS, so
+    the response must be non-empty and ``parent`` must be ``None`` so the
+    UI hides the up-one-level affordance.
+    """
+    out = list_dir_impl("", client_host="127.0.0.1")
+    assert out["path"] == ""
+    assert out["parent"] is None
+    assert isinstance(out["entries"], list)
+    assert len(out["entries"]) >= 1
+    assert all(e["type"] == "dir" for e in out["entries"])


### PR DESCRIPTION
## Summary
Closes the last orphan in `KNOWN_ORPHAN_BASELINE` from PR #104's button audit. Implements `loadFolderBrowser(targetInputId)` — server-side folder picker for source / archive destination forms.

- **`src/dashboard/api.py`**:
  - `GET /api/system/list-dir?path=&show_hidden=` — localhost-only (per #85's lesson), 5000-entry cap, `os.scandir`, dirs-first sort, traversal-safe via `os.path.realpath`/`normpath`
  - Empty path → drive roots on Windows, `/` on Linux/Mac
  - 403 with explanatory message for remote clients
  - 404 for nonexistent paths
- **`src/dashboard/static/index.html`**:
  - `#modal-folder-browser` modal markup
  - `loadFolderBrowser(targetInputId='src-path')` + `folderBrowser{Load,Render,Go,Up,Confirm}` JS family
  - Default `targetInputId='src-path'` keeps the existing argless callsite at line 1254 working untouched
  - Handles 403 (remote client) with Turkish "sunucudan calisirken" banner
  - Truncation banner when > 5000 entries
- **`tests/test_button_audit.py`** — `KNOWN_ORPHAN_BASELINE = frozenset()` (was `{"loadFolderBrowser"}`)
- **`tests/test_list_dir_endpoint.py`** (NEW) — 6 tests

## Audit milestone
`audit_buttons.py --summary` → `handlers=185 unique_functions=93 missing=0 typos=0`. **Zero orphans** for the first time this session.

## Test plan
- [x] Button audit: 7/7 pass
- [x] List-dir endpoint: 6/6 pass (localhost lists, remote 403, 404, 5000-cap, hidden filter)
- [x] Existing dashboard API tests: 5/5 still pass
- [x] Full suite (excl. mcp_eval): 250 passed, 6 skipped
- [ ] Manual: click "+ Kaynak Ekle" → folder picker opens, navigation works, "Sec" populates the input

https://claude.ai/code/session_42ebd88b-d33a-44b2-b45f-b4cf5c2f7a39

---
_Generated by [Claude Code](https://claude.ai/code/session_01A1UzS1A4DZNk1akoP4uhZ7)_