### PR TITLE
Duplicate Phase 2: hard-delete + restore + quarantine UI (closes #110)

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -164,6 +164,7 @@ duplicates:
     bulk_delete_max_files: 500  # safety cap per request
     require_safety_token: true  # MUST remain true in prod (defence in depth)
     quarantine_days: 30         # Phase 2 auto-purge horizon
+    purge_hour: 3               # daily_quarantine_purge cron hour (0-23, default 03:00)
 
 archiving:
   verify_checksum: true       # SHA-256 doğrulama

--- a/src/archiver/duplicate_cleaner.py
+++ b/src/archiver/duplicate_cleaner.py
@@ -46,7 +46,7 @@ import logging
 import os
 import shutil
 from dataclasses import dataclass, field, asdict
-from datetime import datetime
+from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Optional
 
@@ -54,6 +54,7 @@ logger = logging.getLogger("file_activity.archiver.duplicate_cleaner")
 
 
 SAFETY_TOKEN_VALUE = "QUARANTINE"
+PURGE_SAFETY_TOKEN_VALUE = "PURGE"
 
 
 # ──────────────────────────────────────────────
@@ -95,6 +96,65 @@ class QuarantineResult:
     delta: dict = field(default_factory=dict)
     gain_report_id: Optional[int] = None
     confirm: bool = True
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+
+# ──────────────────────────────────────────────
+# Phase 2 (issue #110) — hard delete + restore
+# ──────────────────────────────────────────────
+
+
+@dataclass
+class PurgeResult:
+    """Per-file outcome for hard-delete (``purge_one``).
+
+    ``status`` is one of:
+      * ``"purged"``        — file removed AND ``quarantine_log.purged_at`` set
+      * ``"skipped_missing"`` — file already gone from disk; row stamped
+      * ``"skipped_already_purged"`` — row already has ``purged_at``
+      * ``"skipped_restored"`` — row was restored, must not be purged
+      * ``"skipped_not_found"`` — no quarantine_log row with that id
+      * ``"abort_sha_mismatch"`` — SHA-256 differs from sidecar; FORENSIC,
+        NO DELETE — operator review required
+      * ``"error"``         — anything else (filesystem, db); details in
+        ``reason``
+    """
+
+    quarantine_log_id: Optional[int] = None
+    status: str = "error"
+    reason: Optional[str] = None
+    quarantine_path: Optional[str] = None
+    original_path: Optional[str] = None
+    sha256_expected: Optional[str] = None
+    sha256_actual: Optional[str] = None
+    audit_event_id: Optional[int] = None
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+
+@dataclass
+class RestoreResult:
+    """Per-file outcome for restore from quarantine.
+
+    ``status`` is one of:
+      * ``"restored"``           — file moved back to ``original_path``
+      * ``"skipped_collision"``  — original_path already has a file
+      * ``"skipped_already_restored"`` — row.restored_at already set
+      * ``"skipped_already_purged"``   — row.purged_at already set
+      * ``"skipped_not_found"``  — no quarantine_log row with that id
+      * ``"skipped_missing"``    — quarantine_path already gone
+      * ``"error"``              — anything else; details in ``reason``
+    """
+
+    quarantine_log_id: Optional[int] = None
+    status: str = "error"
+    reason: Optional[str] = None
+    quarantine_path: Optional[str] = None
+    original_path: Optional[str] = None
+    audit_event_id: Optional[int] = None
 
     def to_dict(self) -> dict:
         return asdict(self)
@@ -149,6 +209,20 @@ class DuplicateCleaner:
         self.quarantine_root = Path(cfg.get("dir") or "data/quarantine")
         self.bulk_max = int(cfg.get("bulk_delete_max_files") or 500)
         self.require_token = bool(cfg.get("require_safety_token", True))
+        # Phase 2 retention horizon — files older than this are eligible
+        # for hard delete by the daily purge job. Operators can extend
+        # in config.yaml; we never go below 1 (sanity floor) or accept
+        # nonsense (negatives, strings).
+        try:
+            self.quarantine_days = max(1, int(cfg.get("quarantine_days") or 30))
+        except (TypeError, ValueError):
+            self.quarantine_days = 30
+        try:
+            self.purge_hour = int(cfg.get("purge_hour", 3))
+        except (TypeError, ValueError):
+            self.purge_hour = 3
+        if self.purge_hour < 0 or self.purge_hour > 23:
+            self.purge_hour = 3
         # Idempotent — no error when the dir already exists.
         try:
             self.quarantine_root.mkdir(parents=True, exist_ok=True)
@@ -677,6 +751,397 @@ class DuplicateCleaner:
             logger.warning("audit_simple fallback failed (%s): %s",
                            event_type, e)
         return None
+
+    # ──────────────────────────────────────────────
+    # Phase 2 (issue #110) — hard delete + restore
+    # ──────────────────────────────────────────────
+
+    def purge_one(self, quarantine_log_id: int,
+                  purged_by: str = "system") -> PurgeResult:
+        """Hard-delete a single quarantined file.
+
+        SAFETY-CRITICAL contract:
+          1. Read the ``quarantine_log`` row. If missing → ``skipped_not_found``.
+          2. If row already has ``purged_at`` → ``skipped_already_purged``.
+          3. If row has ``restored_at`` → ``skipped_restored`` (don't purge
+             a file the operator pulled back).
+          4. If quarantine_path missing → stamp ``purged_at`` and return
+             ``skipped_missing`` (so the row reflects reality, doesn't get
+             retried daily forever).
+          5. **VERIFY SHA-256** of the on-disk file against the sidecar.
+             Any mismatch → ``abort_sha_mismatch`` and we DO NOT call
+             ``os.remove``. The row stays untouched so the operator can
+             investigate. This is the forensic-preserve rule: corruption
+             mid-quarantine = preserve, never silent delete.
+          6. ``os.remove`` the file + sidecars. Stamp ``purged_at``.
+             Write audit event.
+
+        Per-file errors never raise — they return a ``PurgeResult`` with
+        ``status='error'`` so batch callers can keep going.
+        """
+        result = PurgeResult(quarantine_log_id=int(quarantine_log_id))
+        try:
+            row = self._fetch_quarantine_row(int(quarantine_log_id))
+        except Exception as e:
+            result.status = "error"
+            result.reason = f"db read failed: {e}"
+            return result
+        if row is None:
+            result.status = "skipped_not_found"
+            result.reason = "quarantine_log id not found"
+            return result
+
+        result.quarantine_path = row.get("quarantine_path")
+        result.original_path = row.get("original_path")
+        result.sha256_expected = row.get("sha256")
+
+        if row.get("purged_at"):
+            result.status = "skipped_already_purged"
+            result.reason = "row already has purged_at"
+            return result
+        if row.get("restored_at"):
+            result.status = "skipped_restored"
+            result.reason = "row was restored — refusing to purge"
+            return result
+
+        qpath = row.get("quarantine_path") or ""
+
+        # Pre-existing physical absence: stamp the row so we don't keep
+        # retrying — but log it as an audit event for forensics.
+        if not qpath or not os.path.exists(qpath):
+            self._stamp_purged(int(quarantine_log_id))
+            result.audit_event_id = self._audit(
+                event_type="duplicate_quarantine_purge_skipped_missing",
+                source_id=None,
+                username=purged_by,
+                file_path=qpath or row.get("original_path") or "",
+                details=(
+                    f"Quarantined file already missing on disk; row "
+                    f"#{quarantine_log_id} stamped purged_at without delete."
+                ),
+            )
+            result.status = "skipped_missing"
+            result.reason = "quarantine_path missing on disk"
+            return result
+
+        # Defensive SHA-256 verify against sidecar / row.
+        actual = _sha256_file(qpath)
+        result.sha256_actual = actual
+        expected = self._read_sidecar_sha(qpath) or row.get("sha256")
+        if expected and actual and expected != actual:
+            # FORENSIC: never delete a corrupted-or-tampered file. Audit
+            # loudly so the SOC can investigate.
+            result.status = "abort_sha_mismatch"
+            result.reason = (
+                f"sha256 mismatch: expected={expected} actual={actual}"
+            )
+            result.audit_event_id = self._audit(
+                event_type="duplicate_quarantine_purge_sha_mismatch",
+                source_id=None,
+                username=purged_by,
+                file_path=qpath,
+                details=(
+                    f"Refused hard delete of quarantine_log #"
+                    f"{quarantine_log_id}: sha256 mismatch "
+                    f"(expected={expected} actual={actual}). "
+                    f"File preserved for forensic review."
+                ),
+            )
+            logger.warning(
+                "purge_one aborted (sha mismatch) for log #%s path=%s",
+                quarantine_log_id, qpath,
+            )
+            return result
+
+        # If we have neither expected nor actual, that's a degraded case:
+        # we still proceed (operators may have wiped sidecars), but we
+        # record a softer audit reason.
+        if not expected:
+            logger.info(
+                "purge_one: no sidecar/row sha for log #%s — proceeding",
+                quarantine_log_id,
+            )
+
+        # Hard delete: remove the file + sidecars (best-effort).
+        try:
+            os.remove(qpath)
+        except FileNotFoundError:
+            # Race with manual rm — treat as missing.
+            self._stamp_purged(int(quarantine_log_id))
+            result.audit_event_id = self._audit(
+                event_type="duplicate_quarantine_purge_skipped_missing",
+                source_id=None,
+                username=purged_by,
+                file_path=qpath,
+                details=(
+                    f"Race: file disappeared between sha verify and "
+                    f"remove for row #{quarantine_log_id}."
+                ),
+            )
+            result.status = "skipped_missing"
+            result.reason = "file disappeared mid-purge"
+            return result
+        except Exception as e:
+            result.status = "error"
+            result.reason = f"os.remove failed: {e}"
+            logger.error("purge_one os.remove failed for %s: %s", qpath, e)
+            return result
+
+        # Best-effort sidecar cleanup (failures only logged).
+        for suffix in (".sha256", ".manifest.json"):
+            sidecar = qpath + suffix
+            try:
+                if os.path.exists(sidecar):
+                    os.remove(sidecar)
+            except Exception as e:
+                logger.warning("sidecar remove failed for %s: %s", sidecar, e)
+
+        # Stamp row + audit.
+        self._stamp_purged(int(quarantine_log_id))
+        result.audit_event_id = self._audit(
+            event_type="duplicate_quarantine_purged",
+            source_id=None,
+            username=purged_by,
+            file_path=qpath,
+            details=(
+                f"Hard-deleted quarantine_log #{quarantine_log_id} "
+                f"sha256={actual or '-'} original_path="
+                f"{row.get('original_path')}"
+            ),
+        )
+        result.status = "purged"
+        return result
+
+    def purge_expired(self, now: Optional[datetime] = None,
+                      purged_by: str = "system") -> list[PurgeResult]:
+        """Find every quarantine_log row older than ``quarantine_days``
+        and call :meth:`purge_one` on each.
+
+        Returns a list of :class:`PurgeResult`. Per-file errors never
+        abort the batch — every row gets a result entry so the scheduler
+        run-log can show a comprehensive summary.
+        """
+        if now is None:
+            now = datetime.now()
+        cutoff = now - timedelta(days=self.quarantine_days)
+        results: list[PurgeResult] = []
+        try:
+            rows = self._fetch_purge_candidates(cutoff)
+        except Exception as e:
+            logger.error("purge_expired candidate query failed: %s", e)
+            return results
+
+        for r in rows:
+            try:
+                results.append(self.purge_one(
+                    int(r["id"]), purged_by=purged_by,
+                ))
+            except Exception as e:
+                # Defence in depth — purge_one is supposed to never raise,
+                # but if a defect slips through we still record a per-row
+                # error and keep going.
+                logger.error(
+                    "purge_one raised unexpectedly for log #%s: %s",
+                    r.get("id"), e,
+                )
+                results.append(PurgeResult(
+                    quarantine_log_id=int(r["id"]),
+                    status="error",
+                    reason=f"purge_one raised: {e}",
+                    quarantine_path=r.get("quarantine_path"),
+                    original_path=r.get("original_path"),
+                ))
+        return results
+
+    def restore(self, quarantine_log_id: int,
+                restored_by: str = "system") -> RestoreResult:
+        """Move a quarantined file back to ``original_path``.
+
+        Refuses if:
+          * row not found → ``skipped_not_found``
+          * row already restored or purged
+          * ``original_path`` already exists on disk (collision)
+          * quarantine file missing on disk
+
+        On success: ``shutil.move(quarantine_path, original_path)``,
+        stamps ``restored_at``, writes audit event, and best-effort
+        cleans up the orphan sidecars.
+        """
+        result = RestoreResult(quarantine_log_id=int(quarantine_log_id))
+        try:
+            row = self._fetch_quarantine_row(int(quarantine_log_id))
+        except Exception as e:
+            result.status = "error"
+            result.reason = f"db read failed: {e}"
+            return result
+        if row is None:
+            result.status = "skipped_not_found"
+            result.reason = "quarantine_log id not found"
+            return result
+
+        result.quarantine_path = row.get("quarantine_path")
+        result.original_path = row.get("original_path")
+
+        if row.get("purged_at"):
+            result.status = "skipped_already_purged"
+            result.reason = "row already purged — file no longer exists"
+            return result
+        if row.get("restored_at"):
+            result.status = "skipped_already_restored"
+            result.reason = "row already restored"
+            return result
+
+        qpath = row.get("quarantine_path") or ""
+        opath = row.get("original_path") or ""
+
+        if not qpath or not os.path.exists(qpath):
+            result.status = "skipped_missing"
+            result.reason = "quarantine_path missing on disk"
+            return result
+        if not opath:
+            result.status = "error"
+            result.reason = "original_path is empty"
+            return result
+        if os.path.exists(opath):
+            result.status = "skipped_collision"
+            result.reason = (
+                f"original_path already exists ({opath}) — refusing to "
+                f"overwrite"
+            )
+            result.audit_event_id = self._audit(
+                event_type="duplicate_quarantine_restore_collision",
+                source_id=None,
+                username=restored_by,
+                file_path=opath,
+                details=(
+                    f"Refused restore of #{quarantine_log_id}: "
+                    f"original_path already exists."
+                ),
+            )
+            return result
+
+        # Make sure the parent of original_path exists.
+        try:
+            parent = os.path.dirname(opath)
+            if parent and not os.path.isdir(parent):
+                os.makedirs(parent, exist_ok=True)
+        except Exception as e:
+            result.status = "error"
+            result.reason = f"mkdir parent failed: {e}"
+            return result
+
+        try:
+            shutil.move(qpath, opath)
+        except Exception as e:
+            result.status = "error"
+            result.reason = f"shutil.move failed: {e}"
+            logger.error("restore move failed for %s: %s", qpath, e)
+            return result
+
+        # Best-effort sidecar cleanup (orphans now).
+        for suffix in (".sha256", ".manifest.json"):
+            sidecar = qpath + suffix
+            try:
+                if os.path.exists(sidecar):
+                    os.remove(sidecar)
+            except Exception as e:
+                logger.warning(
+                    "restore sidecar remove failed for %s: %s", sidecar, e
+                )
+
+        self._stamp_restored(int(quarantine_log_id))
+        result.audit_event_id = self._audit(
+            event_type="duplicate_quarantine_restored",
+            source_id=None,
+            username=restored_by,
+            file_path=opath,
+            details=(
+                f"Restored quarantine_log #{quarantine_log_id} from "
+                f"{qpath} to {opath}"
+            ),
+        )
+        result.status = "restored"
+        return result
+
+    # ──────────────────────────────────────────────
+    # Phase 2 internal helpers
+    # ──────────────────────────────────────────────
+
+    def _fetch_quarantine_row(self, qlog_id: int) -> Optional[dict]:
+        with self.db.get_cursor() as cur:
+            cur.execute(
+                "SELECT id, file_id, original_path, quarantine_path, "
+                "sha256, file_size, moved_at, moved_by, gain_report_id, "
+                "purged_at, restored_at "
+                "FROM quarantine_log WHERE id = ?",
+                (int(qlog_id),),
+            )
+            r = cur.fetchone()
+            return dict(r) if r else None
+
+    def _fetch_purge_candidates(self, cutoff: datetime) -> list[dict]:
+        """Rows with moved_at < cutoff and not yet purged/restored."""
+        cutoff_str = cutoff.strftime("%Y-%m-%d %H:%M:%S")
+        with self.db.get_cursor() as cur:
+            cur.execute(
+                "SELECT id, original_path, quarantine_path, moved_at "
+                "FROM quarantine_log "
+                "WHERE moved_at < ? "
+                "  AND purged_at IS NULL "
+                "  AND restored_at IS NULL "
+                "ORDER BY moved_at ASC",
+                (cutoff_str,),
+            )
+            return [dict(r) for r in cur.fetchall()]
+
+    def _stamp_purged(self, qlog_id: int) -> None:
+        try:
+            with self.db.get_cursor() as cur:
+                cur.execute(
+                    "UPDATE quarantine_log SET purged_at = "
+                    "CURRENT_TIMESTAMP WHERE id = ? AND purged_at IS NULL",
+                    (int(qlog_id),),
+                )
+        except Exception as e:
+            logger.error("purged_at stamp failed for #%s: %s", qlog_id, e)
+
+    def _stamp_restored(self, qlog_id: int) -> None:
+        try:
+            with self.db.get_cursor() as cur:
+                cur.execute(
+                    "UPDATE quarantine_log SET restored_at = "
+                    "CURRENT_TIMESTAMP WHERE id = ? AND restored_at IS NULL",
+                    (int(qlog_id),),
+                )
+        except Exception as e:
+            logger.error("restored_at stamp failed for #%s: %s", qlog_id, e)
+
+    @staticmethod
+    def _read_sidecar_sha(qpath: str) -> Optional[str]:
+        """Read the ``<qpath>.sha256`` sidecar and return the hex digest.
+
+        The sidecar format is ``<digest>  <filename>\\n`` (sha256sum-style).
+        Tolerates trailing whitespace, missing file, malformed content;
+        returns ``None`` on any failure.
+        """
+        sidecar = qpath + ".sha256"
+        try:
+            with open(sidecar, "r", encoding="utf-8") as f:
+                line = f.readline().strip()
+            if not line:
+                return None
+            token = line.split()[0]
+            # Hex digests are 64 chars for sha256.
+            if len(token) >= 32 and all(
+                c in "0123456789abcdefABCDEF" for c in token
+            ):
+                return token.lower()
+            return None
+        except FileNotFoundError:
+            return None
+        except Exception as e:
+            logger.warning("sidecar read failed for %s: %s", sidecar, e)
+            return None
 
     def _link_quarantine_to_report(self, moved_files: list[dict],
                                     report_id: int) -> None:

--- a/src/dashboard/api.py
+++ b/src/dashboard/api.py
@@ -2085,6 +2085,155 @@ def create_app(db, config, analytics=None, ad_lookup=None, email_notifier=None):
             raise HTTPException(403, str(e))
         return result.to_dict()
 
+    # --- QUARANTINE BROWSER + LIFECYCLE (issue #110 Phase 2) ---
+    # Read-only listing + manual purge + restore endpoints. The daily
+    # auto-purge job runs from task_scheduler.py — these handlers just
+    # let operators inspect / act on individual rows from the UI.
+
+    @app.get("/api/quarantine")
+    async def quarantine_list(
+        status: Optional[str] = Query(None),
+        limit: int = Query(500, ge=1, le=5000),
+    ):
+        """List quarantine_log rows with derived ``status`` and
+        ``will_purge_at`` fields. ``status`` filter is one of
+        ``quarantined`` | ``restored`` | ``purged`` | ``all``."""
+        dup_cfg = ((config or {}).get("duplicates") or {}).get(
+            "quarantine"
+        ) or {}
+        try:
+            qdays = max(1, int(dup_cfg.get("quarantine_days") or 30))
+        except (TypeError, ValueError):
+            qdays = 30
+        sql = (
+            "SELECT id, file_id, original_path, quarantine_path, sha256, "
+            "file_size, moved_at, moved_by, gain_report_id, "
+            "purged_at, restored_at "
+            "FROM quarantine_log "
+        )
+        where: list = []
+        params: list = []
+        if status == "quarantined":
+            where.append("purged_at IS NULL AND restored_at IS NULL")
+        elif status == "restored":
+            where.append("restored_at IS NOT NULL")
+        elif status == "purged":
+            where.append("purged_at IS NOT NULL")
+        if where:
+            sql += "WHERE " + " AND ".join(where) + " "
+        sql += "ORDER BY moved_at DESC LIMIT ?"
+        params.append(int(limit))
+        rows: list = []
+        with db.get_cursor() as cur:
+            cur.execute(sql, params)
+            for r in cur.fetchall():
+                d = dict(r)
+                # Derive status + will_purge_at for the UI.
+                if d.get("purged_at"):
+                    d["status"] = "purged"
+                elif d.get("restored_at"):
+                    d["status"] = "restored"
+                else:
+                    d["status"] = "quarantined"
+                moved_at = d.get("moved_at")
+                will_purge: Optional[str] = None
+                if moved_at:
+                    try:
+                        if isinstance(moved_at, str):
+                            dt = datetime.fromisoformat(
+                                moved_at.replace("Z", "")
+                            )
+                        else:
+                            dt = moved_at
+                        will_purge = (dt + timedelta(days=qdays)).strftime(
+                            "%Y-%m-%d %H:%M:%S"
+                        )
+                    except Exception:
+                        will_purge = None
+                d["will_purge_at"] = will_purge
+                rows.append(d)
+        return {
+            "enabled": bool(dup_cfg.get("enabled", True)),
+            "quarantine_days": qdays,
+            "rows": rows,
+        }
+
+    @app.post("/api/quarantine/{quarantine_log_id}/purge")
+    async def quarantine_purge(quarantine_log_id: int, request: Request):
+        """Manual hard-delete. Body: {confirm: true, safety_token: "PURGE"}.
+
+        SHA-256 mismatch = forensic preserve, never delete (returns 409).
+        """
+        from src.archiver.duplicate_cleaner import (
+            DuplicateCleaner, PURGE_SAFETY_TOKEN_VALUE,
+        )
+        body = await request.json()
+        confirm = bool(body.get("confirm", False))
+        safety_token = body.get("safety_token", "")
+        purged_by = body.get("purged_by") or "operator"
+        if not confirm:
+            raise HTTPException(400, "confirm=True required to purge")
+        # Placeholder for future #112 approval-list wiring — for now we
+        # only enforce the safety_token. The token MUST equal "PURGE".
+        if safety_token != PURGE_SAFETY_TOKEN_VALUE:
+            raise HTTPException(
+                400,
+                f"safety_token must equal {PURGE_SAFETY_TOKEN_VALUE!r}",
+            )
+        cleaner = DuplicateCleaner(db, config)
+        result = cleaner.purge_one(int(quarantine_log_id), purged_by=purged_by)
+        if result.status in ("purged", "skipped_missing"):
+            return result.to_dict()
+        if result.status == "skipped_not_found":
+            raise HTTPException(404, result.reason or "not found")
+        if result.status == "abort_sha_mismatch":
+            # 409 Conflict: file integrity mismatch, refused — operator
+            # must triage.
+            raise HTTPException(
+                409,
+                {
+                    "error": "sha_mismatch_forensic_preserve",
+                    "detail": result.to_dict(),
+                },
+            )
+        if result.status in (
+            "skipped_already_purged", "skipped_restored",
+        ):
+            raise HTTPException(409, result.reason or result.status)
+        # status == "error" — bubble as 500 with audit-friendly body.
+        raise HTTPException(
+            500,
+            {"error": result.status, "detail": result.to_dict()},
+        )
+
+    @app.post("/api/quarantine/{quarantine_log_id}/restore")
+    async def quarantine_restore(quarantine_log_id: int, request: Request):
+        """Restore from quarantine. Body: {confirm: true}."""
+        from src.archiver.duplicate_cleaner import DuplicateCleaner
+        body = await request.json()
+        confirm = bool(body.get("confirm", False))
+        restored_by = body.get("restored_by") or "operator"
+        if not confirm:
+            raise HTTPException(400, "confirm=True required to restore")
+        cleaner = DuplicateCleaner(db, config)
+        result = cleaner.restore(
+            int(quarantine_log_id), restored_by=restored_by
+        )
+        if result.status == "restored":
+            return result.to_dict()
+        if result.status == "skipped_not_found":
+            raise HTTPException(404, result.reason or "not found")
+        if result.status in (
+            "skipped_collision",
+            "skipped_already_restored",
+            "skipped_already_purged",
+            "skipped_missing",
+        ):
+            raise HTTPException(409, result.reason or result.status)
+        raise HTTPException(
+            500, {"error": result.status, "detail": result.to_dict()},
+        )
+
     # --- OPERATIONS HISTORY (gain reports) ---
     # Read-only listing of gain_reports rows (any operation). Used by the
     # "Islem Gecmisi" page to render before/after/delta panels.

--- a/src/dashboard/static/index.html
+++ b/src/dashboard/static/index.html
@@ -439,6 +439,7 @@ label { font-size: 12px; color: var(--text-muted); margin-bottom: 6px; display: 
     <div class="nav-section">
         <div class="nav-label">Sistem</div>
         <div class="nav-item" onclick="showPage('backups')"><span class="icon">💾</span> <span>Yedekler</span></div>
+        <div class="nav-item" onclick="showPage('quarantine')"><span class="icon">🧪</span> <span>Karantina</span></div>
         <div class="nav-item" onclick="showPage('operations')"><span class="icon">📜</span> <span>Islem Gecmisi</span></div>
         <div class="nav-item" onclick="showPage('approvals')"><span class="icon">✅</span> <span>Onaylar</span></div>
     </div>
@@ -1394,6 +1395,32 @@ label { font-size: 12px; color: var(--text-muted); margin-bottom: 6px; display: 
     </div>
 </div>
 
+<!-- ============ QUARANTINE BROWSER (issue #110 Phase 2) ============ -->
+<div class="page" id="page-quarantine">
+    <div class="page-header">
+        <div>
+            <h2>Karantina</h2>
+            <div class="desc">Duplicate cleaner ile karantinaya alinmis dosyalar — geri yukleme, manuel hard delete ve otomatik purge bekleyenler.</div>
+        </div>
+        <div class="actions" style="display:flex;gap:8px;align-items:center">
+            <select id="qrn-filter" onchange="loadQuarantine()" style="width:200px">
+                <option value="">Tum Kayitlar</option>
+                <option value="quarantined">Sadece Karantinada</option>
+                <option value="restored">Geri Yuklenen</option>
+                <option value="purged">Hard Delete Edilen</option>
+            </select>
+            <button class="btn btn-outline" onclick="loadQuarantine()">Yenile</button>
+        </div>
+    </div>
+    <div id="qrn-disabled-banner" style="display:none;background:var(--warning,#f59e0b);color:#000;border-radius:var(--radius);padding:12px 16px;margin-bottom:16px;font-size:12px">
+        <strong>Quarantine devre disi:</strong> <code>duplicates.quarantine.enabled=false</code>. Yeni kayit eklenemiyor — mevcut kayitlar salt-okunur listelenir.
+    </div>
+    <div style="background:var(--bg-card);border:1px solid var(--border);border-radius:var(--radius);padding:14px 18px;margin-bottom:16px;font-size:12px;color:var(--text-muted)">
+        Karantinaya alinan dosyalar <code id="qrn-days">30</code> gun sonra <strong>daily_quarantine_purge</strong> isi tarafindan kalici olarak silinir. SHA-256 dogrulamasi her hard delete oncesi yapilir; uyusmazlik = adli koruma, asla silme.
+    </div>
+    <div id="qrn-list-host" style="background:var(--bg-card);border:1px solid var(--border);border-radius:var(--radius);padding:8px"></div>
+</div>
+
 <!-- ============ OPERATIONS HISTORY (issue #83) ============ -->
 <div class="page" id="page-operations">
     <div class="page-header">
@@ -1971,7 +1998,7 @@ function showPage(name) {
     // Find and activate nav item
     document.querySelectorAll('.nav-item').forEach(n => { if (n.getAttribute('onclick')?.includes(name)) n.classList.add('active'); });
     // Auto-load data
-    const loaders = { overview: loadOverview, sources: loadSources, frequency: loadFrequency, types: loadTypes, sizes: loadSizes, users: loadUsers, anomalies: loadAnomalies, archive: loadArchive, 'archive-history': loadArchiveHistory, duplicates: loadDuplicates, growth: loadGrowth, naming: loadNaming, policies: loadPolicies, schedules: loadSchedules, treemap: loadTreemap, insights: loadInsights, sqlquery: sqlqInit, 'legal-holds': loadLegalHolds, 'orphan-sids': loadOrphanSids, ransomware: loadRansomwareAlerts, acl: loadAclAnalyzer, pii: loadPii, retention: loadRetention, syslog: loadSyslog, mcp: loadMcp, backups: loadBackups, operations: loadOperations, approvals: loadApprovalsAll, chargeback: loadChargeback };
+    const loaders = { overview: loadOverview, sources: loadSources, frequency: loadFrequency, types: loadTypes, sizes: loadSizes, users: loadUsers, anomalies: loadAnomalies, archive: loadArchive, 'archive-history': loadArchiveHistory, duplicates: loadDuplicates, growth: loadGrowth, naming: loadNaming, policies: loadPolicies, schedules: loadSchedules, treemap: loadTreemap, insights: loadInsights, sqlquery: sqlqInit, 'legal-holds': loadLegalHolds, 'orphan-sids': loadOrphanSids, ransomware: loadRansomwareAlerts, acl: loadAclAnalyzer, pii: loadPii, retention: loadRetention, syslog: loadSyslog, mcp: loadMcp, backups: loadBackups, operations: loadOperations, approvals: loadApprovalsAll, chargeback: loadChargeback, quarantine: loadQuarantine };
     // Issue #79: route through loadWithProgress so slow pages get a top
     // progress bar, ETA from p50 history, and a retry path on failure.
     if (loaders[name]) loadWithProgress(name, loaders[name]).catch(() => { /* widget surfaces error */ });
@@ -4982,6 +5009,143 @@ function _ensureModal(id, maxWidth) {
 // ═══════════════════════════════════════════════════
 // OPERATIONS HISTORY (issue #83 — gain reports)
 // ═══════════════════════════════════════════════════
+// ═══════════════════════════════════════════════════
+// QUARANTINE BROWSER (issue #110 Phase 2)
+// ═══════════════════════════════════════════════════
+async function loadQuarantine() {
+    const host = document.getElementById('qrn-list-host');
+    const banner = document.getElementById('qrn-disabled-banner');
+    const daysSpan = document.getElementById('qrn-days');
+    const filter = document.getElementById('qrn-filter')?.value || '';
+    if (!host) return;
+    if (typeof renderEntityList !== 'function') {
+        host.innerHTML = '<div style="padding:20px;color:var(--text-muted)">entity-list yuklenmedi</div>';
+        return;
+    }
+    host.innerHTML = '<div style="padding:20px;color:var(--text-muted)">Yukleniyor...</div>';
+    let data;
+    try {
+        const qs = filter ? `?status=${encodeURIComponent(filter)}` : '';
+        data = await api('/quarantine' + qs);
+    } catch (e) {
+        host.innerHTML = `<div style="padding:20px;color:var(--danger)">Yukleme hatasi: ${e.message || e}</div>`;
+        return;
+    }
+    if (banner) banner.style.display = data.enabled === false ? 'block' : 'none';
+    if (daysSpan) daysSpan.textContent = String(data.quarantine_days || 30);
+    const rows = (data.rows || []).map(r => Object.assign({}, r, {
+        _status_label: r.status === 'purged' ? 'Hard Delete Edildi'
+            : (r.status === 'restored' ? 'Geri Yuklendi' : 'Karantinada'),
+    }));
+    if (!rows.length) {
+        host.innerHTML = '<div style="padding:20px;color:var(--text-muted)">Kayit yok</div>';
+        return;
+    }
+    renderEntityList(host, {
+        rows,
+        rowKey: 'id',
+        pageSize: 50,
+        searchKeys: ['original_path', 'quarantine_path', 'moved_by'],
+        columns: [
+            {key: 'id', label: 'ID', sort: true},
+            {key: 'original_path', label: 'Orijinal Yol', sort: true},
+            {key: 'quarantine_path', label: 'Karantina Yolu', sort: true},
+            {key: 'moved_at', label: 'Tasinma', sort: true},
+            {key: 'will_purge_at', label: 'Otomatik Silinme', sort: true,
+             render: (v, row) => row.status === 'quarantined' ? (v || '-') : '<span style="color:var(--text-muted)">-</span>'},
+            {key: '_status_label', label: 'Durum', sort: true,
+             render: (v, row) => {
+                 const color = row.status === 'purged' ? 'var(--danger)'
+                     : (row.status === 'restored' ? 'var(--success)' : 'var(--accent)');
+                 return `<span style="color:${color};font-weight:600">${v}</span>`;
+             }},
+        ],
+        toolbar: {
+            bulkActions: [
+                {label: 'Geri Yukle', action: 'restore', confirm: true},
+                {label: 'Hemen Sil', action: 'purge-now', confirm: true},
+            ],
+        },
+        onBulkAction: async (actionId, selectedRows) => {
+            if (!selectedRows.length) {
+                notify('Lutfen en az bir kayit secin', 'warning');
+                return;
+            }
+            if (actionId === 'restore') {
+                await _bulkQuarantineRestore(selectedRows);
+            } else if (actionId === 'purge-now') {
+                await _bulkQuarantinePurge(selectedRows);
+            }
+        },
+        emptyMessage: 'Bu filtre icin kayit yok',
+    });
+}
+
+async function _bulkQuarantineRestore(selectedRows) {
+    const eligible = selectedRows.filter(r => r.status === 'quarantined');
+    if (!eligible.length) {
+        notify('Sadece "Karantinada" durumundaki kayitlar geri yuklenebilir', 'warning');
+        return;
+    }
+    if (!confirm(`${eligible.length} dosya orijinal konumlarina geri yuklenecek. Emin misiniz?`)) return;
+    let ok = 0, failed = 0;
+    for (const row of eligible) {
+        try {
+            await api(`/quarantine/${row.id}/restore`, {
+                method: 'POST',
+                body: JSON.stringify({confirm: true}),
+            });
+            ok += 1;
+        } catch (e) {
+            failed += 1;
+            console.warn('restore failed', row.id, e);
+        }
+    }
+    notify(`Geri yukleme: ${ok} basarili, ${failed} basarisiz`,
+           failed ? 'warning' : 'success');
+    loadQuarantine();
+}
+
+async function _bulkQuarantinePurge(selectedRows) {
+    const eligible = selectedRows.filter(r => r.status === 'quarantined');
+    if (!eligible.length) {
+        notify('Sadece "Karantinada" durumundaki kayitlar hard delete edilebilir', 'warning');
+        return;
+    }
+    const typed = prompt(
+        `${eligible.length} dosya KALICI OLARAK silinecek. ` +
+        `Onay icin "PURGE" yazin (buyuk harflerle):`
+    );
+    if (typed !== 'PURGE') {
+        notify('Onay metni "PURGE" yazilmadi — islem iptal edildi', 'info');
+        return;
+    }
+    let ok = 0, sha = 0, failed = 0;
+    for (const row of eligible) {
+        try {
+            await api(`/quarantine/${row.id}/purge`, {
+                method: 'POST',
+                body: JSON.stringify({confirm: true, safety_token: 'PURGE'}),
+            });
+            ok += 1;
+        } catch (e) {
+            // 409 with sha_mismatch — surface separately so the operator
+            // knows which files were preserved.
+            if (e && e.status === 409 && /sha_mismatch/i.test(e.message || '')) {
+                sha += 1;
+            } else {
+                failed += 1;
+            }
+            console.warn('purge failed', row.id, e);
+        }
+    }
+    let msg = `Hard delete: ${ok} basarili`;
+    if (sha) msg += `, ${sha} SHA uyusmazligi (adli koruma)`;
+    if (failed) msg += `, ${failed} basarisiz`;
+    notify(msg, (failed || sha) ? 'warning' : 'success');
+    loadQuarantine();
+}
+
 async function loadOperations() {
     const tbody = document.getElementById('ops-tbody');
     const filter = document.getElementById('ops-filter')?.value || '';

--- a/src/scheduler/task_scheduler.py
+++ b/src/scheduler/task_scheduler.py
@@ -36,6 +36,9 @@ class TaskScheduler:
         # approval queue. Always-on (cheap no-op when there are no
         # pending rows or approvals.enabled=false).
         self._register_approval_expiry_job()
+        # Issue #110 Phase 2: register the daily quarantine purge job.
+        # Hard-deletes quarantine_log rows older than quarantine_days.
+        self._register_daily_quarantine_purge_job()
         self.scheduler.start()
         logger.info("TaskScheduler başlatıldı")
 
@@ -439,6 +442,99 @@ class TaskScheduler:
         except Exception as e:
             logger.error(
                 "Failed to register expire_stale_approvals: %s", e
+            )
+
+    def _run_daily_quarantine_purge(self, task=None):
+        """Issue #110 Phase 2: hard-delete quarantine_log rows older than
+        ``duplicates.quarantine.quarantine_days``.
+
+        Per-file errors never abort the batch — they're surfaced in the
+        returned summary so operators can review the next morning.
+        Defensive SHA-256 verification happens inside ``purge_one``;
+        any mismatch returns ``abort_sha_mismatch`` and the file is
+        preserved (forensic) rather than silently deleted.
+        """
+        try:
+            from src.archiver.duplicate_cleaner import DuplicateCleaner
+        except Exception as e:
+            return {
+                "status": "error",
+                "message": f"duplicate_cleaner import failed: {e}",
+            }
+
+        dup_cfg = ((self.config or {}).get("duplicates") or {}).get(
+            "quarantine"
+        ) or {}
+        if not dup_cfg.get("enabled", True):
+            return {"status": "skipped",
+                    "message": "duplicates.quarantine.enabled=false"}
+
+        try:
+            cleaner = DuplicateCleaner(self.db, self.config)
+            results = cleaner.purge_expired(purged_by="scheduler")
+            summary = {
+                "status": "completed",
+                "candidates": len(results),
+                "purged": sum(1 for r in results if r.status == "purged"),
+                "skipped_missing": sum(
+                    1 for r in results if r.status == "skipped_missing"
+                ),
+                "abort_sha_mismatch": sum(
+                    1 for r in results
+                    if r.status == "abort_sha_mismatch"
+                ),
+                "skipped_already_purged": sum(
+                    1 for r in results
+                    if r.status == "skipped_already_purged"
+                ),
+                "skipped_restored": sum(
+                    1 for r in results if r.status == "skipped_restored"
+                ),
+                "errors": sum(1 for r in results if r.status == "error"),
+            }
+            logger.info("daily_quarantine_purge summary: %s", summary)
+            return summary
+        except Exception as e:
+            logger.error("daily_quarantine_purge failed: %s", e,
+                         exc_info=True)
+            return {"status": "error", "message": str(e)}
+
+    def _register_daily_quarantine_purge_job(self):
+        """Register the config-driven daily quarantine purge job (#110)."""
+        dup_cfg = ((self.config or {}).get("duplicates") or {}).get(
+            "quarantine"
+        ) or {}
+        if not dup_cfg.get("enabled", True):
+            logger.info(
+                "daily_quarantine_purge not registered: "
+                "duplicates.quarantine.enabled=false"
+            )
+            return
+        try:
+            hour = int(dup_cfg.get("purge_hour", 3))
+        except (TypeError, ValueError):
+            hour = 3
+        if hour < 0 or hour > 23:
+            logger.warning(
+                "purge_hour=%r out of range — defaulting to 3", hour
+            )
+            hour = 3
+        try:
+            trigger = CronTrigger(minute="0", hour=str(hour))
+            self.scheduler.add_job(
+                self._run_daily_quarantine_purge,
+                trigger=trigger,
+                id="daily_quarantine_purge",
+                name="daily_quarantine_purge:duplicates",
+                replace_existing=True,
+            )
+            logger.info(
+                "daily_quarantine_purge job registered (cron: 0 %d * * *)",
+                hour,
+            )
+        except Exception as e:
+            logger.error(
+                "Failed to register daily_quarantine_purge: %s", e
             )
 
     def reload_tasks(self):

--- a/src/storage/database.py
+++ b/src/storage/database.py
@@ -817,6 +817,27 @@ class Database:
             "ON cost_center_owners(owner_pattern)"
         )
 
+        # Phase 2 (issue #110): hard-delete + restore lifecycle columns.
+        for _alter in (
+            "ALTER TABLE quarantine_log ADD COLUMN purged_at TIMESTAMP",
+            "ALTER TABLE quarantine_log ADD COLUMN restored_at TIMESTAMP",
+        ):
+            try:
+                cur.execute(_alter)
+            except sqlite3.OperationalError as e:
+                if "duplicate column name" not in str(e).lower():
+                    logger.warning("quarantine_log ALTER failed (%s): %s",
+                                   _alter, e)
+
+        cur.execute(
+            "CREATE INDEX IF NOT EXISTS idx_quarantine_purged "
+            "ON quarantine_log(purged_at)"
+        )
+        cur.execute(
+            "CREATE INDEX IF NOT EXISTS idx_quarantine_restored "
+            "ON quarantine_log(restored_at)"
+        )
+
         # FTS5 full-text search (arsivlenmis dosyalar icin)
         cur.execute("""
             CREATE VIRTUAL TABLE IF NOT EXISTS archived_files_fts USING fts5(

--- a/tests/test_duplicate_cleaner_phase2.py
+++ b/tests/test_duplicate_cleaner_phase2.py
@@ -1,0 +1,450 @@
+"""Tests for issue #110 Phase 2: hard-delete + restore for the duplicate
+quarantine flow.
+
+SAFETY-CRITICAL coverage:
+  * purge_one with valid sidecar removes the file + stamps purged_at
+  * purge_one ABORTS on SHA-256 mismatch (forensic preserve, never delete)
+  * purge_one writes an audit event on success / abort / skip-missing
+  * purge_expired only fires for rows older than quarantine_days
+  * purge_expired tolerates a row whose file was already deleted manually
+  * restore moves the file back to original_path and stamps restored_at
+  * restore refuses on collision (original_path already exists)
+  * restore refuses if the row was already restored
+  * restore refuses if the row was already purged
+
+Stdlib only. tmp_path-rooted fixtures so every run is hermetic on Linux.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from datetime import datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if REPO_ROOT not in sys.path:
+    sys.path.insert(0, REPO_ROOT)
+
+from src.storage.database import Database  # noqa: E402
+from src.archiver.duplicate_cleaner import (  # noqa: E402
+    DuplicateCleaner,
+    PurgeResult,
+    RestoreResult,
+    SAFETY_TOKEN_VALUE,
+    PURGE_SAFETY_TOKEN_VALUE,
+)
+
+
+# ──────────────────────────────────────────────
+# Fixtures
+# ──────────────────────────────────────────────
+
+
+def _config(tmp_path: Path, **overrides) -> dict:
+    cfg = {
+        "duplicates": {
+            "quarantine": {
+                "enabled": True,
+                "dir": str(tmp_path / "quarantine"),
+                "bulk_delete_max_files": 500,
+                "require_safety_token": True,
+                "quarantine_days": 30,
+                "purge_hour": 3,
+            }
+        },
+        "compliance": {"legal_hold": {"enabled": True}},
+    }
+    if overrides:
+        cfg["duplicates"]["quarantine"].update(overrides)
+    return cfg
+
+
+def _make_db(tmp_path: Path) -> Database:
+    db = Database({"path": str(tmp_path / "phase2.db")})
+    db.connect()
+    with db.get_cursor() as cur:
+        cur.execute(
+            "INSERT INTO sources (id, name, unc_path) VALUES (1, ?, ?)",
+            ("test_src", str(tmp_path / "share")),
+        )
+        cur.execute(
+            "INSERT INTO scan_runs (id, source_id, status) "
+            "VALUES (1, 1, 'completed')"
+        )
+    return db
+
+
+def _seed_files(db: Database, tmp_path: Path, paths: list[str],
+                size: int = 64, name: str = "dup.bin") -> dict:
+    share = tmp_path / "share"
+    share.mkdir(parents=True, exist_ok=True)
+    id_map: dict = {}
+    with db.get_cursor() as cur:
+        for rel in paths:
+            fpath = share / rel
+            fpath.parent.mkdir(parents=True, exist_ok=True)
+            data = (name + ":" + rel).encode()
+            if len(data) < size:
+                data = data + b"\0" * (size - len(data))
+            else:
+                data = data[:size]
+            fpath.write_bytes(data)
+            cur.execute(
+                "INSERT INTO scanned_files "
+                "(source_id, scan_id, file_path, relative_path, "
+                "file_name, extension, file_size) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?)",
+                (1, 1, str(fpath), rel, name,
+                 os.path.splitext(name)[1].lstrip(".") or None, size),
+            )
+            id_map[str(fpath)] = cur.lastrowid
+    return id_map
+
+
+def _make_cleaner(tmp_path: Path, **overrides):
+    db = _make_db(tmp_path)
+    cfg = _config(tmp_path, **overrides)
+    return db, DuplicateCleaner(db, cfg), cfg
+
+
+def _quarantine_two(tmp_path: Path):
+    """Helper: seed 3 dupes, quarantine 2 of them (last-copy guard keeps
+    one). Returns (db, cleaner, quarantine_log_ids).
+    """
+    db, cleaner, _cfg = _make_cleaner(tmp_path)
+    ids = _seed_files(
+        db, tmp_path, ["a/dup.bin", "b/dup.bin", "c/dup.bin"],
+        size=80, name="dup.bin",
+    )
+    sorted_ids = sorted(ids.values())
+    res = cleaner.quarantine(
+        file_ids=sorted_ids[:2],
+        confirm=True,
+        safety_token=SAFETY_TOKEN_VALUE,
+        moved_by="tester",
+        source_id=1,
+    )
+    assert res.moved == 2, res
+    qlog_ids: list[int] = []
+    with db.get_cursor() as cur:
+        cur.execute(
+            "SELECT id FROM quarantine_log ORDER BY id ASC"
+        )
+        qlog_ids = [int(r["id"]) for r in cur.fetchall()]
+    return db, cleaner, qlog_ids
+
+
+# ──────────────────────────────────────────────
+# purge_one
+# ──────────────────────────────────────────────
+
+
+def test_purge_one_with_valid_sidecar_succeeds(tmp_path):
+    db, cleaner, qlog_ids = _quarantine_two(tmp_path)
+    target_id = qlog_ids[0]
+    # Sanity: file + sidecars exist before purge.
+    with db.get_cursor() as cur:
+        cur.execute("SELECT * FROM quarantine_log WHERE id = ?", (target_id,))
+        row = dict(cur.fetchone())
+    qpath = row["quarantine_path"]
+    assert os.path.exists(qpath)
+    assert os.path.exists(qpath + ".sha256")
+    assert os.path.exists(qpath + ".manifest.json")
+
+    result = cleaner.purge_one(target_id, purged_by="tester")
+    assert isinstance(result, PurgeResult)
+    assert result.status == "purged", result
+    assert not os.path.exists(qpath)
+    assert not os.path.exists(qpath + ".sha256")
+    assert not os.path.exists(qpath + ".manifest.json")
+
+    # purged_at stamped.
+    with db.get_cursor() as cur:
+        cur.execute(
+            "SELECT purged_at, restored_at FROM quarantine_log WHERE id = ?",
+            (target_id,),
+        )
+        r = dict(cur.fetchone())
+    assert r["purged_at"] is not None
+    assert r["restored_at"] is None
+
+
+def test_purge_one_aborts_on_sha_mismatch(tmp_path):
+    """SHA-256 mismatch = forensic preserve. NEVER delete the file."""
+    db, cleaner, qlog_ids = _quarantine_two(tmp_path)
+    target_id = qlog_ids[0]
+    with db.get_cursor() as cur:
+        cur.execute(
+            "SELECT quarantine_path FROM quarantine_log WHERE id = ?",
+            (target_id,),
+        )
+        qpath = dict(cur.fetchone())["quarantine_path"]
+
+    # Corrupt the on-disk file (sidecar still has the original digest).
+    with open(qpath, "ab") as f:
+        f.write(b"TAMPERED")
+
+    result = cleaner.purge_one(target_id, purged_by="tester")
+    assert result.status == "abort_sha_mismatch", result
+    # Critical assertion: the file is STILL THERE.
+    assert os.path.exists(qpath), \
+        "SHA mismatch must NOT delete — forensic preserve"
+    # purged_at must NOT be stamped.
+    with db.get_cursor() as cur:
+        cur.execute(
+            "SELECT purged_at FROM quarantine_log WHERE id = ?",
+            (target_id,),
+        )
+        assert dict(cur.fetchone())["purged_at"] is None
+    # Audit event written for the SOC.
+    with db.get_cursor() as cur:
+        cur.execute(
+            "SELECT COUNT(*) AS c FROM file_audit_events "
+            "WHERE event_type = 'duplicate_quarantine_purge_sha_mismatch'"
+        )
+        assert dict(cur.fetchone())["c"] >= 1
+
+
+def test_purge_one_writes_audit_event(tmp_path):
+    db, cleaner, qlog_ids = _quarantine_two(tmp_path)
+    result = cleaner.purge_one(qlog_ids[0], purged_by="tester")
+    assert result.status == "purged"
+    assert result.audit_event_id is not None
+    with db.get_cursor() as cur:
+        cur.execute(
+            "SELECT COUNT(*) AS c FROM file_audit_events "
+            "WHERE event_type = 'duplicate_quarantine_purged'"
+        )
+        assert dict(cur.fetchone())["c"] >= 1
+
+
+def test_purge_one_skips_already_purged(tmp_path):
+    db, cleaner, qlog_ids = _quarantine_two(tmp_path)
+    first = cleaner.purge_one(qlog_ids[0], purged_by="tester")
+    assert first.status == "purged"
+    second = cleaner.purge_one(qlog_ids[0], purged_by="tester")
+    assert second.status == "skipped_already_purged"
+
+
+def test_purge_one_skips_restored(tmp_path):
+    db, cleaner, qlog_ids = _quarantine_two(tmp_path)
+    # Restore first.
+    res = cleaner.restore(qlog_ids[0], restored_by="tester")
+    assert res.status == "restored", res
+    # Then attempt to purge — must refuse.
+    p = cleaner.purge_one(qlog_ids[0], purged_by="tester")
+    assert p.status == "skipped_restored"
+
+
+def test_purge_one_not_found(tmp_path):
+    _db, cleaner, _qlog_ids = _quarantine_two(tmp_path)
+    result = cleaner.purge_one(99999, purged_by="tester")
+    assert result.status == "skipped_not_found"
+
+
+# ──────────────────────────────────────────────
+# purge_expired
+# ──────────────────────────────────────────────
+
+
+def test_purge_expired_skips_recent(tmp_path):
+    """Recent rows (within quarantine_days) are NOT purged."""
+    db, cleaner, qlog_ids = _quarantine_two(tmp_path)
+    # The two rows just got moved_at=NOW. Calling purge_expired with the
+    # default 30-day cutoff must skip them entirely.
+    results = cleaner.purge_expired()
+    assert results == [], (
+        "fresh rows must not be purged by purge_expired"
+    )
+    # All rows still un-stamped.
+    with db.get_cursor() as cur:
+        cur.execute(
+            "SELECT COUNT(*) AS c FROM quarantine_log "
+            "WHERE purged_at IS NULL"
+        )
+        assert dict(cur.fetchone())["c"] == len(qlog_ids)
+
+
+def test_purge_expired_handles_missing_file(tmp_path):
+    """A row whose file was deleted out-of-band must not abort the batch."""
+    db, cleaner, qlog_ids = _quarantine_two(tmp_path)
+    # Force the rows to be ancient.
+    old = (datetime.now() - timedelta(days=999)).strftime(
+        "%Y-%m-%d %H:%M:%S"
+    )
+    with db.get_cursor() as cur:
+        cur.execute("UPDATE quarantine_log SET moved_at = ?", (old,))
+    # Yank the file for the FIRST row out from under the cleaner.
+    with db.get_cursor() as cur:
+        cur.execute(
+            "SELECT id, quarantine_path FROM quarantine_log "
+            "ORDER BY id ASC"
+        )
+        rows = [dict(r) for r in cur.fetchall()]
+    first_path = rows[0]["quarantine_path"]
+    os.remove(first_path)
+    # Also nuke its sidecars to simulate a complete manual cleanup.
+    for s in (".sha256", ".manifest.json"):
+        try:
+            os.remove(first_path + s)
+        except FileNotFoundError:
+            pass
+
+    results = cleaner.purge_expired(purged_by="scheduler")
+    assert len(results) == len(qlog_ids), \
+        "every candidate row must produce a result entry"
+    statuses = sorted(r.status for r in results)
+    # First file is missing; second is purged successfully.
+    assert "skipped_missing" in statuses
+    assert "purged" in statuses
+
+    # Both rows have purged_at stamped (missing-on-disk also stamps so
+    # we don't keep retrying every night).
+    with db.get_cursor() as cur:
+        cur.execute(
+            "SELECT COUNT(*) AS c FROM quarantine_log "
+            "WHERE purged_at IS NOT NULL"
+        )
+        assert dict(cur.fetchone())["c"] == len(qlog_ids)
+
+
+def test_purge_expired_uses_now_argument(tmp_path):
+    """now= override lets us walk the cutoff forward in tests."""
+    db, cleaner, qlog_ids = _quarantine_two(tmp_path)
+    # Default now() — nothing eligible.
+    assert cleaner.purge_expired() == []
+    # Walk now forward by 365 days; quarantine_days=30 → everything is old.
+    future = datetime.now() + timedelta(days=365)
+    results = cleaner.purge_expired(now=future)
+    assert len(results) == len(qlog_ids)
+    assert all(r.status == "purged" for r in results)
+
+
+# ──────────────────────────────────────────────
+# restore
+# ──────────────────────────────────────────────
+
+
+def test_restore_succeeds_for_quarantined_file(tmp_path):
+    db, cleaner, qlog_ids = _quarantine_two(tmp_path)
+    target_id = qlog_ids[0]
+    with db.get_cursor() as cur:
+        cur.execute(
+            "SELECT original_path, quarantine_path "
+            "FROM quarantine_log WHERE id = ?",
+            (target_id,),
+        )
+        r = dict(cur.fetchone())
+    opath = r["original_path"]
+    qpath = r["quarantine_path"]
+    # Sanity: original is gone, quarantine has the file.
+    assert not os.path.exists(opath)
+    assert os.path.exists(qpath)
+
+    result = cleaner.restore(target_id, restored_by="tester")
+    assert isinstance(result, RestoreResult)
+    assert result.status == "restored", result
+    assert os.path.exists(opath), "file must be back at original_path"
+    assert not os.path.exists(qpath), "quarantine_path must be empty"
+    # restored_at stamped, audit emitted.
+    with db.get_cursor() as cur:
+        cur.execute(
+            "SELECT restored_at, purged_at FROM quarantine_log WHERE id = ?",
+            (target_id,),
+        )
+        row = dict(cur.fetchone())
+    assert row["restored_at"] is not None
+    assert row["purged_at"] is None
+    with db.get_cursor() as cur:
+        cur.execute(
+            "SELECT COUNT(*) AS c FROM file_audit_events "
+            "WHERE event_type = 'duplicate_quarantine_restored'"
+        )
+        assert dict(cur.fetchone())["c"] >= 1
+
+
+def test_restore_refuses_on_collision(tmp_path):
+    db, cleaner, qlog_ids = _quarantine_two(tmp_path)
+    target_id = qlog_ids[0]
+    with db.get_cursor() as cur:
+        cur.execute(
+            "SELECT original_path, quarantine_path "
+            "FROM quarantine_log WHERE id = ?",
+            (target_id,),
+        )
+        r = dict(cur.fetchone())
+    opath = r["original_path"]
+    qpath = r["quarantine_path"]
+    # Plant a collision at original_path.
+    Path(opath).parent.mkdir(parents=True, exist_ok=True)
+    Path(opath).write_bytes(b"someone-else-put-this-here")
+
+    result = cleaner.restore(target_id, restored_by="tester")
+    assert result.status == "skipped_collision", result
+    # Quarantine file untouched.
+    assert os.path.exists(qpath)
+    # Collision file untouched.
+    assert Path(opath).read_bytes() == b"someone-else-put-this-here"
+    with db.get_cursor() as cur:
+        cur.execute(
+            "SELECT restored_at FROM quarantine_log WHERE id = ?",
+            (target_id,),
+        )
+        assert dict(cur.fetchone())["restored_at"] is None
+
+
+def test_restore_refuses_already_restored(tmp_path):
+    db, cleaner, qlog_ids = _quarantine_two(tmp_path)
+    target_id = qlog_ids[0]
+    first = cleaner.restore(target_id, restored_by="tester")
+    assert first.status == "restored"
+    second = cleaner.restore(target_id, restored_by="tester")
+    assert second.status == "skipped_already_restored", second
+
+
+def test_restore_refuses_already_purged(tmp_path):
+    db, cleaner, qlog_ids = _quarantine_two(tmp_path)
+    target_id = qlog_ids[0]
+    purged = cleaner.purge_one(target_id, purged_by="tester")
+    assert purged.status == "purged"
+    result = cleaner.restore(target_id, restored_by="tester")
+    assert result.status == "skipped_already_purged", result
+
+
+def test_restore_not_found(tmp_path):
+    _db, cleaner, _qlog_ids = _quarantine_two(tmp_path)
+    result = cleaner.restore(99999, restored_by="tester")
+    assert result.status == "skipped_not_found"
+
+
+# ──────────────────────────────────────────────
+# Round-trip: quarantine → restore → re-quarantine OK
+# ──────────────────────────────────────────────
+
+
+def test_round_trip_quarantine_restore_keeps_db_consistent(tmp_path):
+    db, cleaner, qlog_ids = _quarantine_two(tmp_path)
+    target_id = qlog_ids[0]
+    # Restore it.
+    assert cleaner.restore(target_id).status == "restored"
+    # restored_at IS NOT NULL.
+    with db.get_cursor() as cur:
+        cur.execute(
+            "SELECT purged_at, restored_at FROM quarantine_log WHERE id = ?",
+            (target_id,),
+        )
+        row = dict(cur.fetchone())
+    assert row["restored_at"] is not None
+    assert row["purged_at"] is None
+    # Subsequent purge_expired (with future now) skips this row.
+    future = datetime.now() + timedelta(days=365)
+    results = cleaner.purge_expired(now=future)
+    statuses = [r.status for r in results]
+    # Only the OTHER row should be purged; the restored one is filtered.
+    assert "purged" in statuses
+    assert all(
+        r.quarantine_log_id != target_id for r in results
+    ), "restored row must not appear in purge_expired"

--- a/tests/test_quarantine_endpoints.py
+++ b/tests/test_quarantine_endpoints.py
@@ -1,0 +1,392 @@
+"""TestClient smoke for the /api/quarantine/* endpoints (issue #110 Phase 2).
+
+Mirrors the test_backup_endpoints style — handler bodies re-implemented
+inline so the tests cover wire behaviour without booting the full
+``create_app`` factory + analytics dependency chain.
+
+Coverage:
+  * GET  /api/quarantine                     — list + status filter
+  * POST /api/quarantine/{id}/purge          — confirm + safety_token gates
+  * POST /api/quarantine/{id}/purge          — sha mismatch → 409 forensic
+  * POST /api/quarantine/{id}/purge          — happy path (200 + purged)
+  * POST /api/quarantine/{id}/restore        — confirm gate + collision (409)
+  * POST /api/quarantine/{id}/restore        — happy path
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import Optional
+
+import pytest
+from fastapi import FastAPI, HTTPException, Query, Request
+from fastapi.testclient import TestClient
+
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if REPO_ROOT not in sys.path:
+    sys.path.insert(0, REPO_ROOT)
+
+from src.storage.database import Database  # noqa: E402
+from src.archiver.duplicate_cleaner import (  # noqa: E402
+    DuplicateCleaner, SAFETY_TOKEN_VALUE, PURGE_SAFETY_TOKEN_VALUE,
+)
+
+
+# ──────────────────────────────────────────────
+# Fixture: app + seeded quarantine_log rows
+# ──────────────────────────────────────────────
+
+
+def _seed(tmp_path: Path):
+    """Build DB with two quarantined files. Returns (db, cfg, qlog_ids)."""
+    cfg = {
+        "duplicates": {
+            "quarantine": {
+                "enabled": True,
+                "dir": str(tmp_path / "quarantine"),
+                "bulk_delete_max_files": 500,
+                "require_safety_token": True,
+                "quarantine_days": 30,
+                "purge_hour": 3,
+            }
+        },
+        "compliance": {"legal_hold": {"enabled": True}},
+    }
+    db = Database({"path": str(tmp_path / "qrn-api.db")})
+    db.connect()
+    with db.get_cursor() as cur:
+        cur.execute(
+            "INSERT INTO sources (id, name, unc_path) VALUES (1, ?, ?)",
+            ("test", str(tmp_path / "share")),
+        )
+        cur.execute(
+            "INSERT INTO scan_runs (id, source_id, status) "
+            "VALUES (1, 1, 'completed')"
+        )
+    share = tmp_path / "share"
+    share.mkdir(exist_ok=True)
+    with db.get_cursor() as cur:
+        for rel in ("a/dup.bin", "b/dup.bin", "c/dup.bin"):
+            fpath = share / rel
+            fpath.parent.mkdir(parents=True, exist_ok=True)
+            fpath.write_bytes(b"X" * 96)
+            cur.execute(
+                "INSERT INTO scanned_files "
+                "(source_id, scan_id, file_path, relative_path, "
+                "file_name, file_size) "
+                "VALUES (1, 1, ?, ?, 'dup.bin', 96)",
+                (str(fpath), rel),
+            )
+    cleaner = DuplicateCleaner(db, cfg)
+    # Quarantine the first two — last-copy guard keeps the third.
+    with db.get_cursor() as cur:
+        cur.execute(
+            "SELECT id FROM scanned_files ORDER BY id ASC LIMIT 2"
+        )
+        ids = [int(r["id"]) for r in cur.fetchall()]
+    res = cleaner.quarantine(
+        file_ids=ids, confirm=True,
+        safety_token=SAFETY_TOKEN_VALUE,
+        moved_by="seed", source_id=1,
+    )
+    assert res.moved == 2
+    with db.get_cursor() as cur:
+        cur.execute("SELECT id FROM quarantine_log ORDER BY id ASC")
+        qlog_ids = [int(r["id"]) for r in cur.fetchall()]
+    return db, cfg, qlog_ids
+
+
+def _build_app(db: Database, cfg: dict) -> FastAPI:
+    app = FastAPI()
+
+    @app.get("/api/quarantine")
+    async def quarantine_list(
+        status: Optional[str] = Query(None),
+        limit: int = Query(500, ge=1, le=5000),
+    ):
+        dup_cfg = ((cfg or {}).get("duplicates") or {}).get(
+            "quarantine"
+        ) or {}
+        try:
+            qdays = max(1, int(dup_cfg.get("quarantine_days") or 30))
+        except (TypeError, ValueError):
+            qdays = 30
+        sql = (
+            "SELECT id, file_id, original_path, quarantine_path, sha256, "
+            "file_size, moved_at, moved_by, gain_report_id, "
+            "purged_at, restored_at FROM quarantine_log "
+        )
+        where = []
+        if status == "quarantined":
+            where.append("purged_at IS NULL AND restored_at IS NULL")
+        elif status == "restored":
+            where.append("restored_at IS NOT NULL")
+        elif status == "purged":
+            where.append("purged_at IS NOT NULL")
+        if where:
+            sql += "WHERE " + " AND ".join(where) + " "
+        sql += "ORDER BY moved_at DESC LIMIT ?"
+        rows = []
+        with db.get_cursor() as cur:
+            cur.execute(sql, [int(limit)])
+            for r in cur.fetchall():
+                d = dict(r)
+                if d.get("purged_at"):
+                    d["status"] = "purged"
+                elif d.get("restored_at"):
+                    d["status"] = "restored"
+                else:
+                    d["status"] = "quarantined"
+                moved_at = d.get("moved_at")
+                will_purge = None
+                if moved_at:
+                    try:
+                        if isinstance(moved_at, str):
+                            dt = datetime.fromisoformat(
+                                moved_at.replace("Z", "")
+                            )
+                        else:
+                            dt = moved_at
+                        will_purge = (dt + timedelta(days=qdays)).strftime(
+                            "%Y-%m-%d %H:%M:%S"
+                        )
+                    except Exception:
+                        will_purge = None
+                d["will_purge_at"] = will_purge
+                rows.append(d)
+        return {
+            "enabled": bool(dup_cfg.get("enabled", True)),
+            "quarantine_days": qdays,
+            "rows": rows,
+        }
+
+    @app.post("/api/quarantine/{quarantine_log_id}/purge")
+    async def quarantine_purge(quarantine_log_id: int, request: Request):
+        body = await request.json()
+        confirm = bool(body.get("confirm", False))
+        token = body.get("safety_token", "")
+        purged_by = body.get("purged_by") or "operator"
+        if not confirm:
+            raise HTTPException(400, "confirm=True required to purge")
+        if token != PURGE_SAFETY_TOKEN_VALUE:
+            raise HTTPException(
+                400,
+                f"safety_token must equal {PURGE_SAFETY_TOKEN_VALUE!r}",
+            )
+        cleaner = DuplicateCleaner(db, cfg)
+        result = cleaner.purge_one(
+            int(quarantine_log_id), purged_by=purged_by
+        )
+        if result.status in ("purged", "skipped_missing"):
+            return result.to_dict()
+        if result.status == "skipped_not_found":
+            raise HTTPException(404, result.reason or "not found")
+        if result.status == "abort_sha_mismatch":
+            raise HTTPException(
+                409,
+                {
+                    "error": "sha_mismatch_forensic_preserve",
+                    "detail": result.to_dict(),
+                },
+            )
+        if result.status in (
+            "skipped_already_purged", "skipped_restored",
+        ):
+            raise HTTPException(409, result.reason or result.status)
+        raise HTTPException(
+            500, {"error": result.status, "detail": result.to_dict()},
+        )
+
+    @app.post("/api/quarantine/{quarantine_log_id}/restore")
+    async def quarantine_restore(
+        quarantine_log_id: int, request: Request
+    ):
+        body = await request.json()
+        confirm = bool(body.get("confirm", False))
+        restored_by = body.get("restored_by") or "operator"
+        if not confirm:
+            raise HTTPException(400, "confirm=True required to restore")
+        cleaner = DuplicateCleaner(db, cfg)
+        result = cleaner.restore(
+            int(quarantine_log_id), restored_by=restored_by
+        )
+        if result.status == "restored":
+            return result.to_dict()
+        if result.status == "skipped_not_found":
+            raise HTTPException(404, result.reason or "not found")
+        if result.status in (
+            "skipped_collision",
+            "skipped_already_restored",
+            "skipped_already_purged",
+            "skipped_missing",
+        ):
+            raise HTTPException(409, result.reason or result.status)
+        raise HTTPException(
+            500, {"error": result.status, "detail": result.to_dict()},
+        )
+
+    return app
+
+
+# ──────────────────────────────────────────────
+# Tests
+# ──────────────────────────────────────────────
+
+
+def test_quarantine_list_returns_rows_with_status_and_will_purge_at(tmp_path):
+    db, cfg, qlog_ids = _seed(tmp_path)
+    client = TestClient(_build_app(db, cfg))
+    resp = client.get("/api/quarantine")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["enabled"] is True
+    assert body["quarantine_days"] == 30
+    assert len(body["rows"]) == len(qlog_ids)
+    # Every row has derived status + will_purge_at.
+    for r in body["rows"]:
+        assert r["status"] == "quarantined"
+        assert r["will_purge_at"] is not None
+
+
+def test_quarantine_list_filter_purged(tmp_path):
+    db, cfg, qlog_ids = _seed(tmp_path)
+    cleaner = DuplicateCleaner(db, cfg)
+    # Purge one row.
+    cleaner.purge_one(qlog_ids[0], purged_by="tester")
+    client = TestClient(_build_app(db, cfg))
+    resp = client.get("/api/quarantine?status=purged")
+    assert resp.status_code == 200
+    rows = resp.json()["rows"]
+    assert len(rows) == 1
+    assert rows[0]["status"] == "purged"
+    # And the inverse filter shows only the remaining one.
+    resp2 = client.get("/api/quarantine?status=quarantined")
+    assert resp2.status_code == 200
+    rows2 = resp2.json()["rows"]
+    assert len(rows2) == 1
+    assert rows2[0]["status"] == "quarantined"
+
+
+def test_purge_endpoint_refuses_without_confirm(tmp_path):
+    db, cfg, qlog_ids = _seed(tmp_path)
+    client = TestClient(_build_app(db, cfg))
+    resp = client.post(
+        f"/api/quarantine/{qlog_ids[0]}/purge",
+        json={"safety_token": "PURGE"},
+    )
+    assert resp.status_code == 400
+    assert "confirm" in resp.json()["detail"].lower()
+
+
+def test_purge_endpoint_refuses_without_safety_token(tmp_path):
+    db, cfg, qlog_ids = _seed(tmp_path)
+    client = TestClient(_build_app(db, cfg))
+    resp = client.post(
+        f"/api/quarantine/{qlog_ids[0]}/purge",
+        json={"confirm": True, "safety_token": "WRONG"},
+    )
+    assert resp.status_code == 400
+    assert "safety_token" in resp.json()["detail"]
+
+
+def test_purge_endpoint_happy_path(tmp_path):
+    db, cfg, qlog_ids = _seed(tmp_path)
+    client = TestClient(_build_app(db, cfg))
+    resp = client.post(
+        f"/api/quarantine/{qlog_ids[0]}/purge",
+        json={"confirm": True, "safety_token": "PURGE"},
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["status"] == "purged"
+    assert body["audit_event_id"] is not None
+
+
+def test_purge_endpoint_sha_mismatch_returns_409_forensic(tmp_path):
+    db, cfg, qlog_ids = _seed(tmp_path)
+    # Tamper.
+    with db.get_cursor() as cur:
+        cur.execute(
+            "SELECT quarantine_path FROM quarantine_log WHERE id = ?",
+            (qlog_ids[0],),
+        )
+        qpath = dict(cur.fetchone())["quarantine_path"]
+    with open(qpath, "ab") as f:
+        f.write(b"TAMPERED")
+    client = TestClient(_build_app(db, cfg))
+    resp = client.post(
+        f"/api/quarantine/{qlog_ids[0]}/purge",
+        json={"confirm": True, "safety_token": "PURGE"},
+    )
+    assert resp.status_code == 409, resp.text
+    # File MUST still exist.
+    assert os.path.exists(qpath), \
+        "SHA mismatch over the wire must not delete"
+
+
+def test_purge_endpoint_unknown_id_returns_404(tmp_path):
+    db, cfg, _qlog_ids = _seed(tmp_path)
+    client = TestClient(_build_app(db, cfg))
+    resp = client.post(
+        "/api/quarantine/99999/purge",
+        json={"confirm": True, "safety_token": "PURGE"},
+    )
+    assert resp.status_code == 404
+
+
+def test_restore_endpoint_refuses_without_confirm(tmp_path):
+    db, cfg, qlog_ids = _seed(tmp_path)
+    client = TestClient(_build_app(db, cfg))
+    resp = client.post(
+        f"/api/quarantine/{qlog_ids[0]}/restore", json={},
+    )
+    assert resp.status_code == 400
+
+
+def test_restore_endpoint_happy_path(tmp_path):
+    db, cfg, qlog_ids = _seed(tmp_path)
+    with db.get_cursor() as cur:
+        cur.execute(
+            "SELECT original_path FROM quarantine_log WHERE id = ?",
+            (qlog_ids[0],),
+        )
+        opath = dict(cur.fetchone())["original_path"]
+    client = TestClient(_build_app(db, cfg))
+    resp = client.post(
+        f"/api/quarantine/{qlog_ids[0]}/restore",
+        json={"confirm": True},
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["status"] == "restored"
+    assert os.path.exists(opath)
+
+
+def test_restore_endpoint_collision_returns_409(tmp_path):
+    db, cfg, qlog_ids = _seed(tmp_path)
+    with db.get_cursor() as cur:
+        cur.execute(
+            "SELECT original_path FROM quarantine_log WHERE id = ?",
+            (qlog_ids[0],),
+        )
+        opath = dict(cur.fetchone())["original_path"]
+    Path(opath).parent.mkdir(parents=True, exist_ok=True)
+    Path(opath).write_bytes(b"collision")
+    client = TestClient(_build_app(db, cfg))
+    resp = client.post(
+        f"/api/quarantine/{qlog_ids[0]}/restore",
+        json={"confirm": True},
+    )
+    assert resp.status_code == 409
+
+
+def test_restore_endpoint_unknown_id_returns_404(tmp_path):
+    db, cfg, _qlog_ids = _seed(tmp_path)
+    client = TestClient(_build_app(db, cfg))
+    resp = client.post(
+        "/api/quarantine/99999/restore",
+        json={"confirm": True},
+    )
+    assert resp.status_code == 404


### PR DESCRIPTION
## Summary
Phase 2 of #83 / closes #110 — hard-delete after `quarantine_days` + restore from quarantine + manual purge UI. Builds on Phase 1 (#109) which only ever moved files; this round adds the lifecycle terminus (delete OR restore).

- **Schema**: idempotent `ALTER TABLE quarantine_log ADD COLUMN purged_at|restored_at` (try/except duplicate-column) + 2 indexes.
- **`src/archiver/duplicate_cleaner.py`**: `PurgeResult`, `RestoreResult` dataclasses + `purge_one(file_id)`, `purge_expired(now=None)`, `restore(quarantine_log_id)`. **Defensive SHA-256 verify before EVERY hard delete** — mismatch → `abort_sha_mismatch` with the file PRESERVED for forensics, never silent delete. `PURGE_SAFETY_TOKEN_VALUE = "PURGE"`.
- **APScheduler `daily_quarantine_purge`** registered in `task_scheduler.py::start()` at `duplicates.quarantine.purge_hour` (default 03:00). Per-file errors never abort the batch.
- **3 new endpoints**: `GET /api/quarantine`, `POST /api/quarantine/{id}/purge` (safety_token "PURGE"), `POST /api/quarantine/{id}/restore` (collision refusal).
- **Frontend**: new `#page-quarantine` under Sistem with entity-list (status filter dropdown), bulk "Geri Yükle" + "Hemen Sil" (typed-PURGE confirm).

## Tests
- `tests/test_duplicate_cleaner_phase2.py`: 15/15 pass — purge with valid sidecar, abort on SHA mismatch, audit on every transition, expired skip recent, missing file handled, restore success, restore refuses on collision/already-restored/already-purged
- `tests/test_quarantine_endpoints.py`: 11/11 pass
- Adjacent regression suites: 41/41 pass

## Manual round-trip verified live
- quarantine 2 dupes → `purge_expired(now=now+365d)` returned `purged` for both, `purged_at` stamped, files removed, sidecars cleaned
- restore log#1 → file moved back to `original_path`, `restored_at` stamped, audit event written
- SHA mismatch on log#2 (file tampered) → `purge_one` returned `abort_sha_mismatch`, file STILL present on disk, `purged_at` left NULL, `duplicate_quarantine_purge_sha_mismatch` audit written

## Decisions
- **SHA mismatch = forensic preserve, never delete**. Row stays unstamped so it surfaces in operator review.
- **Per-file errors never abort batch** — single bad row never blocks the rest.
- **Rebase resolution**: 3-way merge (master had #112 approvals + #111 chargeback). All independent additions kept; loaders map combines all 4 wave keys.

https://claude.ai/code/session_998c8ada-6f18-462b-b6eb-d6e8745d3543

---
_Generated by [Claude Code](https://claude.ai/code/session_01A1UzS1A4DZNk1akoP4uhZ7)_