### PR TITLE
Quota / capacity forecasting (closes #113)

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -191,6 +191,18 @@ reports:
     - html
     - json
 
+forecast:
+  # Kapasite / kota tahmini (issue #113). scan_runs.total_size_bytes
+  # geçmişi üzerinde stdlib-only doğrusal regresyon çalıştırır; sonuç
+  # /api/forecast/{source_id} ile JSON ve XLSX olarak sunulur. Salt
+  # okunur olduğu için varsayılan olarak açıktır; alarm e-postası
+  # smtp.enabled=false iken otomatik no-op çalışır.
+  enabled: true
+  default_horizon_days: 180
+  capacity_threshold_pct: 85       # diskin %X dolduğunda alarm verilir
+  alarm_email: ""                  # bos = alarm postasi yok; doldurulursa daily digest
+  alarm_lead_days: 30              # alarm tarihi bu kadar gun icinde ise digest'e ekle
+
 dashboard:
   host: "0.0.0.0"
   port: 8085

--- a/src/dashboard/api.py
+++ b/src/dashboard/api.py
@@ -2663,6 +2663,25 @@ def create_app(db, config, analytics=None, ad_lookup=None, email_notifier=None):
             pii_backend_info = {"backend": "re", "configured": "auto",
                                  "hyperscan_available": False, "version": None}
 
+        # Issue #113: surface total disk capacity so the forecast page can
+        # compute the default 85% threshold without a second roundtrip.
+        # shutil.disk_usage() works on the volume hosting the SQLite DB —
+        # which is the same volume holding ``data/`` (scans, snapshots,
+        # quarantine), i.e. the resource we care about for capacity alarms.
+        disk_info = None
+        try:
+            import shutil as _shutil
+            target = os.path.dirname(os.path.abspath(db.db_path)) or "."
+            usage = _shutil.disk_usage(target)
+            disk_info = {
+                "path": target,
+                "total_bytes": int(usage.total),
+                "used_bytes": int(usage.used),
+                "free_bytes": int(usage.free),
+            }
+        except Exception as e:  # pragma: no cover - non-critical
+            logger.debug("disk_usage probe failed: %s", e)
+
         return {
             "status": "ok",
             "time": datetime.now().isoformat(),
@@ -2672,6 +2691,7 @@ def create_app(db, config, analytics=None, ad_lookup=None, email_notifier=None):
             "email": email_notifier.health(),
             "wal_warning": wal_warning,
             "pii_backend": pii_backend_info,
+            "disk": disk_info,
         }
 
     @app.get("/api/system/analytics")
@@ -4789,6 +4809,253 @@ def create_app(db, config, analytics=None, ad_lookup=None, email_notifier=None):
             raise HTTPException(500, str(e))
         filename = (
             f"Chargeback_source{source_id}_scan{scan_id}_"
+            f"{datetime.now().strftime('%Y%m%d_%H%M%S')}.xlsx"
+        )
+        return StreamingResponse(
+            _io.BytesIO(blob),
+            media_type=(
+                "application/vnd.openxmlformats-officedocument."
+                "spreadsheetml.sheet"
+            ),
+            headers={
+                "Content-Disposition": f"attachment; filename={filename}",
+            },
+        )
+
+    # ─────────────────────────────────────────────────────────────────────
+    # Forecast / capacity planning (issue #113).
+    #
+    # GET /api/forecast/{source_id}?horizon_days=180&model=linear
+    #   Linear-regression projection over scan_runs history. Returns the
+    #   ForecastResult dataclass shape.
+    #
+    # GET /api/forecast/{source_id}/export.xlsx
+    #   Workbook with Summary / History / Settings sheets. Settings.B2 holds
+    #   the editable threshold (% of disk).
+    # ─────────────────────────────────────────────────────────────────────
+
+    def _scan_history_for(source_id: int) -> list:
+        """Pull (started_at, total_size) pairs from scan_runs for one source.
+
+        Excludes still-running scans because their total_size is interim.
+        Sorted ascending so forecast_growth() can use the first row as t0.
+        """
+        with db.get_cursor() as cur:
+            cur.execute(
+                """
+                SELECT started_at, total_size, total_files
+                FROM scan_runs
+                WHERE source_id = ?
+                  AND status = 'completed'
+                  AND total_size IS NOT NULL
+                  AND total_size > 0
+                ORDER BY started_at ASC
+                """,
+                (int(source_id),),
+            )
+            return [dict(r) for r in cur.fetchall()]
+
+    def _forecast_config() -> dict:
+        cfg = (config or {}).get("forecast") or {}
+        return {
+            "enabled": bool(cfg.get("enabled", True)),
+            "default_horizon_days": int(cfg.get("default_horizon_days", 180)),
+            "capacity_threshold_pct": float(cfg.get("capacity_threshold_pct", 85)),
+            "alarm_email": (cfg.get("alarm_email") or "").strip(),
+            "alarm_lead_days": int(cfg.get("alarm_lead_days", 30)),
+        }
+
+    def _disk_total_bytes() -> int:
+        """Best-effort: total bytes on the volume holding the SQLite DB.
+
+        Same logic as /api/system/health — kept inline so the forecast
+        endpoints don't have to round-trip through the health probe.
+        """
+        try:
+            import shutil as _shutil
+            target = os.path.dirname(os.path.abspath(db.db_path)) or "."
+            return int(_shutil.disk_usage(target).total)
+        except Exception:
+            return 0
+
+    @app.get("/api/forecast/{source_id}")
+    async def forecast_endpoint(
+        source_id: int,
+        horizon_days: int = Query(180, ge=1, le=3650),
+        model: str = Query("linear"),
+        threshold_bytes: Optional[int] = Query(None, ge=0),
+    ):
+        """Capacity forecast for one source (issue #113).
+
+        Currently only ``model=linear`` is supported; future iterations may
+        add seasonal / ARIMA — keeping the query parameter so the URL doesn't
+        break when that arrives.
+        """
+        from src.reports.forecast import forecast_growth
+
+        fc_cfg = _forecast_config()
+        if not fc_cfg["enabled"]:
+            raise HTTPException(404, "forecast.enabled=false")
+
+        if model != "linear":
+            raise HTTPException(
+                400, f"unsupported model {model!r} (only 'linear' for now)"
+            )
+
+        # Verify the source exists so callers get a real 404 (not an empty
+        # forecast with samples_used=0).
+        with db.get_cursor() as cur:
+            cur.execute("SELECT 1 FROM sources WHERE id = ?", (source_id,))
+            if not cur.fetchone():
+                raise HTTPException(404, "source bulunamadi")
+
+        rows = _scan_history_for(source_id)
+
+        # Threshold resolution: explicit query param wins; otherwise fall
+        # back to (capacity_threshold_pct% × disk_total_bytes).
+        thr = threshold_bytes
+        disk_total = _disk_total_bytes()
+        if thr is None and disk_total > 0:
+            thr = int(disk_total * fc_cfg["capacity_threshold_pct"] / 100.0)
+
+        result = forecast_growth(
+            rows,
+            horizon_days=horizon_days,
+            capacity_threshold_bytes=thr,
+            source_id=source_id,
+        )
+        body = result.to_dict()
+        # Surface the threshold + disk total so the frontend can recompute
+        # alarm dates client-side without a second call.
+        body["threshold_bytes"] = int(thr) if thr is not None else None
+        body["disk_total_bytes"] = int(disk_total) if disk_total else None
+        body["capacity_threshold_pct"] = fc_cfg["capacity_threshold_pct"]
+        body["model"] = "linear"
+        return body
+
+    @app.get("/api/forecast/{source_id}/export.xlsx")
+    async def forecast_export_xlsx(
+        source_id: int,
+        horizon_days: int = Query(180, ge=1, le=3650),
+        threshold_bytes: Optional[int] = Query(None, ge=0),
+    ):
+        """XLSX workbook: Summary + History + Settings (editable threshold)."""
+        from fastapi.responses import StreamingResponse
+        import io as _io
+        from src.reports.forecast import forecast_growth
+
+        fc_cfg = _forecast_config()
+        if not fc_cfg["enabled"]:
+            raise HTTPException(404, "forecast.enabled=false")
+
+        with db.get_cursor() as cur:
+            cur.execute(
+                "SELECT id, name FROM sources WHERE id = ?", (source_id,)
+            )
+            src_row = cur.fetchone()
+            if not src_row:
+                raise HTTPException(404, "source bulunamadi")
+        source_name = src_row["name"]
+
+        rows = _scan_history_for(source_id)
+        disk_total = _disk_total_bytes()
+        thr = threshold_bytes
+        if thr is None and disk_total > 0:
+            thr = int(disk_total * fc_cfg["capacity_threshold_pct"] / 100.0)
+
+        result = forecast_growth(
+            rows,
+            horizon_days=horizon_days,
+            capacity_threshold_bytes=thr,
+            source_id=source_id,
+        )
+
+        try:
+            from openpyxl import Workbook
+            from openpyxl.styles import Font, PatternFill
+        except ImportError as e:
+            raise HTTPException(
+                500, f"openpyxl not available: {e}"
+            )
+
+        wb = Workbook()
+
+        # ---- Summary sheet (active by default) ------------------------
+        ws_sum = wb.active
+        ws_sum.title = "Summary"
+        ws_sum["A1"] = "Field"
+        ws_sum["B1"] = "Value"
+        for c in (ws_sum["A1"], ws_sum["B1"]):
+            c.font = Font(bold=True)
+            c.fill = PatternFill("solid", fgColor="DDDDDD")
+        rows_sum = [
+            ("Source ID", source_id),
+            ("Source name", source_name),
+            ("Horizon (days)", result.horizon_days),
+            ("Samples used", result.samples_used),
+            ("R²", round(result.r_squared, 6)),
+            ("Slope (bytes/day)", round(result.slope_bytes_per_day, 2)),
+            ("Predicted bytes", int(result.predicted_bytes)),
+            ("Predicted GiB",
+             round(result.predicted_bytes / (1024 ** 3), 4)),
+            ("CI low (bytes)", int(result.ci_low_bytes)),
+            ("CI high (bytes)", int(result.ci_high_bytes)),
+            ("Threshold (bytes)", int(thr) if thr is not None else ""),
+            ("Disk total (bytes)", int(disk_total) if disk_total else ""),
+            ("Capacity alarm at", result.capacity_alarm_at or ""),
+            ("Generated at (UTC)", datetime.utcnow().isoformat() + "Z"),
+        ]
+        for i, (k, v) in enumerate(rows_sum, start=2):
+            ws_sum.cell(row=i, column=1, value=k)
+            ws_sum.cell(row=i, column=2, value=v)
+        ws_sum.column_dimensions["A"].width = 28
+        ws_sum.column_dimensions["B"].width = 32
+
+        # ---- History sheet (raw scan_runs data) -----------------------
+        ws_hist = wb.create_sheet("History")
+        ws_hist.append(["started_at", "total_size_bytes", "total_files"])
+        for cell in ws_hist[1]:
+            cell.font = Font(bold=True)
+            cell.fill = PatternFill("solid", fgColor="DDDDDD")
+        for r in rows:
+            ws_hist.append([
+                r.get("started_at") or "",
+                int(r.get("total_size") or 0),
+                int(r.get("total_files") or 0),
+            ])
+        ws_hist.column_dimensions["A"].width = 24
+        ws_hist.column_dimensions["B"].width = 22
+        ws_hist.column_dimensions["C"].width = 16
+
+        # ---- Settings sheet (editable threshold cell) -----------------
+        ws_set = wb.create_sheet("Settings")
+        ws_set["A1"] = "Setting"
+        ws_set["B1"] = "Value"
+        for c in (ws_set["A1"], ws_set["B1"]):
+            c.font = Font(bold=True)
+            c.fill = PatternFill("solid", fgColor="DDDDDD")
+        # B2 is the editable threshold percentage. B3 holds the disk total
+        # so auditors can compute (B2/100)*B3 manually if they need to.
+        ws_set["A2"] = "Threshold (% of disk)"
+        ws_set["B2"] = fc_cfg["capacity_threshold_pct"]
+        ws_set["A3"] = "Disk total bytes"
+        ws_set["B3"] = int(disk_total) if disk_total else ""
+        ws_set["A4"] = "Threshold bytes (=B2/100*B3)"
+        ws_set["B4"] = "=B2/100*B3" if disk_total else int(thr or 0)
+        ws_set["A5"] = "Note"
+        ws_set["B5"] = (
+            "Edit B2 to change the threshold; B4 recomputes automatically. "
+            "Re-run the forecast endpoint to refresh the alarm date."
+        )
+        ws_set.column_dimensions["A"].width = 32
+        ws_set.column_dimensions["B"].width = 32
+
+        buf = _io.BytesIO()
+        wb.save(buf)
+        blob = buf.getvalue()
+
+        filename = (
+            f"Forecast_source{source_id}_h{horizon_days}d_"
             f"{datetime.now().strftime('%Y%m%d_%H%M%S')}.xlsx"
         )
         return StreamingResponse(

--- a/src/dashboard/static/index.html
+++ b/src/dashboard/static/index.html
@@ -430,6 +430,7 @@ label { font-size: 12px; color: var(--text-muted); margin-bottom: 6px; display: 
     <div class="nav-section">
         <div class="nav-label">Raporlar</div>
         <div class="nav-item" onclick="showPage('chargeback')"><span class="icon">💵</span> <span>Chargeback / Cost Center</span></div>
+        <div class="nav-item" onclick="showPage('forecast')"><span class="icon">🔮</span> <span>Kapasite Tahmini</span></div>
     </div>
     <div class="nav-section">
         <div class="nav-label">Entegrasyonlar</div>
@@ -1107,6 +1108,54 @@ label { font-size: 12px; color: var(--text-muted); margin-bottom: 6px; display: 
         <button class="btn btn-primary" id="cb-form-submit-btn" onclick="submitChargebackCenterForm(this)">Olustur</button>
     </div>
 </div>
+</div>
+
+<!-- ============ RAPORLAR > KAPASITE TAHMINI (issue #113) ============ -->
+<div class="page" id="page-forecast">
+    <div class="page-header">
+        <div>
+            <div style="font-size:11px;color:var(--text-muted);margin-bottom:2px">Raporlar &raquo; Kapasite Tahmini</div>
+            <h2>Kapasite / Kota Tahmini</h2>
+            <div class="desc">scan_runs gecmisinde dogrusal regresyon ile depolama buyume projeksiyonu — %95 guven aralig + esik asim alarmi (issue #113)</div>
+        </div>
+        <div class="actions">
+            <select id="fc-source" onchange="loadForecast()" style="width:200px">
+                <option value="">Kaynak secin...</option>
+            </select>
+            <select id="fc-horizon" onchange="loadForecast()" style="width:140px">
+                <option value="30">30 gun</option>
+                <option value="90">90 gun</option>
+                <option value="180" selected>180 gun</option>
+                <option value="365">1 yil</option>
+            </select>
+            <input id="fc-threshold-pct" type="number" min="1" max="100" step="1" value="85"
+                   onchange="recomputeForecastAlarm()" title="Disk doluluk esigi (%)"
+                   style="width:90px;padding:6px 10px;background:var(--bg-input);border:1px solid var(--border);border-radius:6px;color:var(--text-primary)">
+            <button class="btn btn-outline" id="fc-xlsx-btn" onclick="exportForecastXlsx(event)" style="display:none">XLSX Indir</button>
+        </div>
+    </div>
+
+    <!-- KPI banner -->
+    <div class="cards" id="fc-kpi-cards"></div>
+
+    <!-- Visual mode -->
+    <div id="fc-visual-host" style="margin-top:20px">
+        <div class="panel">
+            <h3 class="panel-title">Tarihsel + Projeksiyon (95% Konfidans Konisi)</h3>
+            <div style="position:relative;height:380px">
+                <canvas id="fc-line-chart"></canvas>
+            </div>
+            <div id="fc-meta" style="margin-top:10px;font-size:11px;color:var(--text-muted)"></div>
+        </div>
+    </div>
+
+    <!-- Profesyonel mode -->
+    <div id="fc-grid-host" class="view-grid-host" style="display:none">
+        <div class="panel" style="margin-top:20px">
+            <h3 class="panel-title">Aylik Projeksiyon Donum Noktalari</h3>
+            <div id="fc-entity-container"></div>
+        </div>
+    </div>
 </div>
 
 <!-- Modal: Owner pattern ekle -->
@@ -1998,7 +2047,7 @@ function showPage(name) {
     // Find and activate nav item
     document.querySelectorAll('.nav-item').forEach(n => { if (n.getAttribute('onclick')?.includes(name)) n.classList.add('active'); });
     // Auto-load data
-    const loaders = { overview: loadOverview, sources: loadSources, frequency: loadFrequency, types: loadTypes, sizes: loadSizes, users: loadUsers, anomalies: loadAnomalies, archive: loadArchive, 'archive-history': loadArchiveHistory, duplicates: loadDuplicates, growth: loadGrowth, naming: loadNaming, policies: loadPolicies, schedules: loadSchedules, treemap: loadTreemap, insights: loadInsights, sqlquery: sqlqInit, 'legal-holds': loadLegalHolds, 'orphan-sids': loadOrphanSids, ransomware: loadRansomwareAlerts, acl: loadAclAnalyzer, pii: loadPii, retention: loadRetention, syslog: loadSyslog, mcp: loadMcp, backups: loadBackups, operations: loadOperations, approvals: loadApprovalsAll, chargeback: loadChargeback, quarantine: loadQuarantine };
+    const loaders = { overview: loadOverview, sources: loadSources, frequency: loadFrequency, types: loadTypes, sizes: loadSizes, users: loadUsers, anomalies: loadAnomalies, archive: loadArchive, 'archive-history': loadArchiveHistory, duplicates: loadDuplicates, growth: loadGrowth, naming: loadNaming, policies: loadPolicies, schedules: loadSchedules, treemap: loadTreemap, insights: loadInsights, sqlquery: sqlqInit, 'legal-holds': loadLegalHolds, 'orphan-sids': loadOrphanSids, ransomware: loadRansomwareAlerts, acl: loadAclAnalyzer, pii: loadPii, retention: loadRetention, syslog: loadSyslog, mcp: loadMcp, backups: loadBackups, operations: loadOperations, approvals: loadApprovalsAll, chargeback: loadChargeback, quarantine: loadQuarantine, forecast: loadForecast };
     // Issue #79: route through loadWithProgress so slow pages get a top
     // progress bar, ETA from p50 history, and a retry path on failure.
     if (loaders[name]) loadWithProgress(name, loaders[name]).catch(() => { /* widget surfaces error */ });
@@ -2026,10 +2075,10 @@ async function loadSources() {
 }
 
 function populateAllSourceSelects() {
-    ['overview-source','freq-source','types-source','sizes-source','treemap-source','insights-source','ah-source','dup-source','growth-source','naming-source','orphan-sids-source','acl-source','pii-source','cb-source'].forEach(id => populateSourceSelect(id));
+    ['overview-source','freq-source','types-source','sizes-source','treemap-source','insights-source','ah-source','dup-source','growth-source','naming-source','orphan-sids-source','acl-source','pii-source','cb-source','fc-source'].forEach(id => populateSourceSelect(id));
     // Auto-select first source if only one
     if (sources.length === 1) {
-        ['overview-source','freq-source','types-source','sizes-source','treemap-source','insights-source','ah-source','dup-source','growth-source','naming-source','orphan-sids-source','acl-source','pii-source','cb-source'].forEach(id => {
+        ['overview-source','freq-source','types-source','sizes-source','treemap-source','insights-source','ah-source','dup-source','growth-source','naming-source','orphan-sids-source','acl-source','pii-source','cb-source','fc-source'].forEach(id => {
             const sel = document.getElementById(id);
             if (sel && !sel.value) sel.value = sources[0].id;
         });
@@ -7064,6 +7113,363 @@ async function exportChargebackXlsx(ev) {
             `${API}/chargeback/${sid}/export.xlsx`,
             signal,
             `chargeback_source${sid}.xlsx`
+        );
+    });
+}
+
+// ═══════════════════════════════════════════════════
+// CAPACITY FORECAST (issue #113)
+// ═══════════════════════════════════════════════════
+let _fcLastResult = null;        // last forecast response — for client-side recompute
+
+function _attachForecastViewToggle() {
+    const page = document.getElementById('page-forecast');
+    if (!page || typeof attachViewToggle !== 'function') return;
+    attachViewToggle(page, {
+        pageKey: 'forecast',
+        renderVisual: _renderForecastVisual,
+        renderGrid: _renderForecastGrid,
+        defaultMode: 'visual',
+    });
+}
+
+function _renderForecastVisual() {
+    const v = document.getElementById('fc-visual-host');
+    const g = document.getElementById('fc-grid-host');
+    if (v) v.style.display = '';
+    if (g) g.style.display = 'none';
+    if (_fcLastResult) _renderForecastChart(_fcLastResult);
+}
+
+function _renderForecastGrid() {
+    const v = document.getElementById('fc-visual-host');
+    const g = document.getElementById('fc-grid-host');
+    if (v) v.style.display = 'none';
+    if (g) g.style.display = '';
+    if (_fcLastResult) _renderForecastEntityList(_fcLastResult);
+}
+
+async function loadForecast() {
+    _attachForecastViewToggle();
+    const sid = document.getElementById('fc-source').value;
+    const horizon = parseInt(document.getElementById('fc-horizon').value || '180', 10);
+    const xb = document.getElementById('fc-xlsx-btn');
+    if (!sid) {
+        document.getElementById('fc-kpi-cards').innerHTML = '';
+        document.getElementById('fc-meta').innerHTML =
+            '<div style="padding:20px;color:var(--text-muted)">Once bir kaynak secin</div>';
+        if (xb) xb.style.display = 'none';
+        return;
+    }
+
+    let data;
+    try {
+        data = await api(`/forecast/${sid}?horizon_days=${horizon}&model=linear`);
+    } catch (e) {
+        document.getElementById('fc-kpi-cards').innerHTML =
+            '<div style="padding:20px;color:var(--text-muted)">Tahmin alinamadi.</div>';
+        return;
+    }
+    _fcLastResult = data;
+    if (xb) xb.style.display = '';
+
+    // Pull threshold pct from server response if present, otherwise UI default.
+    const pctInput = document.getElementById('fc-threshold-pct');
+    if (data.capacity_threshold_pct && pctInput && !pctInput.dataset.userEdited) {
+        pctInput.value = data.capacity_threshold_pct;
+    }
+
+    _renderForecastKPIs(data);
+    _renderForecastChart(data);
+    _renderForecastEntityList(data);
+}
+
+function _renderForecastKPIs(data) {
+    const samples = data.samples_used || 0;
+    const r2 = (data.r_squared || 0).toFixed(3);
+    const slope = data.slope_bytes_per_day || 0;
+    const slopePerDay = formatSize(Math.abs(slope));
+    const slopeSign = slope < 0 ? '-' : '+';
+    const horizon = data.horizon_days || 0;
+    const predicted = formatSize(data.predicted_bytes || 0);
+
+    let alarmHtml;
+    let alarmColor = 'var(--success)';
+    if (samples < 3) {
+        alarmHtml = '<div class="card-value" style="font-size:18px">Yetersiz veri</div>'
+            + '<div class="card-sub">3+ tarama gecmisi gerekli</div>';
+        alarmColor = 'var(--warning)';
+    } else if (data.capacity_alarm_at) {
+        const today = new Date();
+        const alarm = new Date(data.capacity_alarm_at + 'T00:00:00');
+        const days = Math.round((alarm - today) / 86400000);
+        if (days <= 0) {
+            alarmHtml = `<div class="card-value" style="font-size:20px;color:var(--danger)">ALARM</div>`
+                + `<div class="card-sub">Esik bugun veya gecmis: <code>${data.capacity_alarm_at}</code></div>`;
+            alarmColor = 'var(--danger)';
+        } else {
+            alarmHtml = `<div class="card-value" style="font-size:20px;color:var(--warning)">${days} gun</div>`
+                + `<div class="card-sub">Bu hizla %${data.capacity_threshold_pct || '?'} doluluga <code>${data.capacity_alarm_at}</code> ulasilir</div>`;
+            alarmColor = 'var(--warning)';
+        }
+    } else {
+        alarmHtml = '<div class="card-value" style="font-size:20px">Capacity alarm yok</div>'
+            + '<div class="card-sub">Ufka kadar esige ulasilmiyor</div>';
+    }
+
+    document.getElementById('fc-kpi-cards').innerHTML = `
+        <div class="card" style="border-top:3px solid var(--accent)">
+            <div class="card-label">Ornek Sayisi</div>
+            <div class="card-value">${samples}</div>
+            <div class="card-sub">tamamlanmis scan_runs</div>
+        </div>
+        <div class="card" style="border-top:3px solid var(--info)">
+            <div class="card-label">${horizon} Gunluk Tahmin</div>
+            <div class="card-value" style="font-size:22px">${predicted}</div>
+            <div class="card-sub">95% CI: ${formatSize(data.ci_low_bytes||0)} – ${formatSize(data.ci_high_bytes||0)}</div>
+        </div>
+        <div class="card" style="border-top:3px solid var(--success)">
+            <div class="card-label">Buyume Hizi</div>
+            <div class="card-value" style="font-size:22px">${slopeSign}${slopePerDay}/gun</div>
+            <div class="card-sub">R² = ${r2}</div>
+        </div>
+        <div class="card" style="border-top:3px solid ${alarmColor}">
+            <div class="card-label">Kapasite Alarmi</div>
+            ${alarmHtml}
+        </div>
+    `;
+
+    const meta = document.getElementById('fc-meta');
+    if (meta) {
+        const thr = data.threshold_bytes
+            ? `${formatSize(data.threshold_bytes)} (%${data.capacity_threshold_pct || '?'} disk)`
+            : '(belirsiz)';
+        meta.innerHTML =
+            `Esik: ${thr} · Disk toplami: ${data.disk_total_bytes ? formatSize(data.disk_total_bytes) : '-'} · ` +
+            `Slope: ${slope.toLocaleString('tr-TR')} bayt/gun · R²: ${r2}`;
+    }
+}
+
+function _renderForecastChart(data) {
+    destroyChart('fc-line-chart');
+    const el = document.getElementById('fc-line-chart');
+    if (!el) return;
+
+    const history = data.history || [];
+    if (history.length === 0) {
+        el.parentElement.innerHTML = '<div style="padding:40px;text-align:center;color:var(--text-muted)">Bu kaynakta tarama gecmisi yok.</div>';
+        return;
+    }
+
+    // Build the projection line: from last historical point -> horizon endpoint.
+    const lastTs = history[history.length - 1].ts;
+    const lastBytes = history[history.length - 1].bytes;
+    const horizonDate = new Date(new Date(lastTs).getTime() + (data.horizon_days || 180) * 86400000);
+    const horizonIso = horizonDate.toISOString();
+
+    const histPoints = history.map(h => ({ x: h.ts, y: h.bytes }));
+    const projection = (data.samples_used || 0) >= 3
+        ? [{ x: lastTs, y: lastBytes }, { x: horizonIso, y: data.predicted_bytes }]
+        : [];
+    const ciLow = (data.samples_used || 0) >= 3
+        ? [{ x: lastTs, y: lastBytes }, { x: horizonIso, y: data.ci_low_bytes }]
+        : [];
+    const ciHigh = (data.samples_used || 0) >= 3
+        ? [{ x: lastTs, y: lastBytes }, { x: horizonIso, y: data.ci_high_bytes }]
+        : [];
+
+    // Threshold line (horizontal) — anchored to history start so the user
+    // sees where the projected line will cross it.
+    const thr = data.threshold_bytes;
+    const thrLine = thr
+        ? [{ x: history[0].ts, y: thr }, { x: horizonIso, y: thr }]
+        : [];
+
+    chartInstances['fc-line-chart'] = new Chart(el, {
+        type: 'line',
+        data: {
+            datasets: [
+                {
+                    label: 'Gecmis (bytes)',
+                    data: histPoints,
+                    borderColor: '#3b82f6',
+                    backgroundColor: '#3b82f622',
+                    borderWidth: 2,
+                    pointRadius: 3,
+                    fill: false,
+                    tension: 0.1,
+                },
+                {
+                    label: 'Projeksiyon',
+                    data: projection,
+                    borderColor: '#8b5cf6',
+                    borderDash: [6, 4],
+                    borderWidth: 2,
+                    pointRadius: 0,
+                    fill: false,
+                },
+                {
+                    label: 'CI 95% ust',
+                    data: ciHigh,
+                    borderColor: '#8b5cf655',
+                    borderWidth: 1,
+                    pointRadius: 0,
+                    fill: '+1',
+                    backgroundColor: '#8b5cf61a',
+                },
+                {
+                    label: 'CI 95% alt',
+                    data: ciLow,
+                    borderColor: '#8b5cf655',
+                    borderWidth: 1,
+                    pointRadius: 0,
+                    fill: false,
+                },
+                ...(thrLine.length ? [{
+                    label: 'Esik',
+                    data: thrLine,
+                    borderColor: '#ef4444',
+                    borderDash: [3, 3],
+                    borderWidth: 1.5,
+                    pointRadius: 0,
+                    fill: false,
+                }] : []),
+            ],
+        },
+        options: {
+            responsive: true,
+            maintainAspectRatio: false,
+            parsing: false,
+            scales: {
+                x: {
+                    type: 'time',
+                    time: { unit: 'day' },
+                    grid: { color: '#1e293b' },
+                },
+                y: {
+                    beginAtZero: false,
+                    grid: { color: '#1e293b' },
+                    ticks: {
+                        callback: (v) => formatSize(v),
+                    },
+                },
+            },
+            plugins: {
+                legend: { position: 'top', labels: { boxWidth: 12, padding: 8 } },
+                tooltip: {
+                    callbacks: {
+                        label: (ctx) => `${ctx.dataset.label}: ${formatSize(ctx.parsed.y)}`,
+                    },
+                },
+            },
+        },
+    });
+}
+
+function _renderForecastEntityList(data) {
+    const container = document.getElementById('fc-entity-container');
+    if (!container || typeof renderEntityList !== 'function') return;
+    if ((data.samples_used || 0) < 3) {
+        container.innerHTML = '<div style="padding:30px;text-align:center;color:var(--text-muted)">3+ tarama olunca aylik donum noktalari hesaplanir.</div>';
+        return;
+    }
+
+    // Project monthly milestones across the horizon
+    const slope = data.slope_bytes_per_day || 0;
+    const lastTs = data.last_ts;
+    const lastBytes = data.last_bytes || 0;
+    const horizonDays = data.horizon_days || 180;
+    const monthsOut = Math.max(1, Math.floor(horizonDays / 30));
+    const rows = [];
+    const thr = data.threshold_bytes;
+    const startDate = lastTs ? new Date(lastTs) : new Date();
+
+    for (let m = 1; m <= monthsOut; m++) {
+        const days = m * 30;
+        const dt = new Date(startDate.getTime() + days * 86400000);
+        const projected = lastBytes + slope * days;
+        const pctOfThr = thr ? Math.round((projected / thr) * 100) : null;
+        rows.push({
+            id: m,
+            month: m + ' ay sonra',
+            date: dt.toISOString().slice(0, 10),
+            projected_bytes: Math.round(projected),
+            projected_human: formatSize(projected),
+            pct_of_threshold: pctOfThr === null ? '-' : pctOfThr + '%',
+            over_threshold: thr && projected >= thr ? 'EVET' : '-',
+        });
+    }
+
+    renderEntityList(container, {
+        rows: rows,
+        rowKey: 'id',
+        pageSize: 50,
+        searchKeys: ['month', 'date'],
+        columns: [
+            { key: 'month', label: 'Ufuk' },
+            { key: 'date', label: 'Tarih' },
+            { key: 'projected_human', label: 'Tahmini Boyut' },
+            { key: 'pct_of_threshold', label: '% Esik' },
+            { key: 'over_threshold', label: 'Esik Asildi' },
+        ],
+        toolbar: {},
+        emptyMessage: 'Donum noktasi yok',
+    });
+}
+
+function recomputeForecastAlarm() {
+    const pctInput = document.getElementById('fc-threshold-pct');
+    if (pctInput) pctInput.dataset.userEdited = '1';
+    if (!_fcLastResult) return;
+
+    // Recompute alarm date client-side from slope/intercept + new threshold.
+    const pct = parseFloat(pctInput.value || '85');
+    const diskTotal = _fcLastResult.disk_total_bytes;
+    if (!diskTotal || pct <= 0) return;
+    const newThreshold = diskTotal * pct / 100;
+
+    const slope = _fcLastResult.slope_bytes_per_day || 0;
+    const intercept = _fcLastResult.intercept_bytes || 0;
+    const lastTs = _fcLastResult.last_ts;
+    const lastBytes = _fcLastResult.last_bytes || 0;
+
+    let newAlarm = null;
+    const todayIso = new Date().toISOString().slice(0, 10);
+    if (lastBytes >= newThreshold) {
+        newAlarm = todayIso;
+    } else if (slope > 0 && _fcLastResult.samples_used >= 3) {
+        // intercept + slope * t = newThreshold -> solve t (days from regression t0)
+        const tCross = (newThreshold - intercept) / slope;
+        // Map t back to a real date: t0 = first history sample.
+        const firstTs = (_fcLastResult.history && _fcLastResult.history.length)
+            ? _fcLastResult.history[0].ts : lastTs;
+        if (firstTs) {
+            const alarmDate = new Date(new Date(firstTs).getTime() + tCross * 86400000);
+            if (alarmDate > new Date()) {
+                newAlarm = alarmDate.toISOString().slice(0, 10);
+            } else {
+                newAlarm = todayIso;
+            }
+        }
+    }
+
+    // Patch the result + re-render KPIs (keep the chart's threshold line updated).
+    _fcLastResult.capacity_alarm_at = newAlarm;
+    _fcLastResult.capacity_threshold_pct = pct;
+    _fcLastResult.threshold_bytes = newThreshold;
+    _renderForecastKPIs(_fcLastResult);
+    _renderForecastChart(_fcLastResult);
+}
+
+async function exportForecastXlsx(ev) {
+    const sid = document.getElementById('fc-source').value;
+    const horizon = parseInt(document.getElementById('fc-horizon').value || '180', 10);
+    if (!sid) { notify('Once kaynak secin', 'warning'); return; }
+    await withButtonLoading(ev.target, async (signal) => {
+        await fetchAndDownload(
+            `${API}/forecast/${sid}/export.xlsx?horizon_days=${horizon}`,
+            signal,
+            `forecast_source${sid}_h${horizon}d.xlsx`
         );
     });
 }

--- a/src/reports/forecast.py
+++ b/src/reports/forecast.py
@@ -1,0 +1,417 @@
+"""Quota / capacity forecasting via linear regression on ``scan_runs`` history
+(issue #113).
+
+Given a list of ``scan_runs`` rows for a single source ordered ascending by
+``started_at`` (each carries ``total_size_bytes``), this module computes a
+plain ordinary-least-squares (OLS) linear regression in pure Python (stdlib
+only — no numpy / pandas), projects forward by ``horizon_days`` and returns
+a ``ForecastResult`` dataclass with:
+
+* predicted size at the horizon (intercept + slope * horizon_x)
+* a 95% confidence interval, derived from the residual standard error
+  multiplied by the conservative z-score 1.96 (we use 1.96 instead of a
+  full t-table — for n=3 the CI underestimates the true uncertainty, but
+  capacity-planning callers care more about *direction* than exact widths,
+  and 1.96 is the same constant used by ``/api/system/health`` ops widgets)
+* ``capacity_alarm_at``: ISO date when the projection line crosses
+  ``capacity_threshold_bytes`` (or None if it never does within +10 yr)
+* ``r_squared``: a quick goodness-of-fit hint for the dashboard
+
+Edge cases:
+
+* ``n < 3``: do NOT extrapolate. Return ``predicted == ci_low == ci_high ==
+  last_value`` with ``r_squared = 0`` and ``capacity_alarm_at = None``.
+  Two points fit a line with zero residuals — pretending that's a real
+  trend leads to wildly wrong projections.
+* All-equal y: slope = 0, predicted = last_value, alarm only if last_value
+  >= threshold (in which case alarm = today).
+* Negative slope (storage shrinking): never raises an alarm.
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timedelta, timezone
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger("file_activity.reports.forecast")
+
+# 1.96 ≈ 97.5th-percentile of the standard normal — a conservative stand-in
+# for the t-distribution at large n. For n in [3, 30] this *understates* the
+# true CI; we accept that since the report is read-only and the alarm logic
+# uses the point estimate, not the bound.
+_Z_95 = 1.96
+# Cap the alarm search at 10 years out — anything further is noise.
+_MAX_ALARM_DAYS = 365 * 10
+
+
+# ---------------------------------------------------------------------------
+# Result dataclass
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ForecastResult:
+    """Capacity forecast for a single source.
+
+    The frontend renders ``history`` directly as the time-series, then draws
+    a projection cone using ``ci_low_bytes`` / ``ci_high_bytes`` at the
+    horizon. ``capacity_alarm_at`` drives the KPI banner.
+    """
+
+    source_id: int
+    horizon_days: int
+    predicted_bytes: float
+    ci_low_bytes: float
+    ci_high_bytes: float
+    samples_used: int
+    r_squared: float
+    capacity_alarm_at: Optional[str]  # ISO date or None
+    history: List[Dict[str, Any]] = field(default_factory=list)
+    # Diagnostic fields — useful for debugging but not load-bearing for the UI.
+    slope_bytes_per_day: float = 0.0
+    intercept_bytes: float = 0.0
+    last_bytes: float = 0.0
+    last_ts: Optional[str] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        d = asdict(self)
+        # Normalise floats — JSON does not handle NaN/Infinity.
+        for k in (
+            "predicted_bytes", "ci_low_bytes", "ci_high_bytes", "r_squared",
+            "slope_bytes_per_day", "intercept_bytes", "last_bytes",
+        ):
+            v = d.get(k)
+            if v is None or (isinstance(v, float) and (math.isnan(v) or math.isinf(v))):
+                d[k] = 0.0
+        return d
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def forecast_growth(
+    scan_history: List[Dict[str, Any]],
+    horizon_days: int,
+    capacity_threshold_bytes: Optional[int] = None,
+    *,
+    source_id: int = 0,
+) -> ForecastResult:
+    """Linear-regression forecast over ``scan_history``.
+
+    ``scan_history`` is a list of dicts with at least ``started_at`` (ISO
+    timestamp string OR datetime) and ``total_size_bytes`` (int / float).
+    Caller is responsible for sorting ascending — but we re-sort defensively
+    because the chargeback-style helpers usually return DESC.
+
+    Time axis: days since the first sample (float, fractional days
+    preserved). The predicted point is at ``last_x + horizon_days``.
+    """
+    horizon_days = max(1, int(horizon_days or 0))
+
+    points = _normalise_history(scan_history)
+    n = len(points)
+
+    if n == 0:
+        # Nothing to project from. Return an empty-shape result.
+        return ForecastResult(
+            source_id=int(source_id),
+            horizon_days=horizon_days,
+            predicted_bytes=0.0,
+            ci_low_bytes=0.0,
+            ci_high_bytes=0.0,
+            samples_used=0,
+            r_squared=0.0,
+            capacity_alarm_at=None,
+            history=[],
+        )
+
+    # Always materialise the history payload first — even when n<3 we still
+    # want the chart to draw the points.
+    history_payload = [
+        {
+            "ts": _iso(p["dt"]),
+            "bytes": int(p["bytes"]),
+        }
+        for p in points
+    ]
+    last = points[-1]
+    last_bytes = float(last["bytes"])
+
+    if n < 3:
+        # Not enough samples for a meaningful regression. Hold steady at
+        # the last value; let the UI surface "yetersiz veri" rather than
+        # rendering a ramp from two points.
+        alarm_iso = None
+        if (
+            capacity_threshold_bytes is not None
+            and last_bytes >= float(capacity_threshold_bytes)
+        ):
+            # Already exceeding the threshold — surface that immediately.
+            alarm_iso = _today_iso()
+        return ForecastResult(
+            source_id=int(source_id),
+            horizon_days=horizon_days,
+            predicted_bytes=last_bytes,
+            ci_low_bytes=last_bytes,
+            ci_high_bytes=last_bytes,
+            samples_used=n,
+            r_squared=0.0,
+            capacity_alarm_at=alarm_iso,
+            history=history_payload,
+            slope_bytes_per_day=0.0,
+            intercept_bytes=last_bytes,
+            last_bytes=last_bytes,
+            last_ts=history_payload[-1]["ts"] if history_payload else None,
+        )
+
+    # ── OLS regression on (x = days since first sample, y = bytes) ──
+    t0 = points[0]["dt"]
+    xs = [_days_between(t0, p["dt"]) for p in points]
+    ys = [float(p["bytes"]) for p in points]
+
+    slope, intercept, r2, residual_std = _ols(xs, ys)
+
+    last_x = xs[-1]
+    horizon_x = last_x + float(horizon_days)
+    predicted = intercept + slope * horizon_x
+
+    # 95% CI via residual std error * z-score. This is a *conservative*
+    # surrogate for a proper prediction interval — it ignores the leverage
+    # term (1 + 1/n + (x* - mean_x)^2/Sxx). For stable historical series
+    # the leverage term is small at the right edge of the data; the
+    # operational use case (capacity alarm) only needs order-of-magnitude.
+    half_width = _Z_95 * residual_std
+    ci_low = max(0.0, predicted - half_width)
+    ci_high = predicted + half_width
+
+    # ── capacity_alarm_at ─────────────────────────────────────────────
+    alarm_iso = _solve_alarm_date(
+        slope=slope,
+        intercept=intercept,
+        last_x=last_x,
+        threshold=capacity_threshold_bytes,
+        last_bytes=last_bytes,
+        t0=t0,
+    )
+
+    return ForecastResult(
+        source_id=int(source_id),
+        horizon_days=horizon_days,
+        predicted_bytes=predicted,
+        ci_low_bytes=ci_low,
+        ci_high_bytes=ci_high,
+        samples_used=n,
+        r_squared=r2,
+        capacity_alarm_at=alarm_iso,
+        history=history_payload,
+        slope_bytes_per_day=slope,
+        intercept_bytes=intercept,
+        last_bytes=last_bytes,
+        last_ts=history_payload[-1]["ts"] if history_payload else None,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _normalise_history(rows: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """Coerce + sort + de-duplicate raw scan_runs rows.
+
+    Accepts either ``total_size_bytes`` (preferred field name from the
+    issue) or ``total_size`` (the actual column name on ``scan_runs``).
+    """
+    out: List[Dict[str, Any]] = []
+    for r in rows or []:
+        ts = (
+            r.get("started_at")
+            or r.get("ts")
+            or r.get("date")
+            or r.get("completed_at")
+        )
+        size = (
+            r.get("total_size_bytes")
+            if r.get("total_size_bytes") is not None
+            else r.get("total_size")
+        )
+        if ts is None or size is None:
+            continue
+        try:
+            dt = _to_datetime(ts)
+        except Exception:
+            continue
+        try:
+            b = float(size)
+        except (TypeError, ValueError):
+            continue
+        if b < 0:
+            continue
+        out.append({"dt": dt, "bytes": b})
+    # Sort ascending by timestamp (stable). Drop rows where two scans
+    # share the same timestamp by keeping the larger value (defensive —
+    # a re-run of the same scan should not zero-slope the regression).
+    out.sort(key=lambda x: x["dt"])
+    if not out:
+        return out
+    deduped: List[Dict[str, Any]] = [out[0]]
+    for row in out[1:]:
+        if row["dt"] == deduped[-1]["dt"]:
+            if row["bytes"] > deduped[-1]["bytes"]:
+                deduped[-1] = row
+        else:
+            deduped.append(row)
+    return deduped
+
+
+def _ols(xs: List[float], ys: List[float]) -> tuple:
+    """Plain ordinary least squares — returns (slope, intercept, r2, residual_std).
+
+    Uses the textbook formulation with a single pass over the data:
+        slope = Sxy / Sxx
+        intercept = mean_y - slope * mean_x
+        r2 = 1 - SSres / SStot
+        residual_std = sqrt(SSres / (n - 2))
+
+    All calls here have n >= 3 (the n<2 branch is handled earlier).
+    """
+    n = len(xs)
+    mean_x = sum(xs) / n
+    mean_y = sum(ys) / n
+    sxx = 0.0
+    sxy = 0.0
+    syy = 0.0
+    for x, y in zip(xs, ys):
+        dx = x - mean_x
+        dy = y - mean_y
+        sxx += dx * dx
+        sxy += dx * dy
+        syy += dy * dy
+    if sxx == 0:
+        # All x's identical — degenerate; treat as flat series.
+        return 0.0, mean_y, 0.0, 0.0
+    slope = sxy / sxx
+    intercept = mean_y - slope * mean_x
+
+    # Residuals
+    ss_res = 0.0
+    for x, y in zip(xs, ys):
+        y_pred = intercept + slope * x
+        diff = y - y_pred
+        ss_res += diff * diff
+    if syy == 0:
+        # All y's identical — perfect fit on a flat line. r2 is conventionally
+        # undefined here; report 1.0 (model explains everything trivially).
+        r2 = 1.0
+    else:
+        r2 = 1.0 - (ss_res / syy)
+        # Numerical noise can push this slightly outside [0,1].
+        if r2 < 0:
+            r2 = 0.0
+        elif r2 > 1:
+            r2 = 1.0
+    if n > 2:
+        residual_std = math.sqrt(ss_res / (n - 2))
+    else:
+        residual_std = 0.0
+    return slope, intercept, r2, residual_std
+
+
+def _solve_alarm_date(
+    *,
+    slope: float,
+    intercept: float,
+    last_x: float,
+    threshold: Optional[float],
+    last_bytes: float,
+    t0: datetime,
+) -> Optional[str]:
+    """Solve ``intercept + slope * t = threshold`` for ``t`` (in days since
+    t0), then map back to an ISO date.
+
+    Returns None when:
+      * threshold is None or non-positive
+      * slope <= 0 AND last value below threshold (storage flat / shrinking)
+      * the crossing is more than ``_MAX_ALARM_DAYS`` in the future
+
+    Returns today's ISO date when the threshold is already exceeded —
+    callers should surface this as an immediate alert.
+    """
+    if threshold is None:
+        return None
+    try:
+        thr = float(threshold)
+    except (TypeError, ValueError):
+        return None
+    if thr <= 0:
+        return None
+
+    # Already at or above threshold — alarm is today.
+    if last_bytes >= thr:
+        return _today_iso()
+
+    if slope <= 0:
+        # Flat or decreasing series — the projection never reaches the
+        # threshold within reasonable time.
+        return None
+
+    # intercept + slope * t_cross = thr  ->  t_cross = (thr - intercept) / slope
+    t_cross = (thr - intercept) / slope
+    days_from_last = t_cross - last_x
+    if days_from_last <= 0:
+        # The fitted line *already* says we should be over the threshold —
+        # surface it as today rather than confusing callers with a past date.
+        return _today_iso()
+    if days_from_last > _MAX_ALARM_DAYS:
+        return None
+    alarm_dt = (t0 + timedelta(days=t_cross)).replace(
+        hour=0, minute=0, second=0, microsecond=0
+    )
+    return alarm_dt.date().isoformat()
+
+
+def _to_datetime(ts: Any) -> datetime:
+    """Coerce ``ts`` (datetime / ISO string / SQLite ``YYYY-MM-DD HH:MM:SS``
+    string) to a naive datetime. We strip timezone info — all maths here
+    is delta-based, so the absolute reference frame does not matter."""
+    if isinstance(ts, datetime):
+        return ts.replace(tzinfo=None)
+    if not isinstance(ts, str):
+        raise TypeError(f"unsupported timestamp type: {type(ts)!r}")
+    s = ts.strip()
+    if not s:
+        raise ValueError("empty timestamp")
+    # Try ISO 8601 first (handles 'T' separator + timezone suffix).
+    try:
+        if s.endswith("Z"):
+            s = s[:-1] + "+00:00"
+        dt = datetime.fromisoformat(s)
+        if dt.tzinfo is not None:
+            dt = dt.astimezone(timezone.utc).replace(tzinfo=None)
+        return dt
+    except ValueError:
+        pass
+    # SQLite default format: 'YYYY-MM-DD HH:MM:SS'
+    for fmt in ("%Y-%m-%d %H:%M:%S", "%Y-%m-%d", "%Y/%m/%d %H:%M:%S"):
+        try:
+            return datetime.strptime(s, fmt)
+        except ValueError:
+            continue
+    raise ValueError(f"unparseable timestamp: {ts!r}")
+
+
+def _days_between(a: datetime, b: datetime) -> float:
+    return (b - a).total_seconds() / 86400.0
+
+
+def _iso(dt: datetime) -> str:
+    return dt.replace(microsecond=0).isoformat()
+
+
+def _today_iso() -> str:
+    return datetime.utcnow().date().isoformat()

--- a/src/scheduler/task_scheduler.py
+++ b/src/scheduler/task_scheduler.py
@@ -39,6 +39,10 @@ class TaskScheduler:
         # Issue #110 Phase 2: register the daily quarantine purge job.
         # Hard-deletes quarantine_log rows older than quarantine_days.
         self._register_daily_quarantine_purge_job()
+        # Issue #113: daily capacity-check job. No-op when
+        # forecast.enabled=false, smtp.enabled=false, or
+        # forecast.alarm_email is empty — all three independently disable.
+        self._register_capacity_check_job()
         self.scheduler.start()
         logger.info("TaskScheduler başlatıldı")
 
@@ -536,6 +540,200 @@ class TaskScheduler:
             logger.error(
                 "Failed to register daily_quarantine_purge: %s", e
             )
+
+    # ──────────────────────────────────────────────────────────────────
+    # Issue #113 — daily capacity-alarm digest
+    # ──────────────────────────────────────────────────────────────────
+
+    def _run_capacity_check(self):
+        """Daily capacity check (issue #113).
+
+        For every source with a completed scan history, run the linear
+        forecast. If ``capacity_alarm_at`` is set AND falls within
+        ``forecast.alarm_lead_days`` of today, batch the alert into a
+        single digest email to ``forecast.alarm_email``.
+
+        Returns a dict so the run-log is meaningful. Never raises —
+        scheduler retries tomorrow.
+        """
+        forecast_cfg = (self.config or {}).get("forecast") or {}
+        if not forecast_cfg.get("enabled", True):
+            return {"status": "skipped", "reason": "forecast.enabled=false"}
+        alarm_email = (forecast_cfg.get("alarm_email") or "").strip()
+        if not alarm_email:
+            return {"status": "skipped", "reason": "alarm_email empty"}
+        if self.email_notifier is None or not self.email_notifier.available:
+            return {"status": "skipped", "reason": "email_notifier unavailable"}
+
+        try:
+            lead_days = int(forecast_cfg.get("alarm_lead_days", 30))
+        except (TypeError, ValueError):
+            lead_days = 30
+        try:
+            pct = float(forecast_cfg.get("capacity_threshold_pct", 85))
+        except (TypeError, ValueError):
+            pct = 85.0
+        horizon_days = max(lead_days * 2, 90)  # always look further than the lead
+
+        # Disk total (best-effort) for the default threshold.
+        disk_total = 0
+        try:
+            import shutil as _shutil
+            import os as _os
+            target = _os.path.dirname(_os.path.abspath(self.db.db_path)) or "."
+            disk_total = int(_shutil.disk_usage(target).total)
+        except Exception:
+            disk_total = 0
+        threshold = int(disk_total * pct / 100.0) if disk_total > 0 else 0
+
+        try:
+            from src.reports.forecast import forecast_growth
+        except Exception as e:
+            logger.error("daily_capacity_check forecast import failed: %s", e)
+            return {"status": "error", "message": str(e)}
+
+        now = datetime.now()
+        alarmed: list = []
+        with self.db.get_cursor() as cur:
+            cur.execute("SELECT id, name FROM sources WHERE enabled = 1")
+            sources = [dict(r) for r in cur.fetchall()]
+        for src in sources:
+            sid = int(src["id"])
+            with self.db.get_cursor() as cur:
+                cur.execute(
+                    """
+                    SELECT started_at, total_size, total_files
+                    FROM scan_runs
+                    WHERE source_id = ?
+                      AND status = 'completed'
+                      AND total_size IS NOT NULL
+                      AND total_size > 0
+                    ORDER BY started_at ASC
+                    """,
+                    (sid,),
+                )
+                rows = [dict(r) for r in cur.fetchall()]
+            if not rows:
+                continue
+            try:
+                result = forecast_growth(
+                    rows, horizon_days=horizon_days,
+                    capacity_threshold_bytes=threshold or None,
+                    source_id=sid,
+                )
+            except Exception as e:
+                logger.warning("forecast failed for source %s: %s", sid, e)
+                continue
+            if not result.capacity_alarm_at:
+                continue
+            try:
+                alarm_dt = datetime.fromisoformat(result.capacity_alarm_at)
+            except Exception:
+                continue
+            days_to = (alarm_dt - now).days
+            if days_to > lead_days:
+                continue
+            alarmed.append({
+                "source_id": sid,
+                "source_name": src.get("name") or "?",
+                "alarm_at": result.capacity_alarm_at,
+                "days_to_alarm": days_to,
+                "predicted_bytes": int(result.predicted_bytes),
+                "last_bytes": int(result.last_bytes),
+                "samples_used": result.samples_used,
+            })
+
+        if not alarmed:
+            return {"status": "completed", "alarmed": 0,
+                    "checked_sources": len(sources)}
+
+        # Build a plain-text digest (HTML is optional; keep it simple).
+        lines = [
+            f"File Activity capacity forecast — {now.strftime('%Y-%m-%d')}",
+            f"Threshold: {pct:.1f}% of disk "
+            f"(~{threshold / (1024 ** 3):.1f} GiB)" if threshold else
+            "Threshold: per-request",
+            "",
+            "Sources approaching capacity within "
+            f"{lead_days} days:",
+            "",
+        ]
+        for a in alarmed:
+            lines.append(
+                f"  • [{a['source_id']}] {a['source_name']}: "
+                f"alarm {a['alarm_at']} ({a['days_to_alarm']}d) "
+                f"— last {a['last_bytes'] / (1024**3):.1f} GiB, "
+                f"projected {a['predicted_bytes'] / (1024**3):.1f} GiB"
+            )
+        body = "\n".join(lines)
+
+        # Use a minimal MIME-text send — EmailNotifier.send_user_report is
+        # tied to user-score reports; we just need a plain digest. Reuse
+        # its low-level SMTP plumbing.
+        try:
+            from email.mime.text import MIMEText
+            from email.utils import formataddr
+            msg = MIMEText(body, "plain", "utf-8")
+            subject_prefix = self.email_notifier.subject_prefix or "[File Activity]"
+            msg["Subject"] = (
+                f"{subject_prefix} Kapasite Uyarisi: "
+                f"{len(alarmed)} kaynak"
+            )
+            msg["From"] = formataddr(
+                (self.email_notifier.from_name, self.email_notifier.from_address)
+            )
+            msg["To"] = alarm_email
+            recipients = [alarm_email]
+            cc = (self.email_notifier.admin_cc or "").strip()
+            if cc and cc not in recipients:
+                msg["Cc"] = cc
+                recipients.append(cc)
+            with self.email_notifier._connect() as smtp:
+                smtp.sendmail(
+                    self.email_notifier.from_address,
+                    recipients,
+                    msg.as_string(),
+                )
+            logger.info(
+                "daily_capacity_check digest sent to %s (%d sources)",
+                alarm_email, len(alarmed),
+            )
+            return {
+                "status": "completed",
+                "alarmed": len(alarmed),
+                "checked_sources": len(sources),
+                "to": alarm_email,
+            }
+        except Exception as e:
+            logger.error("daily_capacity_check email send failed: %s", e)
+            return {"status": "error", "message": str(e),
+                    "alarmed": len(alarmed)}
+
+    def _register_capacity_check_job(self):
+        """Register the once-a-day capacity-alarm digest job (issue #113)."""
+        forecast_cfg = (self.config or {}).get("forecast") or {}
+        if not forecast_cfg.get("enabled", True):
+            logger.info("daily_capacity_check not registered: forecast.enabled=false")
+            return
+        if not (forecast_cfg.get("alarm_email") or "").strip():
+            logger.info(
+                "daily_capacity_check not registered: forecast.alarm_email empty"
+            )
+            return
+        # Run once a day at 03:15 — after the daily backup (02:00) so the
+        # snapshot reflects the freshest scans, before business hours.
+        try:
+            trigger = CronTrigger(minute="15", hour="3")
+            self.scheduler.add_job(
+                self._run_capacity_check,
+                trigger=trigger,
+                id="daily_capacity_check",
+                name="daily_capacity_check",
+                replace_existing=True,
+            )
+            logger.info("daily_capacity_check job registered (cron: 15 3 * * *)")
+        except Exception as e:
+            logger.error("Failed to register daily_capacity_check: %s", e)
 
     def reload_tasks(self):
         """Görevleri yeniden yükle."""

--- a/tests/test_forecast.py
+++ b/tests/test_forecast.py
@@ -1,0 +1,306 @@
+"""Tests for capacity / quota forecasting (issue #113).
+
+Pure-Python OLS regression — these tests pin the contract documented in
+``src/reports/forecast.py``:
+
+* n<3 returns ``predicted == last_value`` (no extrapolation)
+* alarm date when growth crosses the threshold
+* no alarm when slope <= 0
+* alarm == today when current size already exceeds threshold
+* high R² for clean linear data, low R² for random data
+* /api/forecast/{id} smoke test on a TestClient-built mini app
+"""
+
+from __future__ import annotations
+
+import math
+import os
+import random
+import sys
+from datetime import datetime, timedelta
+
+import pytest
+from fastapi import FastAPI, HTTPException
+from fastapi.testclient import TestClient
+
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if REPO_ROOT not in sys.path:
+    sys.path.insert(0, REPO_ROOT)
+
+from src.reports.forecast import ForecastResult, forecast_growth  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Fixture builders
+# ---------------------------------------------------------------------------
+
+
+def _series_linear(n: int, start_bytes: int, daily_bytes: int,
+                    start_dt: datetime | None = None,
+                    interval_days: int = 1) -> list:
+    """Build a perfectly-linear scan history."""
+    if start_dt is None:
+        start_dt = datetime(2025, 1, 1, 12, 0, 0)
+    return [
+        {
+            "started_at": (start_dt + timedelta(days=i * interval_days)).isoformat(),
+            "total_size_bytes": start_bytes + daily_bytes * i,
+        }
+        for i in range(n)
+    ]
+
+
+def _series_random(n: int, baseline: int, jitter: int, seed: int = 42) -> list:
+    rng = random.Random(seed)
+    start_dt = datetime(2025, 1, 1, 12, 0, 0)
+    return [
+        {
+            "started_at": (start_dt + timedelta(days=i)).isoformat(),
+            "total_size_bytes": baseline + rng.randint(-jitter, jitter),
+        }
+        for i in range(n)
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Issue #113 required tests
+# ---------------------------------------------------------------------------
+
+
+def test_forecast_with_3_points_returns_real_prediction():
+    """Three perfectly-linear points: predicted == intercept + slope*horizon_x.
+
+    Series: 100, 200, 300 GiB on consecutive days.
+    Slope = 100 GiB/day, intercept = 100 GiB at x=0.
+    Horizon 30 days from last (x=2): predicted = 100 + 100*32 = 3300 GiB.
+    """
+    GiB = 1024 ** 3
+    rows = _series_linear(3, start_bytes=100 * GiB, daily_bytes=100 * GiB)
+    r = forecast_growth(rows, horizon_days=30, source_id=7)
+
+    assert isinstance(r, ForecastResult)
+    assert r.samples_used == 3
+    # Slope ≈ 100 GiB/day.
+    assert math.isclose(r.slope_bytes_per_day, 100 * GiB, rel_tol=1e-9)
+    # Predicted size at horizon (last x = 2, plus 30 days = 32):
+    expected = 100 * GiB + 100 * GiB * 32
+    assert math.isclose(r.predicted_bytes, expected, rel_tol=1e-9)
+    # Perfect line -> r2 == 1.0 and residual_std == 0 -> CI collapses.
+    assert math.isclose(r.r_squared, 1.0, rel_tol=1e-9)
+    assert math.isclose(r.ci_low_bytes, expected, rel_tol=1e-9)
+    assert math.isclose(r.ci_high_bytes, expected, rel_tol=1e-9)
+    # History is materialised for the chart.
+    assert len(r.history) == 3
+    assert r.source_id == 7
+
+
+def test_forecast_with_2_points_returns_last_value():
+    """Two points fit a line trivially — pretending that's a real trend
+    leads to disastrous extrapolation. The contract is: hold the last value."""
+    rows = _series_linear(2, start_bytes=10_000, daily_bytes=5_000)
+    r = forecast_growth(rows, horizon_days=180)
+
+    assert r.samples_used == 2
+    last_value = rows[-1]["total_size_bytes"]
+    assert r.predicted_bytes == float(last_value)
+    assert r.ci_low_bytes == float(last_value)
+    assert r.ci_high_bytes == float(last_value)
+    assert r.r_squared == 0.0
+    assert r.capacity_alarm_at is None
+    # History still includes the two points so the chart can render them.
+    assert len(r.history) == 2
+
+
+def test_forecast_capacity_alarm_when_growth_crosses_threshold():
+    """Linear growth of 10 GiB/day from 100 GiB; threshold 200 GiB →
+    alarm hits ~10 days from start."""
+    GiB = 1024 ** 3
+    rows = _series_linear(5, start_bytes=100 * GiB, daily_bytes=10 * GiB)
+    threshold = 200 * GiB
+
+    r = forecast_growth(rows, horizon_days=30, capacity_threshold_bytes=threshold)
+    assert r.capacity_alarm_at is not None
+    # The 5 rows span days 0..4. Threshold of 200 GiB is hit at day 10
+    # (100 + 10*10 = 200) which is in the future relative to last (x=4).
+    alarm_date = datetime.fromisoformat(r.capacity_alarm_at)
+    first_dt = datetime(2025, 1, 1, 12, 0, 0)
+    days_offset = (alarm_date - first_dt.replace(hour=0, minute=0, second=0)).days
+    # Allow ±1 day for date-floor rounding.
+    assert 9 <= days_offset <= 11, (
+        f"alarm should be ~10 days from start, got {days_offset} ({alarm_date})"
+    )
+
+
+def test_forecast_no_alarm_when_growth_decreases():
+    """Negative slope (storage shrinking, e.g. cleanup running) should
+    NEVER raise an alarm — the projection only goes down."""
+    rows = _series_linear(6, start_bytes=500_000_000, daily_bytes=-10_000_000)
+    r = forecast_growth(rows, horizon_days=180,
+                        capacity_threshold_bytes=1_000_000_000)
+    assert r.slope_bytes_per_day < 0
+    assert r.capacity_alarm_at is None
+
+
+def test_forecast_no_alarm_when_threshold_already_exceeded():
+    """If the latest scan is already over the threshold, alarm is today
+    (operators want this surfaced immediately, not buried in the future)."""
+    rows = _series_linear(3, start_bytes=1_500_000_000, daily_bytes=1_000_000)
+    r = forecast_growth(rows, horizon_days=30,
+                        capacity_threshold_bytes=1_000_000_000)
+    assert r.capacity_alarm_at == datetime.utcnow().date().isoformat()
+
+
+def test_forecast_r_squared_high_for_linear_data():
+    rows = _series_linear(20, start_bytes=10 ** 9, daily_bytes=5 * 10 ** 7)
+    r = forecast_growth(rows, horizon_days=90)
+    assert r.samples_used == 20
+    assert r.r_squared > 0.999, f"perfectly linear should give r2 ~ 1.0, got {r.r_squared}"
+
+
+def test_forecast_r_squared_low_for_random_data():
+    rows = _series_random(40, baseline=10 ** 9, jitter=10 ** 8, seed=1)
+    r = forecast_growth(rows, horizon_days=90)
+    assert r.samples_used == 40
+    # Random noise around a flat baseline — slope ≈ 0, fit explains very little.
+    assert r.r_squared < 0.20, (
+        f"random data should give low r2, got {r.r_squared}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Manual fixture: 30-point linear series, prediction within 5%
+# ---------------------------------------------------------------------------
+
+
+def test_forecast_30_point_linear_within_5_percent():
+    """Issue #113 'manual fixture' check: 30-point linear series, the
+    predicted value must be within 5% of the analytic expected value."""
+    GiB = 1024 ** 3
+    start = 50 * GiB
+    daily = 2 * GiB
+    rows = _series_linear(30, start_bytes=start, daily_bytes=daily)
+    horizon = 60
+    r = forecast_growth(rows, horizon_days=horizon)
+    # last x = 29, horizon_x = 89  -> expected = start + daily * 89
+    expected = start + daily * (29 + horizon)
+    err = abs(r.predicted_bytes - expected) / expected
+    assert err < 0.05, f"prediction off by {err*100:.2f}% (expected {expected}, got {r.predicted_bytes})"
+
+
+# ---------------------------------------------------------------------------
+# API smoke test
+# ---------------------------------------------------------------------------
+
+
+def _build_mini_app(scan_history_by_source):
+    """A minimal FastAPI app that mirrors the dashboard's
+    /api/forecast/{source_id} contract — used to smoke-test the JSON shape
+    without standing up the full create_app() machinery."""
+    app = FastAPI()
+
+    @app.get("/api/forecast/{source_id}")
+    async def forecast(source_id: int, horizon_days: int = 180,
+                       threshold_bytes: int | None = None):
+        rows = scan_history_by_source.get(source_id)
+        if rows is None:
+            raise HTTPException(404, "source bulunamadi")
+        result = forecast_growth(
+            rows, horizon_days=horizon_days,
+            capacity_threshold_bytes=threshold_bytes,
+            source_id=source_id,
+        )
+        return result.to_dict()
+
+    return app
+
+
+def test_api_forecast_returns_expected_shape():
+    GiB = 1024 ** 3
+    rows = _series_linear(15, start_bytes=10 * GiB, daily_bytes=int(0.5 * GiB))
+    app = _build_mini_app({1: rows, 2: []})
+    client = TestClient(app)
+
+    r = client.get("/api/forecast/1?horizon_days=90")
+    assert r.status_code == 200
+    body = r.json()
+    # Required fields
+    for key in (
+        "source_id", "horizon_days", "predicted_bytes", "ci_low_bytes",
+        "ci_high_bytes", "samples_used", "r_squared", "capacity_alarm_at",
+        "history",
+    ):
+        assert key in body, f"missing {key}"
+    assert body["source_id"] == 1
+    assert body["horizon_days"] == 90
+    assert body["samples_used"] == 15
+    assert isinstance(body["history"], list)
+    assert len(body["history"]) == 15
+    for pt in body["history"]:
+        assert "ts" in pt and "bytes" in pt
+    # alarm not requested -> always None
+    assert body["capacity_alarm_at"] is None
+
+    # Empty source -> n=0 result
+    r = client.get("/api/forecast/2?horizon_days=30")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["samples_used"] == 0
+    assert body["history"] == []
+
+
+def test_api_forecast_with_threshold_query_param():
+    """Threshold passed via query string should drive the alarm field."""
+    GiB = 1024 ** 3
+    rows = _series_linear(10, start_bytes=200 * GiB, daily_bytes=20 * GiB)
+    app = _build_mini_app({5: rows})
+    client = TestClient(app)
+
+    threshold = 500 * GiB
+    r = client.get(f"/api/forecast/5?horizon_days=60&threshold_bytes={threshold}")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["capacity_alarm_at"] is not None  # 200 -> 380 by day 9, 500 around day 15
+
+
+# ---------------------------------------------------------------------------
+# Defensive parsing
+# ---------------------------------------------------------------------------
+
+
+def test_forecast_handles_total_size_alias():
+    """The DB column is ``total_size`` (not ``total_size_bytes``). The
+    helper must accept either."""
+    rows = []
+    base = datetime(2025, 1, 1)
+    for i in range(5):
+        rows.append({
+            "started_at": (base + timedelta(days=i)).isoformat(),
+            "total_size": 1_000 + 100 * i,
+        })
+    r = forecast_growth(rows, horizon_days=10)
+    assert r.samples_used == 5
+    assert r.slope_bytes_per_day == pytest.approx(100.0, rel=1e-9)
+
+
+def test_forecast_handles_descending_input():
+    """Caller may pass DESC-ordered rows — internally we re-sort."""
+    rows = _series_linear(5, start_bytes=1_000_000, daily_bytes=10_000)
+    rows_desc = list(reversed(rows))
+    r_asc = forecast_growth(rows, horizon_days=10)
+    r_desc = forecast_growth(rows_desc, horizon_days=10)
+    assert math.isclose(r_asc.predicted_bytes, r_desc.predicted_bytes, rel_tol=1e-9)
+    assert math.isclose(r_asc.slope_bytes_per_day, r_desc.slope_bytes_per_day,
+                        rel_tol=1e-9)
+
+
+def test_forecast_handles_sqlite_string_format():
+    """SQLite stores started_at as 'YYYY-MM-DD HH:MM:SS' (space, no T)."""
+    rows = [
+        {"started_at": "2025-01-01 12:00:00", "total_size_bytes": 100},
+        {"started_at": "2025-01-02 12:00:00", "total_size_bytes": 200},
+        {"started_at": "2025-01-03 12:00:00", "total_size_bytes": 300},
+        {"started_at": "2025-01-04 12:00:00", "total_size_bytes": 400},
+    ]
+    r = forecast_growth(rows, horizon_days=5)
+    assert r.samples_used == 4
+    assert r.slope_bytes_per_day == pytest.approx(100.0, rel=1e-9)


### PR DESCRIPTION
## Summary
Closes #113 — quota / capacity forecasting via stdlib OLS regression on `scan_runs` history. Predicts when share will hit `forecast.capacity_threshold_pct` (default 85%); daily digest email when alarm <30 days out.

- **`src/reports/forecast.py`** (NEW) — `forecast_growth()` + `ForecastResult` dataclass; pure stdlib OLS (no numpy/pandas), 95% CI from residual std, `capacity_alarm_at` solves `intercept + slope*t = threshold`.
- **API**: `GET /api/forecast/{source_id}?horizon_days=180`, `GET /api/forecast/{source_id}/export.xlsx`. `/api/system/health` extended with `disk.{total,used,free}_bytes`.
- **Scheduler**: `_run_capacity_check` daily digest job at 03:15 (after 02:00 backup). Cascading guards: `forecast.enabled`, `alarm_email`, `email_notifier.available` — any one off disables the job silently.
- **Frontend**: new "Quota Forecast" page under "Raporlar". Visual = Chart.js time-series with 95% CI projection cone + KPI banner. Profesyonel = entity-list of monthly milestones. Threshold input recomputes alarm date client-side.
- **Config**: `forecast:` block (enabled, default_horizon_days, capacity_threshold_pct, alarm_email, alarm_lead_days).

## Decisions
- **n<3 path**: returns `predicted == ci_low == ci_high == last_value`, `r_squared = 0`, no extrapolation. Alarm only fires if last value already exceeds threshold.
- **CI calc**: literal `1.96` z-score (per spec) — understates true PI for n<30 but only affects the chart shaded band, not the alarm decision.
- **Email cron**: 03:15 (after backup, before business hours).
- **Source dedup** in `_normalise_history`: same `started_at` → keep larger `total_size`.
- **Rebase resolution**: 3-way with hotfix (#119) + #110 + #117 already in master.

## Test plan
- [x] `tests/test_forecast.py` — 13/13 pass
- [x] Full suite: 338 passed, 6 skipped
- [x] Manual: 30-day +2 GiB/day fixture, 60-day horizon → predicted within 5% of analytic expected (actually 0% on perfectly linear data)

https://claude.ai/code/session_8a4c57f4-b4b4-49b7-ad67-2266794b535c

---
_Generated by [Claude Code](https://claude.ai/code/session_01A1UzS1A4DZNk1akoP4uhZ7)_