### PR TITLE
GitHub security: Dependabot + CodeQL workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,35 +1,64 @@
 version: 2
+# Dependabot config: weekly Monday 09:00 Europe/Istanbul scan across all
+# ecosystems used in this repo. The pip block uses a single entry rooted
+# at "/" — Dependabot auto-discovers every requirements*.txt at that path
+# (requirements.txt, requirements-accel.txt, requirements-mcp.txt,
+# requirements-dev.txt, requirements-playground.txt) so we don't have to
+# enumerate them individually and keep the config in sync as files move.
+# Open-PR limit of 5 per ecosystem caps weekly noise.
 updates:
-  # Python requirements.txt: haftalik guncelleme taramasi
+  # Python dependencies (all requirements*.txt at repo root)
   - package-ecosystem: pip
-    directory: /
+    directory: "/"
     schedule:
       interval: weekly
       day: monday
-      time: "04:00"
+      time: "09:00"
       timezone: Europe/Istanbul
     open-pull-requests-limit: 5
     labels:
       - dependencies
-      - python
+    reviewers:
+      - deepdarbe
     commit-message:
       prefix: deps
       include: scope
     groups:
-      # Hep birlikte gidenler icin tek PR (patch upgrade gruplamasi)
+      # Group patch-level bumps into a single PR to reduce review load.
       patch-updates:
         update-types:
           - patch
 
-  # GitHub Actions workflow versiyonlari
+  # GitHub Actions workflow versions
   - package-ecosystem: github-actions
-    directory: /
+    directory: "/"
     schedule:
-      interval: monthly
-    open-pull-requests-limit: 3
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: Europe/Istanbul
+    open-pull-requests-limit: 5
     labels:
       - dependencies
-      - ci
+    reviewers:
+      - deepdarbe
     commit-message:
       prefix: ci
+      include: scope
+
+  # Docker base image for the test container (docker/Dockerfile.test, #92)
+  - package-ecosystem: docker
+    directory: "/docker"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: Europe/Istanbul
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+    reviewers:
+      - deepdarbe
+    commit-message:
+      prefix: docker
       include: scope

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,54 @@
+name: CodeQL
+
+# CodeQL static-analysis scan for Python (server, CLI, dev_server) and
+# JavaScript (the dashboard HTML/JS). Runs on every push/PR to master and
+# on a weekly schedule so we catch advisories that land between commits.
+#
+# `continue-on-error: true` is intentional for the initial rollout — we
+# don't yet know what existing findings look like and we don't want to
+# block PR merges on a noisy first scan. Flip to `false` once the
+# baseline is clean (or after explicit findings are triaged / dismissed).
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+  schedule:
+    # Mondays 06:00 UTC ~= 09:00 Europe/Istanbul, matching dependabot cadence.
+    - cron: "0 6 * * 1"
+
+# Cancel an in-flight CodeQL run for the same ref when a new commit lands —
+# the older SHA's findings would be stale anyway.
+concurrency:
+  group: codeql-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  security-events: write
+  actions: read
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    # Advisory until baseline findings are triaged. See header comment.
+    continue-on-error: true
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [python, javascript]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 **Windows File Share Analysis, Archiving & Compliance System**
 
+[![CodeQL](https://github.com/deepdarbe/FILE_ACTIVITY/actions/workflows/codeql.yml/badge.svg?branch=master)](https://github.com/deepdarbe/FILE_ACTIVITY/actions/workflows/codeql.yml)
+
 [🇹🇷 Türkçe](#-türkçe) | [🇬🇧 English](#-english)
 
 ---


### PR DESCRIPTION
## Summary
GitHub security automation — Dependabot + CodeQL.

- **`.github/dependabot.yml`** rewritten: weekly Mondays 09:00 Istanbul, max 5 PRs/ecosystem, `dependencies` label, reviewer `deepdarbe`. Single `pip` entry at `directory: "/"` (auto-discovers all 5 `requirements*.txt`). Docker entry at `/docker`. GitHub Actions ecosystem covered. Existing `patch-updates` group preserved (reduces PR volume).
- **`.github/workflows/codeql.yml`** (NEW): CodeQL analysis for `python` + `javascript`. Runs on push to master, PR to master, weekly Mon 06:00 UTC (~09:00 Istanbul, aligned with Dependabot review window). Concurrency-grouped. `continue-on-error: true` initially.
- **README.md**: CodeQL badge added at top.

## Test plan
- [x] Both YAML files pass `yaml.safe_load`
- [x] Existing `ci.yml` workflow untouched
- [x] Pinned action versions (@v4, @v3)
- [ ] First Dependabot run (week after merge): inspect any PR opened, verify label + reviewer

## Decisions
- **Single pip entry**: Dependabot auto-discovers all 5 requirement files via repo scan — simpler than 5 duplicate blocks that need to stay in sync.
- **CodeQL `continue-on-error: true` initially**: until we know what existing findings look like. Flip to gating after first clean run.

https://claude.ai/code/session_da1e681c-07bf-426c-be53-42b5baa2a1e9

---
_Generated by [Claude Code](https://claude.ai/code/session_01A1UzS1A4DZNk1akoP4uhZ7)_