### PR TITLE
Two-person approval framework Phase 1 (snapshot_restore pilot) — closes #112

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -281,3 +281,32 @@ compliance:
   legal_hold:
     enabled: true
     poll_interval_minutes: 5
+
+approvals:
+  # Two-person approval framework (issue #112). Phase 1 wires the
+  # snapshot restore endpoint as a proof of concept; archive_bulk,
+  # purge_bulk and retention_apply are queued for follow-up PRs.
+  # When ``enabled: false`` (default) every existing endpoint behaves
+  # exactly as before — no row is queued, no second person is asked.
+  # Self-approval (B == A) is refused server-side regardless of any
+  # client-side disablement.
+  enabled: false
+  # Operations that require a second person before execution. Even
+  # when ``enabled: true``, an op missing from this list runs straight
+  # through the normal endpoint.
+  require_for: []
+  # e.g.:
+  #   require_for: ['snapshot_restore', 'archive_bulk', 'purge_bulk',
+  #                 'retention_apply']
+  # Pending rows older than this are flipped to ``expired`` by an
+  # hourly APScheduler job. 24h is the default — long enough for an
+  # off-hours request to be approved, short enough to keep the queue
+  # tidy.
+  expiry_hours: 24
+  # How the framework figures out *who* is calling the API:
+  #   * 'windows'         — os.getlogin() (recommended on Windows hosts)
+  #   * 'header'          — read identity_header (auth proxy in front)
+  #   * 'client_supplied' — read body['username'] (UNSAFE; emits a
+  #                         startup warning. Use only during evaluation.)
+  identity_source: "client_supplied"
+  identity_header: "X-Forwarded-User"

--- a/src/dashboard/api.py
+++ b/src/dashboard/api.py
@@ -3790,15 +3790,18 @@ def create_app(db, config, analytics=None, ad_lookup=None, email_notifier=None):
             raise HTTPException(500, f"snapshot_failed: {e}")
         return {"ok": True, **meta.to_dict()}
 
-    @app.post("/api/system/backups/restore/{snapshot_id}")
-    async def restore_snapshot(snapshot_id: str, body: dict):
-        """Restore the live DB from ``snapshot_id``. Refuses if a live
-        connection holds the DB lock — the caller must stop the dashboard
-        first. Body must include ``confirm: true``.
+    def _do_snapshot_restore(payload: dict) -> dict:
+        """Execute a snapshot restore from a payload dict.
+
+        Shared by the direct endpoint (when approvals are disabled or
+        the op isn't gated) and ``ApprovalRegistry.execute`` so the same
+        code path runs whether or not the two-person rule is in effect.
+        Raises ``HTTPException`` so both callers can surface the same
+        error semantics.
         """
-        body = body or {}
-        if not bool(body.get("confirm", False)):
-            raise HTTPException(400, "confirm: true required")
+        snapshot_id = (payload or {}).get("snapshot_id")
+        if not snapshot_id:
+            raise HTTPException(400, "snapshot_id required in payload")
         try:
             mgr = _get_backup_manager()
         except Exception as e:
@@ -3812,12 +3815,59 @@ def create_app(db, config, analytics=None, ad_lookup=None, email_notifier=None):
         except FileNotFoundError as e:
             raise HTTPException(404, str(e))
         except RuntimeError as e:
-            # Live-connection refusal or sha mismatch — surface to UI.
             raise HTTPException(409, str(e))
         except Exception as e:
             logger.error("restore failed: %s", e)
             raise HTTPException(500, f"restore_failed: {e}")
         return {"ok": True, "restored": snapshot_id}
+
+    # Map of operation_type -> executor callable. Used by
+    # ``POST /api/approvals/{id}/execute`` to dispatch the approved
+    # payload back through the original code path. Phase 1 only wires
+    # snapshot_restore — archive_bulk, purge_bulk, retention_apply
+    # follow in subsequent PRs.
+    app.state.approval_executors = {
+        "snapshot_restore": _do_snapshot_restore,
+    }
+
+    @app.post("/api/system/backups/restore/{snapshot_id}")
+    async def restore_snapshot(snapshot_id: str, body: dict, request: Request):
+        """Restore the live DB from ``snapshot_id``. Refuses if a live
+        connection holds the DB lock — the caller must stop the dashboard
+        first. Body must include ``confirm: true``.
+
+        When ``approvals.enabled=true`` AND ``'snapshot_restore'`` is in
+        ``approvals.require_for``, this endpoint queues a pending
+        approval row instead of executing immediately. The caller must
+        then have a *different* operator approve via
+        ``POST /api/approvals/{id}/approve`` and finally trigger
+        execution via ``POST /api/approvals/{id}/execute``.
+        """
+        body = body or {}
+        if not bool(body.get("confirm", False)):
+            raise HTTPException(400, "confirm: true required")
+
+        # Route through approvals when gated. The framework is opt-in;
+        # default config keeps this branch dormant.
+        registry = getattr(app.state, "approval_registry", None)
+        if registry is not None and registry.is_required("snapshot_restore"):
+            from src.security.identity import resolve_user
+            requested_by = resolve_user(request, config, body)
+            req = registry.request(
+                "snapshot_restore",
+                {"snapshot_id": snapshot_id},
+                requested_by,
+            )
+            return {
+                "pending_approval_id": req.id,
+                "status": "pending",
+                "operation_type": req.operation_type,
+                "expires_at": req.expires_at,
+                "requested_by": req.requested_by,
+                "message": "Awaiting second-person approval",
+            }
+
+        return _do_snapshot_restore({"snapshot_id": snapshot_id})
 
     @app.get("/api/system/backups/export")
     async def export_backups_xlsx():
@@ -4367,5 +4417,122 @@ def create_app(db, config, analytics=None, ad_lookup=None, email_notifier=None):
             "active_count": len(actives),
             "held_paths_count": held_paths,
         }
+
+    # ──────────────────────────────────────────────
+    # Two-person approval framework (issue #112)
+    # ──────────────────────────────────────────────
+    # Registry lives on app.state so the snapshot-restore endpoint
+    # (above) and these endpoints share a single instance. Constructed
+    # unconditionally — when ``approvals.enabled=false`` every
+    # ``is_required`` call short-circuits to False and existing ops run
+    # straight through, so this is zero-cost backwards compat.
+    from src.security.approvals import (
+        ApprovalRegistry, ApprovalNotFound, SelfApprovalError,
+        InvalidStateError, ApprovalExpiredError, ApprovalError,
+    )
+    from src.security.identity import resolve_user, warn_if_unsafe
+    app.state.approval_registry = ApprovalRegistry(db, config)
+    warn_if_unsafe(config)
+
+    def _approval_to_json(req) -> dict:
+        return req.to_dict()
+
+    @app.get("/api/approvals/config")
+    async def approvals_config():
+        """Expose the runtime config of the approval framework so the
+        frontend can render the right banners + disable/enable buttons.
+        Safe to read while disabled — returns ``enabled=false``."""
+        cfg = (config or {}).get("approvals") or {}
+        return {
+            "enabled": bool(cfg.get("enabled", False)),
+            "require_for": list(cfg.get("require_for") or []),
+            "expiry_hours": int(cfg.get("expiry_hours", 24) or 24),
+            "identity_source": (cfg.get("identity_source")
+                                or "client_supplied"),
+        }
+
+    @app.get("/api/approvals/pending")
+    async def approvals_list_pending():
+        registry = app.state.approval_registry
+        rows = registry.list_pending()
+        return {"rows": [_approval_to_json(r) for r in rows]}
+
+    @app.get("/api/approvals/history")
+    async def approvals_history(limit: int = Query(50, ge=1, le=1000)):
+        registry = app.state.approval_registry
+        rows = registry.list_history(limit=limit)
+        return {"rows": [_approval_to_json(r) for r in rows]}
+
+    @app.post("/api/approvals/{approval_id}/approve")
+    async def approvals_approve(approval_id: int, body: dict, request: Request):
+        body = body or {}
+        registry = app.state.approval_registry
+        approved_by = (body.get("approved_by")
+                       or resolve_user(request, config, body))
+        try:
+            req = registry.approve(approval_id, approved_by)
+        except ApprovalNotFound:
+            raise HTTPException(404, f"approval {approval_id} not found")
+        except SelfApprovalError as e:
+            raise HTTPException(403, str(e))
+        except ApprovalExpiredError as e:
+            raise HTTPException(409, str(e))
+        except InvalidStateError as e:
+            raise HTTPException(409, str(e))
+        except ApprovalError as e:
+            raise HTTPException(400, str(e))
+        return {"ok": True, "approval": _approval_to_json(req)}
+
+    @app.post("/api/approvals/{approval_id}/reject")
+    async def approvals_reject(approval_id: int, body: dict, request: Request):
+        body = body or {}
+        registry = app.state.approval_registry
+        rejected_by = (body.get("rejected_by")
+                       or resolve_user(request, config, body))
+        reason = (body.get("reason") or "").strip()
+        try:
+            req = registry.reject(approval_id, rejected_by, reason)
+        except ApprovalNotFound:
+            raise HTTPException(404, f"approval {approval_id} not found")
+        except InvalidStateError as e:
+            raise HTTPException(409, str(e))
+        except ApprovalError as e:
+            raise HTTPException(400, str(e))
+        return {"ok": True, "approval": _approval_to_json(req)}
+
+    @app.post("/api/approvals/{approval_id}/execute")
+    async def approvals_execute(approval_id: int, body: dict):
+        """Run the executor mapped to the approval's operation_type.
+
+        Body may carry an ``executor_token`` reserved for future
+        signing (issue #112 follow-up); Phase 1 ignores it but the
+        field is documented in the API surface so client code can
+        pre-stage support.
+        """
+        body = body or {}
+        registry = app.state.approval_registry
+        try:
+            req = registry.get(approval_id)
+        except ApprovalNotFound:
+            raise HTTPException(404, f"approval {approval_id} not found")
+
+        executor_map = getattr(app.state, "approval_executors", {}) or {}
+        executor = executor_map.get(req.operation_type)
+        if executor is None:
+            raise HTTPException(
+                400,
+                f"no executor registered for operation_type "
+                f"{req.operation_type!r} (Phase 1 wires snapshot_restore only)",
+            )
+        try:
+            result = registry.execute(approval_id, executor)
+        except InvalidStateError as e:
+            raise HTTPException(409, str(e))
+        except HTTPException:
+            # Executor surfaced its own HTTP error — propagate.
+            raise
+        except ApprovalError as e:
+            raise HTTPException(400, str(e))
+        return {"ok": True, "result": result}
 
     return app

--- a/src/dashboard/static/index.html
+++ b/src/dashboard/static/index.html
@@ -436,6 +436,7 @@ label { font-size: 12px; color: var(--text-muted); margin-bottom: 6px; display: 
         <div class="nav-label">Sistem</div>
         <div class="nav-item" onclick="showPage('backups')"><span class="icon">💾</span> <span>Yedekler</span></div>
         <div class="nav-item" onclick="showPage('operations')"><span class="icon">📜</span> <span>Islem Gecmisi</span></div>
+        <div class="nav-item" onclick="showPage('approvals')"><span class="icon">✅</span> <span>Onaylar</span></div>
     </div>
     <div class="sidebar-footer">
         <div class="status"><span class="dot"></span> <span>Sistem Aktif</span></div>
@@ -1203,6 +1204,64 @@ label { font-size: 12px; color: var(--text-muted); margin-bottom: 6px; display: 
     </div>
 </div>
 
+<!-- ============ APPROVALS (#112) ============ -->
+<div class="page" id="page-approvals">
+    <div class="page-header">
+        <div><h2>Iki Kisilik Onay Kuyrugu</h2><div class="desc">Yuksek etkili admin islemleri icin ikinci kisi dogrulamasi (snapshot restore vb.)</div></div>
+        <div class="actions">
+            <input id="approvals-current-user" placeholder="Kullanici adi (header/proxy yoksa)" style="width:220px">
+            <button class="btn btn-primary" onclick="loadApprovalsAll()">Yenile</button>
+        </div>
+    </div>
+    <div id="approvals-flag-banner" style="display:none;background:var(--warning,#f59e0b);color:#000;padding:12px 16px;border-radius:8px;margin-bottom:16px;font-size:13px">
+        <strong>Onay cercevesi kapali.</strong> Aktif etmek icin <code>config.yaml</code> dosyasinda <code>approvals.enabled: true</code> ayarlayin ve <code>require_for</code> listesine ilgili islemi ekleyin.
+    </div>
+    <div id="approvals-meta" style="background:var(--bg-card);border:1px solid var(--border);border-radius:var(--radius);padding:14px 18px;margin-bottom:16px;font-size:12px;color:var(--text-muted);display:none">
+        Aktif islemler: <span id="approvals-require-for" style="color:var(--accent)">-</span> &nbsp;|&nbsp;
+        Sona erme: <span id="approvals-expiry-hours">-</span>h &nbsp;|&nbsp;
+        Kimlik kaynagi: <code id="approvals-identity-source">-</code>
+    </div>
+
+    <div class="tabs" style="display:flex;gap:8px;margin-bottom:16px;border-bottom:1px solid var(--border)">
+        <button class="btn btn-outline approvals-tab active" data-tab="pending" onclick="switchApprovalsTab('pending')">Bekleyen</button>
+        <button class="btn btn-outline approvals-tab" data-tab="history" onclick="switchApprovalsTab('history')">Onay Gecmisi</button>
+    </div>
+
+    <div id="approvals-pending-wrap">
+        <div class="table-wrap" style="overflow:auto">
+            <table style="width:100%;border-collapse:collapse">
+                <thead><tr>
+                    <th style="text-align:left;padding:10px;border-bottom:1px solid var(--border)">ID</th>
+                    <th style="text-align:left;padding:10px;border-bottom:1px solid var(--border)">Islem</th>
+                    <th style="text-align:left;padding:10px;border-bottom:1px solid var(--border)">Payload</th>
+                    <th style="text-align:left;padding:10px;border-bottom:1px solid var(--border)">Talep Eden</th>
+                    <th style="text-align:left;padding:10px;border-bottom:1px solid var(--border)">Talep Zamani</th>
+                    <th style="text-align:left;padding:10px;border-bottom:1px solid var(--border)">Sona Eriyor</th>
+                    <th style="text-align:right;padding:10px;border-bottom:1px solid var(--border);width:240px">Islem</th>
+                </tr></thead>
+                <tbody id="approvals-pending-tbody"><tr><td colspan="7" style="padding:20px;text-align:center;color:var(--text-muted)">Yukleniyor...</td></tr></tbody>
+            </table>
+        </div>
+    </div>
+
+    <div id="approvals-history-wrap" style="display:none">
+        <div class="table-wrap" style="overflow:auto">
+            <table style="width:100%;border-collapse:collapse">
+                <thead><tr>
+                    <th style="text-align:left;padding:10px;border-bottom:1px solid var(--border)">ID</th>
+                    <th style="text-align:left;padding:10px;border-bottom:1px solid var(--border)">Islem</th>
+                    <th style="text-align:left;padding:10px;border-bottom:1px solid var(--border)">Durum</th>
+                    <th style="text-align:left;padding:10px;border-bottom:1px solid var(--border)">Talep Eden</th>
+                    <th style="text-align:left;padding:10px;border-bottom:1px solid var(--border)">Onaylayan</th>
+                    <th style="text-align:left;padding:10px;border-bottom:1px solid var(--border)">Reddeden</th>
+                    <th style="text-align:left;padding:10px;border-bottom:1px solid var(--border)">Talep Zamani</th>
+                </tr></thead>
+                <tbody id="approvals-history-tbody"><tr><td colspan="7" style="padding:20px;text-align:center;color:var(--text-muted)">Yukleniyor...</td></tr></tbody>
+            </table>
+        </div>
+    </div>
+</div>
+
 <!-- ============ BACKUPS ============ -->
 <div class="page" id="page-backups">
     <div class="page-header">
@@ -1811,7 +1870,7 @@ function showPage(name) {
     // Find and activate nav item
     document.querySelectorAll('.nav-item').forEach(n => { if (n.getAttribute('onclick')?.includes(name)) n.classList.add('active'); });
     // Auto-load data
-    const loaders = { overview: loadOverview, sources: loadSources, frequency: loadFrequency, types: loadTypes, sizes: loadSizes, users: loadUsers, anomalies: loadAnomalies, archive: loadArchive, 'archive-history': loadArchiveHistory, duplicates: loadDuplicates, growth: loadGrowth, naming: loadNaming, policies: loadPolicies, schedules: loadSchedules, treemap: loadTreemap, insights: loadInsights, sqlquery: sqlqInit, 'legal-holds': loadLegalHolds, 'orphan-sids': loadOrphanSids, ransomware: loadRansomwareAlerts, acl: loadAclAnalyzer, pii: loadPii, retention: loadRetention, syslog: loadSyslog, mcp: loadMcp, backups: loadBackups, operations: loadOperations };
+    const loaders = { overview: loadOverview, sources: loadSources, frequency: loadFrequency, types: loadTypes, sizes: loadSizes, users: loadUsers, anomalies: loadAnomalies, archive: loadArchive, 'archive-history': loadArchiveHistory, duplicates: loadDuplicates, growth: loadGrowth, naming: loadNaming, policies: loadPolicies, schedules: loadSchedules, treemap: loadTreemap, insights: loadInsights, sqlquery: sqlqInit, 'legal-holds': loadLegalHolds, 'orphan-sids': loadOrphanSids, ransomware: loadRansomwareAlerts, acl: loadAclAnalyzer, pii: loadPii, retention: loadRetention, syslog: loadSyslog, mcp: loadMcp, backups: loadBackups, operations: loadOperations, approvals: loadApprovalsAll };
     // Issue #79: route through loadWithProgress so slow pages get a top
     // progress bar, ETA from p50 history, and a retry path on failure.
     if (loaders[name]) loadWithProgress(name, loaders[name]).catch(() => { /* widget surfaces error */ });
@@ -5625,6 +5684,213 @@ async function exportBackupsXlsx(ev) {
     if (!btn) return;
     await withButtonLoading(btn, async (signal) => {
         await fetchAndDownload('/api/system/backups/export', signal, 'backups.xlsx');
+    });
+}
+
+// ═══════════════════════════════════════════════════
+// APPROVALS (issue #112)
+// ═══════════════════════════════════════════════════
+
+let _approvalsConfig = { enabled: false, require_for: [], expiry_hours: 24, identity_source: 'client_supplied' };
+let _approvalsTab = 'pending';
+
+function _approvalsCurrentUser() {
+    const el = document.getElementById('approvals-current-user');
+    return (el && el.value || '').trim();
+}
+
+function _formatExpiry(expiresAt) {
+    if (!expiresAt) return '-';
+    const exp = new Date(expiresAt.replace(' ', 'T'));
+    if (isNaN(exp.getTime())) return _esc(expiresAt);
+    const ms = exp.getTime() - Date.now();
+    if (ms <= 0) return '<span style="color:var(--danger)">Sona erdi</span>';
+    const h = Math.floor(ms / 3600000);
+    const m = Math.floor((ms % 3600000) / 60000);
+    return `<span title="${_esc(expiresAt)}">${h}s ${m}d</span>`;
+}
+
+async function loadApprovalsConfig() {
+    try {
+        const r = await fetch('/api/approvals/config');
+        if (!r.ok) return;
+        const d = await r.json();
+        _approvalsConfig = d || _approvalsConfig;
+        const banner = document.getElementById('approvals-flag-banner');
+        if (banner) banner.style.display = _approvalsConfig.enabled ? 'none' : 'block';
+        const meta = document.getElementById('approvals-meta');
+        if (meta) {
+            meta.style.display = 'block';
+            const rf = (_approvalsConfig.require_for || []).join(', ') || '(yok)';
+            const rfEl = document.getElementById('approvals-require-for');
+            if (rfEl) rfEl.textContent = rf;
+            const exEl = document.getElementById('approvals-expiry-hours');
+            if (exEl) exEl.textContent = _approvalsConfig.expiry_hours;
+            const idEl = document.getElementById('approvals-identity-source');
+            if (idEl) idEl.textContent = _approvalsConfig.identity_source;
+        }
+    } catch (e) {
+        console.error('loadApprovalsConfig error:', e);
+    }
+}
+
+async function loadApprovalsAll() {
+    await loadApprovalsConfig();
+    await loadApprovalsPending();
+    await loadApprovalsHistory();
+}
+
+function switchApprovalsTab(tab) {
+    _approvalsTab = tab;
+    document.querySelectorAll('.approvals-tab').forEach(b => {
+        if (b.getAttribute('data-tab') === tab) b.classList.add('active');
+        else b.classList.remove('active');
+    });
+    const pendingWrap = document.getElementById('approvals-pending-wrap');
+    const historyWrap = document.getElementById('approvals-history-wrap');
+    if (pendingWrap) pendingWrap.style.display = (tab === 'pending') ? 'block' : 'none';
+    if (historyWrap) historyWrap.style.display = (tab === 'history') ? 'block' : 'none';
+}
+
+async function loadApprovalsPending() {
+    const tbody = document.getElementById('approvals-pending-tbody');
+    if (!tbody) return;
+    try {
+        const r = await fetch('/api/approvals/pending');
+        const d = r.ok ? await r.json() : { rows: [] };
+        const rows = d.rows || [];
+        if (!rows.length) {
+            tbody.innerHTML = '<tr><td colspan="7" style="padding:20px;text-align:center;color:var(--text-muted)">Bekleyen onay yok</td></tr>';
+            return;
+        }
+        const me = _approvalsCurrentUser();
+        tbody.innerHTML = rows.map(row => {
+            const isSelf = me && (me === row.requested_by);
+            const buttons = `
+                <button class="btn btn-primary" style="font-size:11px;padding:4px 10px;margin-right:4px"
+                        ${isSelf ? 'disabled title="Kendi talebinizi onaylayamazsiniz"' : ''}
+                        onclick="approveApproval(${row.id}, this)">Onayla</button>
+                <button class="btn btn-outline" style="font-size:11px;padding:4px 10px;border-color:var(--danger);color:var(--danger);margin-right:4px"
+                        onclick="openRejectModal(${row.id})">Reddet</button>
+                <button class="btn btn-outline" style="font-size:11px;padding:4px 10px"
+                        onclick="executeApproval(${row.id}, this)">Calistir</button>`;
+            return `
+                <tr>
+                    <td style="padding:10px;border-bottom:1px solid var(--border)"><code>${row.id}</code></td>
+                    <td style="padding:10px;border-bottom:1px solid var(--border)"><code>${_esc(row.operation_type)}</code></td>
+                    <td style="padding:10px;border-bottom:1px solid var(--border);font-size:11px"><code>${_esc(JSON.stringify(row.payload || {}))}</code></td>
+                    <td style="padding:10px;border-bottom:1px solid var(--border)">${_esc(row.requested_by)}</td>
+                    <td style="padding:10px;border-bottom:1px solid var(--border);font-size:11px">${_esc(row.requested_at)}</td>
+                    <td style="padding:10px;border-bottom:1px solid var(--border)">${_formatExpiry(row.expires_at)}</td>
+                    <td style="padding:10px;border-bottom:1px solid var(--border);text-align:right">${buttons}</td>
+                </tr>`;
+        }).join('');
+    } catch (e) {
+        console.error('loadApprovalsPending error:', e);
+        tbody.innerHTML = `<tr><td colspan="7" style="padding:20px;text-align:center;color:var(--danger)">Hata: ${_esc(e.message)}</td></tr>`;
+    }
+}
+
+async function loadApprovalsHistory() {
+    const tbody = document.getElementById('approvals-history-tbody');
+    if (!tbody) return;
+    try {
+        const r = await fetch('/api/approvals/history?limit=100');
+        const d = r.ok ? await r.json() : { rows: [] };
+        const rows = d.rows || [];
+        if (!rows.length) {
+            tbody.innerHTML = '<tr><td colspan="7" style="padding:20px;text-align:center;color:var(--text-muted)">Kayit yok</td></tr>';
+            return;
+        }
+        tbody.innerHTML = rows.map(row => {
+            const statusColor = {
+                pending: 'var(--warning)', approved: 'var(--accent)',
+                rejected: 'var(--danger)', expired: 'var(--text-muted)',
+                executed: 'var(--success)',
+            }[row.status] || 'var(--text-muted)';
+            return `
+                <tr>
+                    <td style="padding:10px;border-bottom:1px solid var(--border)"><code>${row.id}</code></td>
+                    <td style="padding:10px;border-bottom:1px solid var(--border)"><code>${_esc(row.operation_type)}</code></td>
+                    <td style="padding:10px;border-bottom:1px solid var(--border);color:${statusColor};font-weight:600">${_esc(row.status)}</td>
+                    <td style="padding:10px;border-bottom:1px solid var(--border)">${_esc(row.requested_by)}</td>
+                    <td style="padding:10px;border-bottom:1px solid var(--border)">${_esc(row.approved_by || '-')}</td>
+                    <td style="padding:10px;border-bottom:1px solid var(--border)">${_esc(row.rejected_by || '-')}</td>
+                    <td style="padding:10px;border-bottom:1px solid var(--border);font-size:11px">${_esc(row.requested_at)}</td>
+                </tr>`;
+        }).join('');
+    } catch (e) {
+        console.error('loadApprovalsHistory error:', e);
+        tbody.innerHTML = `<tr><td colspan="7" style="padding:20px;text-align:center;color:var(--danger)">Hata: ${_esc(e.message)}</td></tr>`;
+    }
+}
+
+async function approveApproval(id, btn) {
+    const me = _approvalsCurrentUser();
+    if (!me) {
+        if (!confirm('Kullanici adi girilmedi. Server tarafi kimlik cozumlemesi kullanilacak. Devam edilsin mi?')) return;
+    }
+    await withButtonLoading(btn, async (signal) => {
+        const r = await fetch(`/api/approvals/${id}/approve`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(me ? { approved_by: me } : {}),
+            signal,
+        });
+        const d = await r.json().catch(() => ({}));
+        if (!r.ok) {
+            notify('Onaylanamadi: ' + (d.detail || `HTTP ${r.status}`), 'error');
+            return;
+        }
+        notify('Onaylandi: #' + id, 'success');
+        await loadApprovalsAll();
+    });
+}
+
+function openRejectModal(id) {
+    const reason = prompt('Red gerekcesi:', '');
+    if (reason === null) return;
+    rejectApproval(id, reason);
+}
+
+async function rejectApproval(id, reason) {
+    const me = _approvalsCurrentUser();
+    const body = { reason: reason || '' };
+    if (me) body.rejected_by = me;
+    try {
+        const r = await fetch(`/api/approvals/${id}/reject`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(body),
+        });
+        const d = await r.json().catch(() => ({}));
+        if (!r.ok) {
+            notify('Reddedilemedi: ' + (d.detail || `HTTP ${r.status}`), 'error');
+            return;
+        }
+        notify('Reddedildi: #' + id, 'success');
+        loadApprovalsAll();
+    } catch (e) {
+        notify('Reddedilemedi: ' + e.message, 'error');
+    }
+}
+
+async function executeApproval(id, btn) {
+    if (!confirm('Onaylanmis islem calistirilsin mi? Bu islem geri alinamaz.')) return;
+    await withButtonLoading(btn, async (signal) => {
+        const r = await fetch(`/api/approvals/${id}/execute`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({}),
+            signal,
+        });
+        const d = await r.json().catch(() => ({}));
+        if (!r.ok) {
+            notify('Calistirma basarisiz: ' + (d.detail || `HTTP ${r.status}`), 'error');
+            return;
+        }
+        notify('Islem calistirildi: #' + id, 'success');
+        await loadApprovalsAll();
     });
 }
 

--- a/src/scheduler/task_scheduler.py
+++ b/src/scheduler/task_scheduler.py
@@ -32,6 +32,10 @@ class TaskScheduler:
         # This is config-driven (not stored in scheduled_tasks) so it
         # works on fresh installs without a manual setup step.
         self._register_daily_backup_job()
+        # Issue #112: hourly expire_stale job for the two-person
+        # approval queue. Always-on (cheap no-op when there are no
+        # pending rows or approvals.enabled=false).
+        self._register_approval_expiry_job()
         self.scheduler.start()
         logger.info("TaskScheduler başlatıldı")
 
@@ -389,6 +393,53 @@ class TaskScheduler:
             )
         except Exception as e:
             logger.error("Failed to register daily_backup: %s", e)
+
+    def _run_approval_expiry(self):
+        """Flip stale pending approvals to ``expired`` (issue #112)."""
+        try:
+            from src.security.approvals import ApprovalRegistry
+        except Exception as e:
+            logger.warning("approvals import failed: %s", e)
+            return {"status": "error", "message": str(e)}
+        try:
+            registry = ApprovalRegistry(self.db, self.config)
+            n = registry.expire_stale()
+            logger.info("expire_stale_approvals: flipped %d row(s)", n)
+            return {"status": "ok", "expired": n}
+        except Exception as e:
+            logger.error("expire_stale_approvals failed: %s", e, exc_info=True)
+            return {"status": "error", "message": str(e)}
+
+    def _register_approval_expiry_job(self):
+        """Register the hourly approval-expiry job (issue #112)."""
+        approvals_cfg = (self.config or {}).get("approvals") or {}
+        # Allow operators to override the cron with
+        # approvals.expire_check_hour (still hourly, just lets them set
+        # which minute each hour the job runs). Default minute=5 to
+        # avoid the top-of-hour scheduler-startup rush.
+        try:
+            minute = int(approvals_cfg.get("expire_check_minute", 5))
+        except (TypeError, ValueError):
+            minute = 5
+        if minute < 0 or minute > 59:
+            minute = 5
+        try:
+            trigger = CronTrigger(minute=str(minute))
+            self.scheduler.add_job(
+                self._run_approval_expiry,
+                trigger=trigger,
+                id="expire_stale_approvals",
+                name="expire_stale_approvals",
+                replace_existing=True,
+            )
+            logger.info(
+                "expire_stale_approvals job registered (cron: %d * * * *)",
+                minute,
+            )
+        except Exception as e:
+            logger.error(
+                "Failed to register expire_stale_approvals: %s", e
+            )
 
     def reload_tasks(self):
         """Görevleri yeniden yükle."""

--- a/src/security/approvals.py
+++ b/src/security/approvals.py
@@ -1,0 +1,535 @@
+"""Two-person approval framework — Phase 1 (issue #112).
+
+High-impact admin operations (snapshot restore, bulk archive/purge,
+retention apply) can be gated behind a two-person rule so a single
+compromised or careless account can't wipe a database. The framework
+itself is generic: each callsite pushes a payload onto the
+``pending_approvals`` queue, a *different* operator approves it, and a
+final ``execute`` step runs the operation by invoking a callable
+registered for the operation type.
+
+Phase 1 wires only ``snapshot_restore`` as a proof of concept. Other
+operations follow in subsequent PRs.
+
+Design notes
+------------
+
+* **Default OFF.** ``approvals.enabled=false`` makes ``is_required``
+  return False unconditionally — every existing endpoint behaves
+  exactly as before. Backwards compat is critical.
+* **Self-approval refused server-side.** ``approve()`` raises
+  ``SelfApprovalError`` when the approving user matches
+  ``requested_by``. The frontend must also disable the button, but the
+  rule lives on the server.
+* **Idempotent transitions.** ``approve``/``reject``/``execute`` reject
+  rows that aren't in the expected source state.
+* **Audit trail.** Every transition writes a ``file_audit_events`` row
+  via ``insert_audit_event_chained`` when available (issue #38), with
+  ``insert_audit_event`` / ``insert_audit_event_simple`` fallbacks. A
+  failure to audit is logged but doesn't break the operation.
+* **Expiry.** ``expires_at`` defaults to now + ``expiry_hours``. The
+  scheduler runs ``expire_stale`` hourly to flip stale rows to
+  ``expired``.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass, asdict
+from datetime import datetime, timedelta
+from typing import Any, Callable, Optional
+
+logger = logging.getLogger("file_activity.security.approvals")
+
+
+# ── Exceptions ─────────────────────────────────────────────
+
+
+class ApprovalError(Exception):
+    """Base class for approval framework errors."""
+
+
+class ApprovalNotFound(ApprovalError):
+    """No row with the given id."""
+
+
+class SelfApprovalError(ApprovalError):
+    """Refused: the approving user is the same as the requester."""
+
+
+class InvalidStateError(ApprovalError):
+    """Row not in the expected source state for this transition."""
+
+
+class ApprovalExpiredError(ApprovalError):
+    """Row expired before the requested transition could run."""
+
+
+# ── DTO ────────────────────────────────────────────────────
+
+
+@dataclass
+class ApprovalRequest:
+    """Snapshot of a ``pending_approvals`` row.
+
+    ``payload`` is the parsed JSON dict; the raw column is
+    ``payload_json``. Time fields are ISO strings as returned by SQLite
+    so the dataclass is JSON-serialisable for API responses.
+    """
+
+    id: int
+    operation_type: str
+    payload: dict
+    requested_by: str
+    requested_at: str
+    expires_at: str
+    status: str
+    approved_by: Optional[str] = None
+    approved_at: Optional[str] = None
+    rejected_by: Optional[str] = None
+    rejected_at: Optional[str] = None
+    rejection_reason: Optional[str] = None
+    executed_at: Optional[str] = None
+    executed_result: Optional[dict] = None
+
+    def to_dict(self) -> dict:
+        d = asdict(self)
+        return d
+
+
+def _row_to_request(row: dict) -> ApprovalRequest:
+    payload = {}
+    raw = row.get("payload_json")
+    if raw:
+        try:
+            payload = json.loads(raw)
+        except Exception:
+            payload = {"_raw": raw}
+    result = None
+    raw_r = row.get("executed_result_json")
+    if raw_r:
+        try:
+            result = json.loads(raw_r)
+        except Exception:
+            result = {"_raw": raw_r}
+    return ApprovalRequest(
+        id=int(row["id"]),
+        operation_type=row["operation_type"],
+        payload=payload,
+        requested_by=row["requested_by"],
+        requested_at=str(row.get("requested_at") or ""),
+        expires_at=str(row.get("expires_at") or ""),
+        status=row["status"],
+        approved_by=row.get("approved_by"),
+        approved_at=str(row["approved_at"]) if row.get("approved_at") else None,
+        rejected_by=row.get("rejected_by"),
+        rejected_at=str(row["rejected_at"]) if row.get("rejected_at") else None,
+        rejection_reason=row.get("rejection_reason"),
+        executed_at=str(row["executed_at"]) if row.get("executed_at") else None,
+        executed_result=result,
+    )
+
+
+# ── Registry ───────────────────────────────────────────────
+
+
+class ApprovalRegistry:
+    """SQLite-backed pending approval queue.
+
+    Cheap to construct; stores no state outside the DB. Safe to share
+    across threads — every method acquires its own cursor.
+    """
+
+    def __init__(self, db, config: Any):
+        self.db = db
+        self.config = config or {}
+        cfg = (self.config.get("approvals") or {}) if isinstance(self.config, dict) else {}
+        self.enabled = bool(cfg.get("enabled", False))
+        try:
+            self.expiry_hours = int(cfg.get("expiry_hours", 24))
+        except (TypeError, ValueError):
+            self.expiry_hours = 24
+        if self.expiry_hours <= 0:
+            self.expiry_hours = 24
+        raw_list = cfg.get("require_for") or []
+        self.require_for: list[str] = [
+            str(x) for x in raw_list if isinstance(x, str)
+        ]
+
+    # ── Audit helper ───────────────────────────────────────
+
+    def _audit(self, event_type: str, username: str, details: dict) -> None:
+        """Write an audit event. Never raises — audit is best-effort."""
+        try:
+            payload = json.dumps(details, default=str, sort_keys=True)
+        except Exception:
+            payload = str(details)
+        try:
+            if hasattr(self.db, "insert_audit_event_chained"):
+                self.db.insert_audit_event_chained({
+                    "source_id": None,
+                    "event_type": event_type,
+                    "username": username,
+                    "file_path": f"approval:{details.get('approval_id', '?')}",
+                    "details": payload,
+                    "detected_by": "approvals",
+                })
+                return
+        except Exception as e:
+            logger.warning("approvals chained audit failed: %s", e)
+        try:
+            if hasattr(self.db, "insert_audit_event"):
+                self.db.insert_audit_event(
+                    source_id=None,
+                    event_time=datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
+                    event_type=event_type,
+                    username=username,
+                    file_path=f"approval:{details.get('approval_id', '?')}",
+                    file_name=None,
+                    details=payload,
+                    detected_by="approvals",
+                )
+                return
+        except Exception as e:
+            logger.warning("approvals audit fallback failed: %s", e)
+        try:
+            if hasattr(self.db, "insert_audit_event_simple"):
+                self.db.insert_audit_event_simple(
+                    source_id=None,
+                    event_type=event_type,
+                    username=username,
+                    file_path=f"approval:{details.get('approval_id', '?')}",
+                    details=payload,
+                    detected_by="approvals",
+                )
+        except Exception as e:
+            logger.warning("approvals audit_simple fallback failed: %s", e)
+
+    # ── Public API ─────────────────────────────────────────
+
+    def is_required(self, operation_type: str) -> bool:
+        """True if approvals are enabled AND the op is in
+        ``require_for``."""
+        if not self.enabled:
+            return False
+        return operation_type in self.require_for
+
+    def request(
+        self,
+        operation_type: str,
+        payload: dict,
+        requested_by: str,
+    ) -> ApprovalRequest:
+        """Insert a pending row, return the populated DTO."""
+        if not isinstance(operation_type, str) or not operation_type.strip():
+            raise ApprovalError("operation_type required")
+        if not isinstance(requested_by, str) or not requested_by.strip():
+            requested_by = "unknown"
+        payload_json = json.dumps(payload or {}, default=str, sort_keys=True)
+        expires_at = (datetime.now() + timedelta(hours=self.expiry_hours)) \
+            .strftime("%Y-%m-%d %H:%M:%S")
+
+        with self.db.get_cursor() as cur:
+            cur.execute(
+                """
+                INSERT INTO pending_approvals
+                  (operation_type, payload_json, requested_by, expires_at, status)
+                VALUES (?, ?, ?, ?, 'pending')
+                """,
+                (operation_type, payload_json, requested_by, expires_at),
+            )
+            new_id = cur.lastrowid
+            cur.execute(
+                "SELECT * FROM pending_approvals WHERE id = ?", (new_id,)
+            )
+            row = cur.fetchone()
+
+        req = _row_to_request(dict(row))
+        self._audit(
+            "approval_requested",
+            requested_by,
+            {
+                "approval_id": req.id,
+                "operation_type": req.operation_type,
+                "expires_at": req.expires_at,
+            },
+        )
+        logger.info(
+            "approval requested id=%s op=%s by=%s expires=%s",
+            req.id, req.operation_type, req.requested_by, req.expires_at,
+        )
+        return req
+
+    def get(self, approval_id: int) -> ApprovalRequest:
+        """Fetch a single approval row or raise ``ApprovalNotFound``."""
+        with self.db.get_cursor() as cur:
+            cur.execute(
+                "SELECT * FROM pending_approvals WHERE id = ?",
+                (int(approval_id),),
+            )
+            row = cur.fetchone()
+        if row is None:
+            raise ApprovalNotFound(f"approval id {approval_id} not found")
+        return _row_to_request(dict(row))
+
+    def approve(
+        self,
+        approval_id: int,
+        approved_by: str,
+    ) -> ApprovalRequest:
+        """Mark the row approved. Refuses self-approval (B == A)."""
+        if not isinstance(approved_by, str) or not approved_by.strip():
+            approved_by = "unknown"
+        req = self.get(approval_id)
+        if req.status != "pending":
+            raise InvalidStateError(
+                f"cannot approve: status={req.status!r} (need 'pending')"
+            )
+        if self._is_expired(req.expires_at):
+            # Auto-flip to expired and refuse the approve.
+            self._mark_expired(approval_id)
+            raise ApprovalExpiredError(
+                f"approval {approval_id} expired at {req.expires_at}"
+            )
+        if approved_by == req.requested_by:
+            raise SelfApprovalError(
+                "self-approval refused: approver must differ from requester"
+            )
+        now = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+        with self.db.get_cursor() as cur:
+            cur.execute(
+                """
+                UPDATE pending_approvals
+                SET status='approved', approved_by=?, approved_at=?
+                WHERE id=? AND status='pending'
+                """,
+                (approved_by, now, approval_id),
+            )
+            if cur.rowcount == 0:
+                raise InvalidStateError(
+                    "approval row changed mid-flight (lost race)"
+                )
+        self._audit(
+            "approval_approved",
+            approved_by,
+            {
+                "approval_id": approval_id,
+                "operation_type": req.operation_type,
+                "requested_by": req.requested_by,
+            },
+        )
+        logger.info(
+            "approval approved id=%s by=%s (requested_by=%s)",
+            approval_id, approved_by, req.requested_by,
+        )
+        return self.get(approval_id)
+
+    def reject(
+        self,
+        approval_id: int,
+        rejected_by: str,
+        reason: str,
+    ) -> ApprovalRequest:
+        """Mark the row rejected. Anyone (including the requester) can
+        reject — useful for the requester to cancel their own request."""
+        if not isinstance(rejected_by, str) or not rejected_by.strip():
+            rejected_by = "unknown"
+        if not isinstance(reason, str):
+            reason = ""
+        reason = reason.strip()
+        req = self.get(approval_id)
+        if req.status != "pending":
+            raise InvalidStateError(
+                f"cannot reject: status={req.status!r} (need 'pending')"
+            )
+        now = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+        with self.db.get_cursor() as cur:
+            cur.execute(
+                """
+                UPDATE pending_approvals
+                SET status='rejected', rejected_by=?, rejected_at=?,
+                    rejection_reason=?
+                WHERE id=? AND status='pending'
+                """,
+                (rejected_by, now, reason, approval_id),
+            )
+            if cur.rowcount == 0:
+                raise InvalidStateError(
+                    "approval row changed mid-flight (lost race)"
+                )
+        self._audit(
+            "approval_rejected",
+            rejected_by,
+            {
+                "approval_id": approval_id,
+                "operation_type": req.operation_type,
+                "requested_by": req.requested_by,
+                "reason": reason,
+            },
+        )
+        logger.info(
+            "approval rejected id=%s by=%s reason=%r",
+            approval_id, rejected_by, reason,
+        )
+        return self.get(approval_id)
+
+    def execute(
+        self,
+        approval_id: int,
+        executor: Callable[[dict], dict],
+    ) -> dict:
+        """Run ``executor(payload)`` on an approved row. Records the
+        result, transitions to ``executed``. Re-raises whatever the
+        executor raises *after* recording the failure in audit log.
+        """
+        req = self.get(approval_id)
+        if req.status != "approved":
+            raise InvalidStateError(
+                f"cannot execute: status={req.status!r} (need 'approved')"
+            )
+
+        # We don't gate execute on expiry because operators may
+        # legitimately approve an op late in the window and execute past
+        # it — the approve step has already happened, expiry was for the
+        # approval gate, not the execution gate.
+
+        try:
+            result = executor(dict(req.payload))
+        except Exception as e:
+            logger.exception(
+                "approval execute failed id=%s op=%s err=%s",
+                approval_id, req.operation_type, e,
+            )
+            self._audit(
+                "approval_execute_failed",
+                req.approved_by or "unknown",
+                {
+                    "approval_id": approval_id,
+                    "operation_type": req.operation_type,
+                    "error": str(e),
+                },
+            )
+            raise
+        if not isinstance(result, dict):
+            result = {"result": result}
+        now = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+        with self.db.get_cursor() as cur:
+            cur.execute(
+                """
+                UPDATE pending_approvals
+                SET status='executed', executed_at=?, executed_result_json=?
+                WHERE id=? AND status='approved'
+                """,
+                (now, json.dumps(result, default=str, sort_keys=True),
+                 approval_id),
+            )
+            if cur.rowcount == 0:
+                raise InvalidStateError(
+                    "approval row changed mid-flight (lost race)"
+                )
+        self._audit(
+            "approval_executed",
+            req.approved_by or "unknown",
+            {
+                "approval_id": approval_id,
+                "operation_type": req.operation_type,
+                "requested_by": req.requested_by,
+            },
+        )
+        logger.info(
+            "approval executed id=%s op=%s",
+            approval_id, req.operation_type,
+        )
+        return result
+
+    def list_pending(self) -> list[ApprovalRequest]:
+        """All rows still in ``pending`` (not yet expired by clock time
+        — the scheduler flips those to ``expired`` separately)."""
+        with self.db.get_cursor() as cur:
+            cur.execute(
+                "SELECT * FROM pending_approvals "
+                "WHERE status='pending' ORDER BY requested_at DESC, id DESC"
+            )
+            rows = cur.fetchall()
+        return [_row_to_request(dict(r)) for r in rows]
+
+    def list_history(self, limit: int = 50) -> list[ApprovalRequest]:
+        """All approvals (any status), most recent first."""
+        try:
+            limit = max(1, min(int(limit), 1000))
+        except (TypeError, ValueError):
+            limit = 50
+        with self.db.get_cursor() as cur:
+            cur.execute(
+                "SELECT * FROM pending_approvals "
+                "ORDER BY requested_at DESC, id DESC LIMIT ?",
+                (limit,),
+            )
+            rows = cur.fetchall()
+        return [_row_to_request(dict(r)) for r in rows]
+
+    def expire_stale(self) -> int:
+        """Flip any pending rows whose ``expires_at`` is in the past to
+        ``expired``. Returns the number of rows flipped. Intended to be
+        called from an APScheduler hourly job."""
+        now = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+        with self.db.get_cursor() as cur:
+            cur.execute(
+                "SELECT id, operation_type, requested_by FROM pending_approvals "
+                "WHERE status='pending' AND expires_at < ?",
+                (now,),
+            )
+            stale = cur.fetchall()
+            if not stale:
+                return 0
+            cur.execute(
+                "UPDATE pending_approvals SET status='expired' "
+                "WHERE status='pending' AND expires_at < ?",
+                (now,),
+            )
+            n = cur.rowcount
+        for row in stale:
+            self._audit(
+                "approval_expired",
+                "system",
+                {
+                    "approval_id": row["id"],
+                    "operation_type": row["operation_type"],
+                    "requested_by": row["requested_by"],
+                },
+            )
+        if n:
+            logger.info("expired %s stale approval rows", n)
+        return n
+
+    # ── Internals ─────────────────────────────────────────
+
+    @staticmethod
+    def _is_expired(expires_at: str) -> bool:
+        if not expires_at:
+            return False
+        try:
+            ts = datetime.strptime(expires_at, "%Y-%m-%d %H:%M:%S")
+        except ValueError:
+            try:
+                ts = datetime.fromisoformat(expires_at)
+            except ValueError:
+                return False
+        return ts < datetime.now()
+
+    def _mark_expired(self, approval_id: int) -> None:
+        try:
+            with self.db.get_cursor() as cur:
+                cur.execute(
+                    "UPDATE pending_approvals SET status='expired' "
+                    "WHERE id=? AND status='pending'",
+                    (approval_id,),
+                )
+        except Exception as e:  # pragma: no cover - defensive
+            logger.warning("mark_expired failed for %s: %s", approval_id, e)
+        self._audit(
+            "approval_expired",
+            "system",
+            {"approval_id": approval_id},
+        )

--- a/src/security/identity.py
+++ b/src/security/identity.py
@@ -1,0 +1,156 @@
+"""Caller identity resolution for the approval framework (issue #112).
+
+Approvals need to know *who* is requesting / approving / executing each
+high-impact operation so we can refuse self-approval (B != A) and write
+the calling user into the audit trail. Authentication is intentionally
+out of scope for this PR — the dashboard ships without an in-app login,
+relying on either:
+
+* a Windows host where ``os.getlogin()`` reflects the operator,
+* a reverse-proxy injecting an authenticated header
+  (e.g. ``X-Forwarded-User`` from Authentik / nginx auth_request /
+  IIS Windows Auth), or
+* a transitional "client_supplied" mode where the body carries
+  ``username`` (UNSAFE — the user is whatever the request claims).
+
+The mode is selected by ``approvals.identity_source`` in config.yaml.
+``client_supplied`` is documented as unsafe and emits a startup warning
+so operators are nudged to harden the deployment before production use.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any, Optional
+
+logger = logging.getLogger("file_activity.security.identity")
+
+
+_UNKNOWN = "unknown"
+
+
+def _config_section(config: Any) -> dict:
+    """Return ``approvals`` sub-dict regardless of whether the caller
+    passed the full app config or the section directly. Empty dict on
+    anything malformed."""
+    if not isinstance(config, dict):
+        return {}
+    if "approvals" in config and isinstance(config["approvals"], dict):
+        return config["approvals"]
+    return config
+
+
+def _from_windows() -> Optional[str]:
+    try:
+        # ``os.getlogin`` is the canonical answer on Windows; on POSIX
+        # it can raise OSError when stdin isn't a TTY (e.g. systemd).
+        u = os.getlogin()
+        if u:
+            return u
+    except OSError:
+        pass
+    except Exception as e:  # pragma: no cover - defensive
+        logger.debug("os.getlogin failed: %s", e)
+    # Fall back to environment variables.
+    for env in ("USERNAME", "USER", "LOGNAME"):
+        v = os.environ.get(env)
+        if v:
+            return v
+    return None
+
+
+def _from_header(request: Any, header_name: str) -> Optional[str]:
+    if request is None or not header_name:
+        return None
+    headers = getattr(request, "headers", None)
+    if headers is None:
+        return None
+    try:
+        v = headers.get(header_name)
+    except Exception:
+        return None
+    if not v:
+        # Try lowercase / case variants — Starlette is case-insensitive
+        # but a plain dict (used by tests) might not be.
+        try:
+            v = headers.get(header_name.lower())
+        except Exception:
+            v = None
+    return v.strip() if isinstance(v, str) and v.strip() else None
+
+
+def _from_body(body: Any) -> Optional[str]:
+    if not isinstance(body, dict):
+        return None
+    for key in ("username", "user", "requested_by", "approved_by",
+                "rejected_by"):
+        v = body.get(key)
+        if isinstance(v, str) and v.strip():
+            return v.strip()
+    return None
+
+
+def resolve_user(
+    request: Any = None,
+    config: Any = None,
+    body: Any = None,
+) -> str:
+    """Resolve the calling user's identity.
+
+    Strategies (selected by ``approvals.identity_source``):
+
+    * ``windows``: ``os.getlogin()``, then ``USERNAME``/``USER`` env.
+    * ``header``: read configured header (default ``X-Forwarded-User``).
+    * ``client_supplied``: read ``body['username']``. UNSAFE.
+
+    Returns ``"unknown"`` if the chosen strategy fails. The caller is
+    expected to treat ``"unknown"`` as a refusal-to-self-approve guard
+    rather than a security feature.
+    """
+    cfg = _config_section(config)
+    source = (cfg.get("identity_source") or "client_supplied").strip().lower()
+    header_name = cfg.get("identity_header") or "X-Forwarded-User"
+
+    if source == "windows":
+        u = _from_windows()
+        if u:
+            return u
+        # Soft fall-through: header → body → unknown so a misconfigured
+        # Linux test bench can still surface *some* user instead of
+        # silently bricking every approval.
+        u = _from_header(request, header_name) or _from_body(body)
+        return u or _UNKNOWN
+
+    if source == "header":
+        u = _from_header(request, header_name)
+        if u:
+            return u
+        # On miss we *do not* fall back to body — that would defeat the
+        # point of trusting only the proxy. Log + return unknown.
+        logger.debug(
+            "identity header %r missing; returning 'unknown'", header_name
+        )
+        return _UNKNOWN
+
+    # Default: client_supplied. Body wins, then header, then env.
+    u = _from_body(body) or _from_header(request, header_name) or _from_windows()
+    return u or _UNKNOWN
+
+
+def warn_if_unsafe(config: Any) -> None:
+    """Emit a startup warning when ``identity_source`` is unsafe.
+
+    Called once at app boot (see :func:`create_app`). Idempotent.
+    """
+    cfg = _config_section(config)
+    if not bool(cfg.get("enabled", False)):
+        return
+    source = (cfg.get("identity_source") or "client_supplied").strip().lower()
+    if source == "client_supplied":
+        logger.warning(
+            "approvals.identity_source='client_supplied' is UNSAFE for "
+            "production: any caller can claim any username. Switch to "
+            "'header' (with an auth proxy) or 'windows' (on Windows hosts) "
+            "before relying on the two-person rule."
+        )

--- a/src/storage/database.py
+++ b/src/storage/database.py
@@ -774,6 +774,42 @@ class Database:
             "ON quarantine_log(original_path)"
         )
 
+        # Two-person approval framework (issue #112). Generic queue for
+        # high-impact admin operations (snapshot restore, archive_bulk,
+        # purge_bulk, retention_apply). Phase 1 wires snapshot_restore as
+        # the pilot; other ops follow in subsequent PRs. payload_json
+        # holds the operation-specific arguments. Self-approval is
+        # refused server-side via approve(): the row records both the
+        # requested_by and approved_by users so the executor can verify
+        # they differ.
+        cur.execute("""
+            CREATE TABLE IF NOT EXISTS pending_approvals (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                operation_type TEXT NOT NULL,
+                payload_json TEXT NOT NULL,
+                requested_by TEXT NOT NULL,
+                requested_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                approved_by TEXT,
+                approved_at TIMESTAMP,
+                rejected_by TEXT,
+                rejected_at TIMESTAMP,
+                rejection_reason TEXT,
+                expires_at TIMESTAMP NOT NULL,
+                status TEXT NOT NULL DEFAULT 'pending'
+                    CHECK (status IN ('pending','approved','rejected','expired','executed')),
+                executed_at TIMESTAMP,
+                executed_result_json TEXT
+            )
+        """)
+        cur.execute(
+            "CREATE INDEX IF NOT EXISTS idx_pa_status "
+            "ON pending_approvals(status, expires_at)"
+        )
+        cur.execute(
+            "CREATE INDEX IF NOT EXISTS idx_pa_type "
+            "ON pending_approvals(operation_type)"
+        )
+
         # FTS5 full-text search (arsivlenmis dosyalar icin)
         cur.execute("""
             CREATE VIRTUAL TABLE IF NOT EXISTS archived_files_fts USING fts5(

--- a/tests/test_approvals.py
+++ b/tests/test_approvals.py
@@ -1,0 +1,318 @@
+"""Tests for issue #112: two-person approval framework (Phase 1).
+
+Coverage:
+  * is_required short-circuits when approvals.enabled=false.
+  * is_required gates only ops in require_for.
+  * request creates a pending row + audit event.
+  * approve refuses self-approval (B == A).
+  * approve succeeds for a different user.
+  * execute only after approve (refuses pending/rejected).
+  * reject blocks execute.
+  * expire_stale flips old pending rows to 'expired'.
+  * Snapshot restore endpoint routes through approval when enabled.
+  * Snapshot restore endpoint executes immediately when disabled
+    (default — backwards compat).
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from datetime import datetime, timedelta
+
+import pytest
+
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if REPO_ROOT not in sys.path:
+    sys.path.insert(0, REPO_ROOT)
+
+from src.storage.database import Database  # noqa: E402
+from src.security.approvals import (  # noqa: E402
+    ApprovalRegistry,
+    SelfApprovalError,
+    InvalidStateError,
+    ApprovalNotFound,
+)
+
+
+# ── Fixtures ───────────────────────────────────────────────
+
+
+def _make_db(tmp_path) -> Database:
+    db = Database({"path": str(tmp_path / "approvals.db")})
+    db.connect()
+    return db
+
+
+def _make_registry(tmp_path, **overrides) -> tuple[Database, ApprovalRegistry]:
+    db = _make_db(tmp_path)
+    cfg = {
+        "approvals": {
+            "enabled": True,
+            "require_for": ["snapshot_restore"],
+            "expiry_hours": 24,
+            "identity_source": "client_supplied",
+        }
+    }
+    cfg["approvals"].update(overrides)
+    return db, ApprovalRegistry(db, cfg)
+
+
+# ── is_required ────────────────────────────────────────────
+
+
+def test_approval_disabled_returns_false_for_is_required(tmp_path):
+    db = _make_db(tmp_path)
+    reg = ApprovalRegistry(db, {"approvals": {"enabled": False,
+                                              "require_for": ["snapshot_restore"]}})
+    assert reg.is_required("snapshot_restore") is False
+    assert reg.is_required("anything_else") is False
+
+
+def test_is_required_only_for_listed_ops(tmp_path):
+    db, reg = _make_registry(tmp_path)
+    assert reg.is_required("snapshot_restore") is True
+    assert reg.is_required("archive_bulk") is False
+
+
+# ── request ────────────────────────────────────────────────
+
+
+def test_request_creates_pending_row(tmp_path):
+    db, reg = _make_registry(tmp_path)
+    req = reg.request("snapshot_restore", {"snapshot_id": "snap-001"}, "alice")
+    assert req.id > 0
+    assert req.status == "pending"
+    assert req.operation_type == "snapshot_restore"
+    assert req.requested_by == "alice"
+    assert req.payload == {"snapshot_id": "snap-001"}
+    assert req.expires_at  # populated
+
+    with db.get_cursor() as cur:
+        cur.execute("SELECT COUNT(*) AS c FROM pending_approvals")
+        assert cur.fetchone()["c"] == 1
+        cur.execute(
+            "SELECT COUNT(*) AS c FROM file_audit_events "
+            "WHERE event_type='approval_requested'"
+        )
+        assert cur.fetchone()["c"] == 1
+
+
+# ── approve ────────────────────────────────────────────────
+
+
+def test_approve_refuses_self_approval(tmp_path):
+    db, reg = _make_registry(tmp_path)
+    req = reg.request("snapshot_restore", {"snapshot_id": "s"}, "alice")
+    with pytest.raises(SelfApprovalError):
+        reg.approve(req.id, "alice")
+    # Row must still be pending after refusal.
+    with db.get_cursor() as cur:
+        cur.execute(
+            "SELECT status FROM pending_approvals WHERE id=?", (req.id,)
+        )
+        assert cur.fetchone()["status"] == "pending"
+
+
+def test_approve_succeeds_for_different_user(tmp_path):
+    db, reg = _make_registry(tmp_path)
+    req = reg.request("snapshot_restore", {"snapshot_id": "s"}, "alice")
+    out = reg.approve(req.id, "bob")
+    assert out.status == "approved"
+    assert out.approved_by == "bob"
+    assert out.approved_at
+    # Audit event recorded.
+    with db.get_cursor() as cur:
+        cur.execute(
+            "SELECT COUNT(*) AS c FROM file_audit_events "
+            "WHERE event_type='approval_approved'"
+        )
+        assert cur.fetchone()["c"] == 1
+
+
+def test_approve_unknown_id_raises(tmp_path):
+    db, reg = _make_registry(tmp_path)
+    with pytest.raises(ApprovalNotFound):
+        reg.approve(9999, "bob")
+
+
+# ── execute ────────────────────────────────────────────────
+
+
+def test_execute_only_after_approve(tmp_path):
+    db, reg = _make_registry(tmp_path)
+    req = reg.request("snapshot_restore", {"snapshot_id": "s1"}, "alice")
+    # Execute before approve refuses.
+    with pytest.raises(InvalidStateError):
+        reg.execute(req.id, lambda payload: {"ran": True})
+    # Approve, then execute succeeds.
+    reg.approve(req.id, "bob")
+    captured = {}
+
+    def _executor(payload):
+        captured.update(payload)
+        return {"ok": True, "snapshot_id": payload["snapshot_id"]}
+
+    result = reg.execute(req.id, _executor)
+    assert result == {"ok": True, "snapshot_id": "s1"}
+    assert captured == {"snapshot_id": "s1"}
+    # Re-execute on already-executed row refuses.
+    with pytest.raises(InvalidStateError):
+        reg.execute(req.id, _executor)
+
+
+def test_reject_blocks_execute(tmp_path):
+    db, reg = _make_registry(tmp_path)
+    req = reg.request("snapshot_restore", {"snapshot_id": "s"}, "alice")
+    out = reg.reject(req.id, "bob", "looks wrong")
+    assert out.status == "rejected"
+    assert out.rejected_by == "bob"
+    assert out.rejection_reason == "looks wrong"
+    with pytest.raises(InvalidStateError):
+        reg.execute(req.id, lambda p: {"ok": True})
+
+
+# ── expire_stale ───────────────────────────────────────────
+
+
+def test_expire_stale_marks_old_pending_as_expired(tmp_path):
+    db, reg = _make_registry(tmp_path)
+    req = reg.request("snapshot_restore", {"snapshot_id": "s"}, "alice")
+    # Manually backdate expires_at into the past.
+    past = (datetime.now() - timedelta(hours=1)).strftime("%Y-%m-%d %H:%M:%S")
+    with db.get_cursor() as cur:
+        cur.execute(
+            "UPDATE pending_approvals SET expires_at=? WHERE id=?",
+            (past, req.id),
+        )
+    # Plus one fresh row that should NOT expire.
+    fresh = reg.request("snapshot_restore", {"snapshot_id": "s2"}, "alice")
+    n = reg.expire_stale()
+    assert n == 1
+    with db.get_cursor() as cur:
+        cur.execute(
+            "SELECT status FROM pending_approvals WHERE id=?", (req.id,)
+        )
+        assert cur.fetchone()["status"] == "expired"
+        cur.execute(
+            "SELECT status FROM pending_approvals WHERE id=?", (fresh.id,)
+        )
+        assert cur.fetchone()["status"] == "pending"
+
+
+# ── Endpoint integration ───────────────────────────────────
+
+
+def _make_app(tmp_path, *, enabled=False, require_for=None):
+    """Build a real FastAPI app pointed at a tmp DB so we can hit the
+    snapshot-restore endpoint with TestClient. Stubs the BackupManager
+    so we don't need a real snapshot file."""
+    import importlib
+
+    db = _make_db(tmp_path)
+    cfg = {
+        "database": {"path": db.db_path},
+        "backup": {"enabled": False},  # we stub the manager below
+        "approvals": {
+            "enabled": enabled,
+            "require_for": list(require_for or []),
+            "expiry_hours": 24,
+            "identity_source": "client_supplied",
+        },
+        "analytics": {"enabled": False},
+        "active_directory": {"enabled": False},
+        "smtp": {"enabled": False},
+        "audit": {"chain_enabled": False},
+    }
+
+    api = importlib.import_module("src.dashboard.api")
+    app = api.create_app(db, cfg)
+
+    # Replace the backup manager with a stub that captures restore() calls.
+    class _StubManager:
+        enabled = True
+        backup_dir = "/tmp"
+        keep_last_n = 1
+        keep_weekly = 1
+        restored_ids = []
+
+        def list_snapshots(self):
+            return []
+
+        def restore(self, snapshot_id):
+            self.restored_ids.append(snapshot_id)
+
+    stub = _StubManager()
+    app.state.backup_manager = stub
+    return app, stub
+
+
+def test_snapshot_restore_executes_immediately_when_disabled(tmp_path):
+    """Default config (approvals.enabled=false) must preserve legacy
+    behaviour: the endpoint runs the restore right away."""
+    from fastapi.testclient import TestClient
+
+    app, stub = _make_app(tmp_path, enabled=False)
+    client = TestClient(app, raise_server_exceptions=False)
+    r = client.post(
+        "/api/system/backups/restore/snap-xyz",
+        json={"confirm": True},
+    )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body == {"ok": True, "restored": "snap-xyz"}
+    assert stub.restored_ids == ["snap-xyz"]
+
+
+def test_snapshot_restore_routes_through_approval_when_enabled(tmp_path):
+    """When approvals.enabled=true and snapshot_restore is required,
+    the endpoint must queue a pending row and NOT call restore()."""
+    from fastapi.testclient import TestClient
+
+    app, stub = _make_app(
+        tmp_path, enabled=True, require_for=["snapshot_restore"]
+    )
+    client = TestClient(app, raise_server_exceptions=False)
+
+    # Step 1: alice requests the restore — gets a pending id back.
+    r = client.post(
+        "/api/system/backups/restore/snap-abc",
+        json={"confirm": True, "username": "alice"},
+    )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["status"] == "pending"
+    assert body["requested_by"] == "alice"
+    assert "pending_approval_id" in body
+    pid = body["pending_approval_id"]
+    # Restore must NOT have run yet.
+    assert stub.restored_ids == []
+
+    # Step 2: alice tries to self-approve — refused.
+    r2 = client.post(
+        f"/api/approvals/{pid}/approve",
+        json={"approved_by": "alice"},
+    )
+    assert r2.status_code == 403, r2.text
+
+    # Step 3: bob approves — succeeds.
+    r3 = client.post(
+        f"/api/approvals/{pid}/approve",
+        json={"approved_by": "bob"},
+    )
+    assert r3.status_code == 200, r3.text
+    assert r3.json()["approval"]["status"] == "approved"
+
+    # Step 4: execute runs the restore.
+    r4 = client.post(f"/api/approvals/{pid}/execute", json={})
+    assert r4.status_code == 200, r4.text
+    out = r4.json()
+    assert out["ok"] is True
+    assert out["result"]["restored"] == "snap-abc"
+    assert stub.restored_ids == ["snap-abc"]
+
+    # History reflects the executed row.
+    r5 = client.get("/api/approvals/history?limit=10")
+    assert r5.status_code == 200
+    rows = r5.json()["rows"]
+    assert any(row["id"] == pid and row["status"] == "executed" for row in rows)


### PR DESCRIPTION
## Summary
Phase 1 of #112 — generic two-person approval framework. Snapshot restore (from PR #106 / #77 Phase 2) wired as the pilot operation. `archive_bulk`, `purge_bulk`, `retention_apply` follow in subsequent PRs.

- **`src/security/approvals.py`** (NEW) — `ApprovalRegistry` with `request/approve/reject/execute/list_pending/list_history/expire_stale`. **Self-approval refused server-side** via `SelfApprovalError`. Every transition writes a chained audit event.
- **`src/security/identity.py`** (NEW) — `resolve_user(request, config)` strategies: `windows` (server-side `os.getlogin`), `header` (e.g. `X-Forwarded-User` from auth proxy), `client_supplied` (unsafe; startup warning).
- **Schema** — `pending_approvals` table + 2 indexes (idempotent).
- **`src/dashboard/api.py`** — refactored snapshot-restore into shared `_do_snapshot_restore`, gated through registry; 6 new endpoints (`/api/approvals/{config|pending|history|{id}/{approve,reject,execute}}`).
- **`src/scheduler/task_scheduler.py`** — hourly `expire_stale_approvals` job.
- **`src/dashboard/static/index.html`** — new `#page-approvals` under Sistem with pending+history tabs, countdown timer, approve/reject/execute buttons (self-approve disabled client-side too as defense-in-depth).
- **`config.yaml`** — `approvals:` block with `enabled: false` default.

## Backwards-compat (critical)
With default `approvals.enabled=false`, `is_required()` short-circuits to `False` and `restore_snapshot` calls `_do_snapshot_restore` directly. Verified by `test_snapshot_restore_executes_immediately_when_disabled`. Existing `tests/test_backup_endpoints.py` (6 tests) still passes unchanged.

## Test plan
- [x] 11 new tests pass (`tests/test_approvals.py`)
- [x] Full suite: 246 passed, 6 skipped (mcp/bench excluded). No regressions.
- [x] Manual integration: Alice request → Alice self-approve refused (403) → Bob approves → execute runs the actual restore

## Rebase resolution
Three conflicts auto-resolved against master (which had #109 + #111):
- `database.py` — kept both `gain_reports`/`quarantine_log` (#83) AND `pending_approvals` (#112)
- `index.html` sidebar — kept both `operations` (#83) AND `approvals` (#112) nav items
- `index.html` `loaders` map — merged both keys

## Follow-ups
- Wire `archive_bulk`, `purge_bulk`, `retention_apply` through registry
- Add `executor_token` signing
- Audit chain integration for execute step

https://claude.ai/code/session_998c8ada-6f18-462b-b6eb-d6e8745d3543

---
_Generated by [Claude Code](https://claude.ai/code/session_01A1UzS1A4DZNk1akoP4uhZ7)_