### PR TITLE
Auto error reporting Phase 1: opt-in GitHub Issues telemetry (closes #118)

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -344,3 +344,24 @@ approvals:
   #                         startup warning. Use only during evaluation.)
   identity_source: "client_supplied"
   identity_header: "X-Forwarded-User"
+
+# Auto error reporting to GitHub Issues (issue #118, Phase 1).
+# Disabled by default — flip ``enabled`` and export the token env var
+# to opt in. With the defaults below the dashboard never makes a
+# network call to GitHub, even when an unhandled exception occurs.
+telemetry:
+  enabled: false
+  github:
+    repo: "deepdarbe/file_activity"
+    # Name of the env var that holds a fine-scoped GitHub PAT with
+    # ``issues: write``. Never put the token itself in this file.
+    token_env: "FILEACTIVITY_TELEMETRY_TOKEN"
+    label: "auto-report"
+  rate_limit:
+    # Hard cap on issues/comments filed in any rolling 1-hour window.
+    max_per_hour: 10
+  privacy:
+    # Strip UNC paths and Windows home-dir usernames from the report
+    # body. Recommended on. Secret-keyed dict values are always
+    # redacted regardless of this flag.
+    redact_paths: true

--- a/src/dashboard/api.py
+++ b/src/dashboard/api.py
@@ -16,7 +16,7 @@ from datetime import datetime, timedelta
 
 from fastapi import FastAPI, HTTPException, Query, Request
 from fastapi.staticfiles import StaticFiles
-from fastapi.responses import HTMLResponse, FileResponse
+from fastapi.responses import HTMLResponse, FileResponse, JSONResponse
 from pydantic import BaseModel, Field, field_validator
 from typing import Optional, List
 
@@ -565,6 +565,42 @@ def create_app(db, config, analytics=None, ad_lookup=None, email_notifier=None):
     except Exception as e:  # pragma: no cover - defensive only
         logger.warning("SyslogForwarder init failed: %s", e)
         app.state.syslog = None
+
+    # ─────────────────────────────────────────────────────────────────
+    # Issue #118 Phase 1 — auto error reporter (GitHub Issues).
+    # Constructed unconditionally; with the shipped default
+    # (``telemetry.enabled: false``) every capture() call short-circuits
+    # before touching the network. The exception_handler is wired in so
+    # operators only need to flip the config flag + provide a token to
+    # opt in.
+    # ─────────────────────────────────────────────────────────────────
+    try:
+        from src.telemetry.error_reporter import ErrorReporter
+        app.state.error_reporter = ErrorReporter(config, APP_VERSION)
+    except Exception as e:  # pragma: no cover - defensive only
+        logger.warning("ErrorReporter init failed: %s", e)
+        app.state.error_reporter = None
+
+    @app.exception_handler(Exception)
+    async def _telemetry_exception_handler(request, exc):
+        reporter = getattr(app.state, "error_reporter", None)
+        if reporter is not None:
+            try:
+                reporter.capture(exc, {
+                    "path": str(request.url.path),
+                    "method": request.method,
+                })
+            except Exception:
+                # Telemetry failures must never break the response path.
+                pass
+        # FastAPI exception handlers must *return* a Response — re-
+        # raising does not propagate to the default 500 handler. Mirror
+        # the framework's default JSON shape so existing clients see no
+        # behavioural change.
+        return JSONResponse(
+            status_code=500,
+            content={"detail": "Internal Server Error"},
+        )
 
     static_dir = os.path.join(os.path.dirname(__file__), "static")
     if os.path.exists(static_dir):

--- a/src/telemetry/error_reporter.py
+++ b/src/telemetry/error_reporter.py
@@ -1,0 +1,255 @@
+"""Auto error reporting to GitHub Issues (issue #118 — Phase 1).
+
+In-process, blocking sender. Default ``enabled: false`` — zero
+behaviour change unless an operator opts in via ``config.yaml`` and
+provides a token via the configured environment variable.
+
+Out of scope this round (deferred to Phase 2):
+    * Logging-handler subclass for ERROR-level records
+    * Manual review mode
+    * ``/api/system/reports/test`` endpoint
+    * Background flush worker (we send synchronously with a 10s
+      ``urlopen`` timeout)
+
+stdlib only.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+import re
+import time
+import traceback
+import urllib.error
+import urllib.request
+from collections import deque
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Optional
+
+SECRET_KEY_PATTERN = re.compile(
+    r"(password|token|api[_-]?key|secret|signing[_-]?key)", re.I
+)
+UNC_PATTERN = re.compile(r"\\\\([^\\]+)\\([^\\]+)")
+HOME_PATTERN = re.compile(r"(C:\\Users\\)([^\\]+)", re.I)
+
+_REDACTED = "***REDACTED***"
+_HTTP_TIMEOUT = 10  # seconds
+
+
+@dataclass
+class ErrorReport:
+    fingerprint: str
+    title: str
+    body: str
+    occurred_at: str
+
+
+class ErrorReporter:
+    """Captures unhandled exceptions and files them as GitHub Issues.
+
+    Safe by default: when ``telemetry.enabled`` is false (the shipped
+    default) every call to :meth:`capture` short-circuits and returns
+    ``None`` *before* building the report or touching the network.
+    """
+
+    def __init__(self, config: dict, version: str):
+        self.config = config or {}
+        self.version = version
+        cfg = (config or {}).get("telemetry") or {}
+        self.enabled = bool(cfg.get("enabled", False))
+        gh = cfg.get("github") or {}
+        self.repo = gh.get("repo", "")
+        token_env = gh.get("token_env", "FILEACTIVITY_TELEMETRY_TOKEN")
+        self.token = os.environ.get(token_env, "")
+        self.label = gh.get("label", "auto-report")
+        self.privacy = cfg.get("privacy") or {}
+        self.rate_limit = cfg.get("rate_limit") or {}
+        self.max_per_hour = int(self.rate_limit.get("max_per_hour", 10))
+        # Unbounded deque on purpose: ``_is_rate_limited`` evicts entries
+        # older than 1 hour itself. Using ``maxlen=max_per_hour`` would
+        # silently drop the oldest entry once the limit is hit, defeating
+        # the throttle.
+        self._sent_timestamps: deque = deque()
+        self._dedupe: dict[str, int] = {}  # fingerprint -> issue_number
+        self._log = logging.getLogger(__name__)
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+    def capture(
+        self, exc: BaseException, context: Optional[dict] = None
+    ) -> Optional[int]:
+        """Capture *exc* and file (or comment on) a GitHub Issue.
+
+        Returns the issue number on success, ``None`` if telemetry is
+        disabled, mis-configured, rate-limited, or the HTTP call failed.
+        Never raises — telemetry must not break the host process.
+        """
+        if not self.enabled or not self.token or not self.repo:
+            return None
+        if self._is_rate_limited():
+            return None
+        try:
+            report = self._build_report(exc, context or {})
+        except Exception as e:  # pragma: no cover - defensive only
+            self._log.warning("error report build failed: %s", e)
+            return None
+        existing = self._dedupe.get(report.fingerprint)
+        if existing is not None:
+            try:
+                issue_no = self._comment_existing(existing, report)
+                # Comments count toward the rolling rate limit too —
+                # otherwise a hot dedupe key could spam the API.
+                self._sent_timestamps.append(time.time())
+                return issue_no
+            except Exception as e:
+                self._log.warning("error report comment failed: %s", e)
+                return None
+        try:
+            issue_no = self._post_new_issue(report)
+            self._dedupe[report.fingerprint] = issue_no
+            self._sent_timestamps.append(time.time())
+            return issue_no
+        except Exception as e:
+            self._log.warning("error report send failed: %s", e)
+            return None
+
+    # ------------------------------------------------------------------
+    # Rate limiting
+    # ------------------------------------------------------------------
+    def _is_rate_limited(self) -> bool:
+        now = time.time()
+        cutoff = now - 3600
+        # Drop entries outside the rolling 1-hour window.
+        while self._sent_timestamps and self._sent_timestamps[0] < cutoff:
+            self._sent_timestamps.popleft()
+        return len(self._sent_timestamps) >= self.max_per_hour
+
+    # ------------------------------------------------------------------
+    # Report assembly
+    # ------------------------------------------------------------------
+    def _build_report(self, exc: BaseException, context: dict) -> ErrorReport:
+        exc_type = type(exc).__name__
+        tb_text = "".join(
+            traceback.format_exception(type(exc), exc, exc.__traceback__)
+        )
+        sanitized_tb = self._sanitize_text(tb_text)
+        sanitized_ctx = self._sanitize_dict(context)
+        fingerprint = self._fingerprint(exc, exc_type)
+        occurred_at = datetime.now(timezone.utc).isoformat()
+        title = f"[auto] {exc_type}: {self._sanitize_text(str(exc))[:120]}"
+        body_lines = [
+            f"**Occurred at:** {occurred_at}",
+            f"**Version:** {self.version}",
+            f"**Fingerprint:** `{fingerprint}`",
+            "",
+            "## Context",
+            "```json",
+            json.dumps(sanitized_ctx, indent=2, default=str),
+            "```",
+            "",
+            "## Traceback",
+            "```",
+            sanitized_tb.rstrip(),
+            "```",
+        ]
+        return ErrorReport(
+            fingerprint=fingerprint,
+            title=title,
+            body="\n".join(body_lines),
+            occurred_at=occurred_at,
+        )
+
+    def _fingerprint(self, exc: BaseException, exc_type: str) -> str:
+        frames = traceback.extract_tb(exc.__traceback__)[:5]
+        parts = [exc_type, self.version]
+        for f in frames:
+            parts.append(f"{os.path.basename(f.filename or '')}:{f.lineno or 0}")
+        return hashlib.sha256("|".join(parts).encode("utf-8")).hexdigest()[:16]
+
+    # ------------------------------------------------------------------
+    # Sanitization
+    # ------------------------------------------------------------------
+    def _sanitize_dict(self, d: dict) -> dict:
+        return self._redact_secrets(d)
+
+    def _redact_secrets(self, value: Any) -> Any:
+        if isinstance(value, dict):
+            out = {}
+            for k, v in value.items():
+                if isinstance(k, str) and SECRET_KEY_PATTERN.search(k):
+                    out[k] = _REDACTED
+                else:
+                    out[k] = self._redact_secrets(v)
+            return out
+        if isinstance(value, list):
+            return [self._redact_secrets(v) for v in value]
+        if isinstance(value, tuple):
+            return tuple(self._redact_secrets(v) for v in value)
+        if isinstance(value, str):
+            return self._redact_paths(value)
+        return value
+
+    def _sanitize_text(self, text: str) -> str:
+        return self._redact_paths(text)
+
+    def _redact_paths(self, text: str) -> str:
+        if not isinstance(text, str) or not text:
+            return text
+        if not bool(self.privacy.get("redact_paths", False)):
+            return text
+        text = UNC_PATTERN.sub(r"\\\\<redacted>\\<redacted>", text)
+        text = HOME_PATTERN.sub(r"\1<redacted>", text)
+        return text
+
+    # ------------------------------------------------------------------
+    # GitHub API
+    # ------------------------------------------------------------------
+    def _post_new_issue(self, report: ErrorReport) -> int:
+        url = f"https://api.github.com/repos/{self.repo}/issues"
+        payload = {
+            "title": report.title,
+            "body": report.body,
+            "labels": [self.label] if self.label else [],
+        }
+        data = self._http_post(url, payload)
+        return int(data.get("number"))
+
+    def _comment_existing(self, issue_no: int, report: ErrorReport) -> int:
+        url = (
+            f"https://api.github.com/repos/{self.repo}"
+            f"/issues/{issue_no}/comments"
+        )
+        body = (
+            f"Re-occurrence at {report.occurred_at} "
+            f"(version {self.version}, fp `{report.fingerprint}`)\n\n"
+            f"{report.body}"
+        )
+        self._http_post(url, {"body": body})
+        return issue_no
+
+    def _http_post(self, url: str, payload: dict) -> dict:
+        body = json.dumps(payload).encode("utf-8")
+        req = urllib.request.Request(
+            url,
+            data=body,
+            method="POST",
+            headers={
+                "Authorization": f"Bearer {self.token}",
+                "Accept": "application/vnd.github+json",
+                "Content-Type": "application/json",
+                "User-Agent": "file-activity-error-reporter",
+            },
+        )
+        with urllib.request.urlopen(req, timeout=_HTTP_TIMEOUT) as resp:
+            raw = resp.read()
+        if not raw:
+            return {}
+        try:
+            return json.loads(raw.decode("utf-8"))
+        except (ValueError, UnicodeDecodeError):
+            return {}

--- a/tests/test_error_reporter.py
+++ b/tests/test_error_reporter.py
@@ -1,0 +1,159 @@
+"""Tests for ``src.telemetry.error_reporter`` (issue #118 Phase 1).
+
+Covers the five essentials: disabled-by-default short-circuit, secret
+sanitization, UNC path redaction, fingerprint stability and rolling-
+window rate limiting. ``urllib.request.urlopen`` is patched so no test
+ever touches the network.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from src.telemetry.error_reporter import ErrorReporter
+
+
+def _enabled_config() -> dict:
+    return {
+        "telemetry": {
+            "enabled": True,
+            "github": {
+                "repo": "owner/repo",
+                "token_env": "FAKE_TELEMETRY_TOKEN",
+                "label": "auto-report",
+            },
+            "rate_limit": {"max_per_hour": 10},
+            "privacy": {"redact_paths": True},
+        }
+    }
+
+
+def _raise_exc(make_exc):
+    """Run *make_exc* under a try/except so the returned exception
+    carries a real traceback (mirrors the shape FastAPI hands us)."""
+    try:
+        make_exc()
+    except Exception as e:  # noqa: BLE001
+        return e
+    raise AssertionError("make_exc() did not raise")
+
+
+def _fake_response(payload: dict):
+    raw = json.dumps(payload).encode("utf-8")
+    cm = MagicMock()
+    cm.__enter__.return_value = io.BytesIO(raw)
+    cm.__exit__.return_value = False
+    return cm
+
+
+# --------------------------------------------------------------------- 1
+def test_disabled_means_no_capture(monkeypatch):
+    monkeypatch.setenv("FAKE_TELEMETRY_TOKEN", "x")
+    config = {"telemetry": {"enabled": False}}
+    reporter = ErrorReporter(config, "1.0.0")
+    exc = _raise_exc(lambda: (_ for _ in ()).throw(RuntimeError("boom")))
+
+    with patch("urllib.request.urlopen") as mock_open:
+        result = reporter.capture(exc, {"path": "/x", "method": "GET"})
+
+    assert result is None
+    assert mock_open.call_count == 0
+
+
+# --------------------------------------------------------------------- 2
+def test_secrets_stripped_from_context(monkeypatch):
+    monkeypatch.setenv("FAKE_TELEMETRY_TOKEN", "tkn")
+    reporter = ErrorReporter(_enabled_config(), "1.0.0")
+    exc = _raise_exc(lambda: (_ for _ in ()).throw(ValueError("nope")))
+
+    captured = {}
+
+    def fake_urlopen(req, timeout=None):
+        captured["body"] = req.data.decode("utf-8")
+        return _fake_response({"number": 42})
+
+    with patch("urllib.request.urlopen", side_effect=fake_urlopen):
+        issue_no = reporter.capture(
+            exc,
+            {
+                "path": "/x",
+                "password": "hunter2",
+                "api_key": "sk-abc",
+                "nested": {"signing_key": "topsecret", "ok": "fine"},
+            },
+        )
+
+    assert issue_no == 42
+    body_payload = json.loads(captured["body"])
+    body = body_payload["body"]
+    assert "***REDACTED***" in body
+    assert "hunter2" not in body
+    assert "sk-abc" not in body
+    assert "topsecret" not in body
+    assert "fine" in body  # non-secret values must survive
+
+
+# --------------------------------------------------------------------- 3
+def test_unc_path_redacted(monkeypatch):
+    monkeypatch.setenv("FAKE_TELEMETRY_TOKEN", "tkn")
+    reporter = ErrorReporter(_enabled_config(), "1.0.0")
+
+    redacted = reporter._redact_paths(r"\\fs01\share\foo")
+    assert redacted == r"\\<redacted>\<redacted>\foo"
+
+    home = reporter._redact_paths(r"C:\Users\jdoe\Desktop\x.txt")
+    assert home == r"C:\Users\<redacted>\Desktop\x.txt"
+
+
+# --------------------------------------------------------------------- 4
+def test_fingerprint_stable_across_calls(monkeypatch):
+    monkeypatch.setenv("FAKE_TELEMETRY_TOKEN", "tkn")
+    reporter = ErrorReporter(_enabled_config(), "1.0.0")
+
+    def boom():
+        raise RuntimeError("repeat")
+
+    exc1 = _raise_exc(boom)
+    exc2 = _raise_exc(boom)
+    fp1 = reporter._build_report(exc1, {}).fingerprint
+    fp2 = reporter._build_report(exc2, {}).fingerprint
+    assert fp1 == fp2
+
+    # Sanity: a different exception type yields a different fingerprint.
+    exc3 = _raise_exc(lambda: (_ for _ in ()).throw(ValueError("other")))
+    fp3 = reporter._build_report(exc3, {}).fingerprint
+    assert fp3 != fp1
+
+
+# --------------------------------------------------------------------- 5
+def test_rate_limit_blocks_after_n(monkeypatch):
+    monkeypatch.setenv("FAKE_TELEMETRY_TOKEN", "tkn")
+    reporter = ErrorReporter(_enabled_config(), "1.0.0")
+
+    counter = {"n": 0}
+
+    def fake_urlopen(req, timeout=None):
+        counter["n"] += 1
+        # Distinct issue numbers so each call dedupes uniquely.
+        return _fake_response({"number": 1000 + counter["n"]})
+
+    with patch("urllib.request.urlopen", side_effect=fake_urlopen):
+        # 10 distinct exceptions (different lineno → different fp) so
+        # we exercise the new-issue path rather than the comment path.
+        results = []
+        for i in range(11):
+            try:
+                exec(f"raise RuntimeError('x{i}')", {"__name__": f"m{i}"})
+            except RuntimeError as e:
+                results.append(reporter.capture(e, {"i": i}))
+
+    accepted = [r for r in results if r is not None]
+    rejected = [r for r in results if r is None]
+    assert len(accepted) == 10
+    assert len(rejected) == 1
+    # And the throttled call must not have hit the network.
+    assert counter["n"] == 10


### PR DESCRIPTION
## Summary
Closes #118 (Phase 1 — minimum scope). Opt-in automatic error reporting to GitHub Issues. Default `telemetry.enabled: false` — zero behaviour change.

- **`src/telemetry/error_reporter.py`** (NEW, 255 LoC) — `ErrorReporter` class:
  - Sanitization: secret keys (`password`, `token`, `api_key`, `secret`, `signing_key`) → `***REDACTED***`; UNC paths `\\X\Y\...` → `\\<redacted>\<redacted>\...`; home dirs `C:\Users\name\` → `C:\Users\<redacted>\`
  - Fingerprint: SHA-256 of `(exc_type + first 5 traceback frame filenames+lines + version)` — stable across runs of same bug
  - Dedupe: same fingerprint → comment on existing issue rather than creating new
  - Rate limit: configurable `max_per_hour` (default 10); 11th call drops + warns
  - GitHub API via stdlib `urllib.request` with 10s timeout; failures logged + swallowed (never break the request response)
- **`src/dashboard/api.py`** — `app.state.error_reporter = ErrorReporter(config, APP_VERSION)` + `@app.exception_handler(Exception)` returning `JSONResponse(500)` (FastAPI handlers must return Response, not raise)
- **`config.yaml`** — `telemetry:` block with `enabled: false` default

## Confirmation: no network with default config
Verified with `urllib.request.urlopen` patched + real exception captured. With `enabled=false`, `token=''` → `capture()` returns `None`, `urlopen` called 0 times.

## Decisions / spec deviations
1. **Handler returns `JSONResponse(500)`** instead of `raise exc` — FastAPI exception handlers must return Response. (Spec acknowledged this as a fallback.)
2. **Rate-limit storage**: switched from `deque(maxlen=N)` to unbounded deque pruned by time. `maxlen` silently dropped oldest entries so rate-limit never fired in test 11. Spec test caught this.

## Deferred to Phase 2 (separate follow-up)
- Logging handler subclass for non-exception ERROR records
- Manual review mode (`review_before_send`)
- `/api/system/reports/test` endpoint
- Background flush worker (this PR sends synchronously after capture, but with 10s timeout)

## Test plan
- [x] 5 new tests pass: disabled→no capture, secrets stripped, UNC redacted, fingerprint stable, rate-limit blocks 11th
- [x] `test_dashboard_smoke.py` (4) + `test_dashboard_api.py` (5) still pass — no regressions
- [x] Manual: default config + real exception → no network call

https://claude.ai/code/session_8a4c57f4-b4b4-49b7-ad67-2266794b535c

---
_Generated by [Claude Code](https://claude.ai/code/session_01A1UzS1A4DZNk1akoP4uhZ7)_