### PR TITLE
docs/: operator runbook + troubleshooting + release notes + 5 discussion seed files

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,43 @@
+# FILE ACTIVITY — Docs
+
+Operatör + topluluk dokümantasyon dizini.
+
+## İşletim
+
+- [`operator-runbook.md`](operator-runbook.md) — Kurulum, güncelleme,
+  sık senaryolar, performans, yedekleme/kurtarma, sorun giderme
+- [`troubleshooting.md`](troubleshooting.md) — "X oluyor → Y yap"
+  decision tree
+
+## Sürüm notları
+
+- [`release-notes/v1.9.0-rc1.md`](release-notes/v1.9.0-rc1.md) —
+  47 PR + 4 direkt commit, customer prod RC
+
+## Topluluk tartışmaları (seed)
+
+GitHub Discussions'a manuel açılacak başlıklar — `cat` ile body'sini
+kopyala, GitHub UI'ya yapıştır:
+
+- [`discussions/01-welcome-v1.9.0-rc1.md`](discussions/01-welcome-v1.9.0-rc1.md)
+  — Announcements
+- [`discussions/02-operator-runbook.md`](discussions/02-operator-runbook.md)
+  — Q&A
+- [`discussions/03-roadmap-brainstorm.md`](discussions/03-roadmap-brainstorm.md)
+  — Ideas
+- [`discussions/04-show-and-tell.md`](discussions/04-show-and-tell.md)
+  — Show and tell
+- [`discussions/05-performance-benchmarks.md`](discussions/05-performance-benchmarks.md)
+  — General
+
+## Diğer
+
+- [`mcp_server.md`](mcp_server.md) — MCP sunucu referansı
+- [`playground.md`](playground.md) — Streamlit analytics playground
+
+## Kaynak dokümanlar (kök)
+
+- [`../README.md`](../README.md) — Proje özeti
+- [`../ROADMAP.md`](../ROADMAP.md) — Roadmap (single source of truth)
+- [`../CONTRIBUTING.md`](../CONTRIBUTING.md)
+- [`../SECURITY.md`](../SECURITY.md)

--- a/docs/discussions/01-welcome-v1.9.0-rc1.md
+++ b/docs/discussions/01-welcome-v1.9.0-rc1.md
@@ -1,0 +1,46 @@
+---
+category: Announcements
+title: "v1.9.0-rc1 Release Candidate"
+---
+
+# v1.9.0-rc1 Release Candidate
+
+Selam topluluk!
+
+`v1.9.0-rc1` etiketini master'a bastık — **47 PR + 4 direkt commit**.
+Şu an müşteri prod testindeyiz; geri dönüşler gelirse rc2 ile
+toparlayıp final `v1.9.0`'a geçeceğiz.
+
+## Highlights
+
+- **Hyperscan PII** — Linux'ta default `re`'ye göre **11x** hızlanma
+  (Windows fallback `re`)
+- **Auto-backup** Phase 1 + **opt-in auto-restore** corruption durumunda
+- **9 yeni dashboard sayfası** — Security (Orphan SIDs, Ransomware,
+  ACL), Compliance (PII findings, Retention, Legal Holds),
+  Integrations (Syslog, MCP) + System (Backups)
+- **Sidebar responsive** — scroll, search, collapse, narrow + mobile
+  hamburger
+- **MFT scanner incremental progress** + phase reporting
+- **Streamlit analytics playground** (opt-in, read-only, admin-only)
+- **Two-person approval framework** Phase 1
+- **Chargeback / cost-center raporu** Phase 1
+- **Quota / capacity forecast**
+
+Tam liste: [Release notes](../release-notes/v1.9.0-rc1.md).
+
+## Yükseltme
+
+```cmd
+C:\FileActivity\update.cmd
+```
+
+Snapshot otomatik. Veri / config / log korunur. Sidebar üst sol köşede
+`1.9.0-rc1 (<sha>)` görünmeli.
+
+## Sıradaki
+
+- rc2 (varsa) — müşteri test bulguları
+- post-rc1 ideas: [Roadmap brainstorm tartışması](03-roadmap-brainstorm.md)
+
+Test eden, hata bulan, "şu da olsa" diyen — buraya yazın.

--- a/docs/discussions/02-operator-runbook.md
+++ b/docs/discussions/02-operator-runbook.md
@@ -1,0 +1,64 @@
+---
+category: Q&A
+title: "Operator runbook — common scenarios"
+---
+
+# Operator runbook — sık senaryolar
+
+Sahada en sık karşılaşılan 4 durumu tek başlık altında topladım. Tam
+runbook: [`../operator-runbook.md`](../operator-runbook.md).
+
+## 1. WAL şişti, dashboard hung
+
+**Belirti:** `data/file_activity.db-wal` 1 GB+ , dashboard "Yükleniyor..."
+takılı.
+
+**Çözüm:**
+
+```powershell
+Stop-Service FileActivity   # ya da: taskkill /F /IM FileActivity.exe
+sqlite3 C:\FileActivity\data\file_activity.db "PRAGMA wal_checkpoint(TRUNCATE);"
+Start-Service FileActivity
+```
+
+Tekrar ediyorsa scan/archive zamanlamasını üst üste koyma.
+
+## 2. Snapshot manuel
+
+Riskli işlemden önce manuel backup:
+
+```bash
+curl -X POST http://localhost:8085/api/backup/run
+```
+
+`InstallDir\backups\file_activity_<TIMESTAMP>.db` üretir (SQLite Online
+Backup API — DB kapatmaya gerek yok).
+
+## 3. Tarama durdur
+
+Yanlış kaynak / prod saatleri / herhangi bir sebep:
+
+```bash
+curl -X POST http://localhost:8085/api/scan/{source_id}/stop
+```
+
+PR #134 sonrası: cancel flag worker tarafından her batch sonunda
+kontrol edilir. ~5-10 sn'de durur.
+
+## 4. Eski tarama temizliği
+
+Son N taramayı tut, gerisini sil:
+
+```bash
+curl -X POST "http://localhost:8085/api/scans/cleanup?keep_last=5"
+```
+
+`keep_last=0` legal (#133/#134) — "tüm taramalar". Eski build'de 422
+döner, `update.cmd` çalıştır.
+
+## Soru / paylaşım
+
+- Hangi senaryoda runbook seni bıraktı? Yorumda yaz, runbook'a
+  ekleyelim.
+- Sizin shop'ta WAL ne sıklıkta şişiyor — günlük? haftalık?
+- Cleanup için `keep_last` kaç tutuyorsunuz?

--- a/docs/discussions/03-roadmap-brainstorm.md
+++ b/docs/discussions/03-roadmap-brainstorm.md
@@ -1,0 +1,47 @@
+---
+category: Ideas
+title: "Roadmap brainstorm — sonraki 3 ay"
+---
+
+# Roadmap brainstorm — sonraki 3 ay
+
+`v1.9.0-rc1` ile büyük bir Wave kapandı. Şimdi sonraki 3 ay için
+kapsam toplama vakti. Aşağıdaki açık issue'ları topluluğa açıyoruz —
+"ben ne istiyorum" değil, **"sahada gerçekten lazım mı"** sorusunu
+beraber cevaplayalım.
+
+> Roadmap kaynağı: [`../../ROADMAP.md`](../../ROADMAP.md). Burası
+> brainstorm — orayı duplicate etmiyoruz, sadece "neye ağırlık
+> versek" tartışıyoruz.
+
+## Açık ana parçalar
+
+- **#110** — Duplicates Phase 3 (smart dedupe, hard-link önerisi)
+- **#111** — Chargeback Phase 2 (faturalama entegrasyonu, e-mail
+  rapor şablonları)
+- **#112** — Two-person approval Phase 2 (delegation chains, mobile
+  approve)
+- **#113** — Capacity forecast Phase 2 (linear → ARIMA / Prophet,
+  trigger alerts)
+- **#114** — Pluggable storage backend Phase 2 (Postgres? S3? gerçek
+  scenario var mı)
+
+## Topluluğa sorular
+
+1. **ElasticSearch backend gerçekten gerekli mi?** Bizdeki SQLite +
+   DuckDB stack milyonlarca dosyayı kaldırıyor. ES'i sahada kim
+   istiyor, hangi pain point için?
+2. **Chargeback için hangi model?** Per-GB? Per-file? Department
+   weighted? Sizin kuruluşta nasıl faturalanıyor?
+3. **PII dışında ne tarayalım?** Şu anda regex tabanlı PII
+   (TC kimlik, IBAN, e-mail, kredi kartı). Eklemek istediğiniz
+   pattern? Trade secret detection? Source code leak?
+4. **Mobile yeterli mi?** Sidebar PR #126 ile responsive — gerçek
+   kullanım mobil tarafta var mı, yoksa daha çok desktop-only mı
+   bakıyorsunuz?
+5. **Yeni ana feature?** Roadmap'te olmayan ama "şu olsa" dediğiniz?
+
+## Format
+
+Yorumlara **yazılı paragraf** + **upvote** ile katkı yeterli. Hangi
+issue'ya kaynak ayırmamız gerektiğini buradan belirleyeceğiz.

--- a/docs/discussions/04-show-and-tell.md
+++ b/docs/discussions/04-show-and-tell.md
@@ -1,0 +1,34 @@
+---
+category: Show and tell
+title: "FILE_ACTIVITY ne için kullanıyorsun?"
+---
+
+# FILE_ACTIVITY ne için kullanıyorsun?
+
+Toplulukta kim ne için kullanıyor merak ediyoruz. Geliştirme önceliği
+belirlerken çok yardımcı oluyor.
+
+## Şablon (yorumda doldur)
+
+```
+- **Hangi share?** (örn. departman dosya server'ı, NAS, AD home dir,
+  proje arşivi)
+- **File count + size?** (örn. 2.5M dosya / 8 TB)
+- **En değerli feature?** (örn. duplicate detection, PII tarama,
+  archive policy, chargeback)
+- **Eksik bulduğun?** ("Şu özellik olsa hayatım kolaylaşır" listen)
+- **Hangi build'desin?** (Sidebar version SHA — `1.9.0-rc1 (xxxxxxx)`)
+```
+
+## Bizim referans
+
+- **Share:** karma — bir AD home (~800 user), bir proje paylaşımı,
+  bir scan/archive test mount'u
+- **File count:** 1M MFT + ~300K SMB
+- **En değerli feature:** Duplicate detection (#83 + #110) +
+  capacity forecast (#113). 2 hafta'da 600 GB temizlik.
+- **Eksik:** Mobile approval flow (Phase 2 — #112). Şu an sadece
+  desktop'tan onay verilebiliyor.
+- **Build:** `1.9.0-rc1`
+
+Sıra sizde — sahnedeki use case'ler benzer mi, çok farklı mı?

--- a/docs/discussions/05-performance-benchmarks.md
+++ b/docs/discussions/05-performance-benchmarks.md
@@ -1,0 +1,47 @@
+---
+category: General
+title: "Performance benchmarks — paylaş"
+---
+
+# Performance benchmarks — paylaş
+
+Sahadaki gerçek rakamlar bize altın değerinde. Roadmap önceliği,
+Hyperscan opt-in default'unu açıp açmama, MFT vs SMB seçimi —
+hepsinin temeli sizin paylaşacağınız ölçümler.
+
+## Şablon
+
+```
+- **Donanım:** CPU / RAM / disk (NVMe? HDD?) / network (1G / 10G)
+- **Share boyut:** file count + total size (örn. 2.5M / 8 TB)
+- **Backend:** MFT (lokal NTFS) ya da SMB (`os.walk` UNC)
+- **Scan süresi:** baştan sona
+- **PII engine:** `re` ya da `hyperscan`?
+- **Memory peak:** scan sırasında dashboard process en yüksek
+- **Build:** sidebar version SHA
+- **Notlar:** atlamak istediğin tuhaflık (ilk scan vs incremental,
+  cache hit etkisi, vs.)
+```
+
+## Bizim referans
+
+- **Donanım:** 8 vCPU / 32 GB RAM / NVMe / 1G NIC (lab)
+- **Share boyut:** ~1M dosya MFT (lokal NTFS test mount)
+- **Backend:** MFT
+- **Scan süresi:** ~3 dk (cold), ~45 sn (incremental)
+- **PII engine:** `hyperscan` (Linux container'da test)
+- **Memory peak:** ~50 MB scan boyunca (dashboard process)
+- **Build:** `1.9.0-rc1`
+- **Notlar:** PR #136 sonrası MFT progress phase'leri görünüyor,
+  hangi fazda zaman geçiyor net oldu — `phase=enriching` (ACL/owner
+  lookup) en pahalısı, toplam süreyi ~%40 buradan harcıyoruz.
+
+## Karşılaştırma noktaları
+
+- **Hyperscan vs `re`:** Linux'ta benchmark harness (#70 / PR #73)
+  ile **11x** ölçüldü. Sizin payload'ınızda da aynı oran mı?
+- **MFT vs SMB:** Aynı dataset üzerinde 2 backend ile koşan var mı?
+- **Scan tekrarları:** Cold vs warm cache farkı?
+
+Yorumda paylaşın — düzenli derleme yapıp roadmap'e referans
+ekleyeceğiz.

--- a/docs/operator-runbook.md
+++ b/docs/operator-runbook.md
@@ -1,0 +1,405 @@
+# FILE ACTIVITY — Operator Runbook
+
+> Operatör için günlük işletim kılavuzu. Kurulum, güncelleme, sık karşılaşılan
+> senaryolar, performans ayarı, yedekleme/kurtarma ve sorun giderme tek bir
+> yerde. v1.9.0-rc1 sürümü için yazıldı.
+
+İçindekiler:
+
+- [Kurulum (Install)](#kurulum-install)
+- [Güncelleme (Update)](#guncelleme-update)
+- [Sık Karşılaşılan Senaryolar](#sik-karsilasilan-senaryolar)
+- [Performans Ayarı](#performans-ayari)
+- [Yedekleme + Kurtarma](#yedekleme--kurtarma)
+- [Sorun Giderme](#sorun-giderme)
+
+---
+
+## Kurulum (Install)
+
+### Önerilen yol — kaynak yükleme (`setup-source.ps1`)
+
+**Gereksinim:** Hedefte Python 3.10+ (yoksa script otomatik 3.11 indirir).
+Komut Admin PowerShell ile çalıştırılır.
+
+```powershell
+# PowerShell (Run as Admin):
+powershell -ExecutionPolicy Bypass -Command "[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; irm https://raw.githubusercontent.com/deepdarbe/FILE_ACTIVITY/master/deploy/setup-source.ps1 | iex"
+```
+
+Baştaki TLS 1.2 ataması Windows Server 2012/2016 üzerinde zorunludur —
+PowerShell 5.1 hâlâ TLS 1.0/1.1 default'ında ve GitHub bunları 2018'den beri
+reddediyor. Yeni sistemlerde zararsız, kanonik form olarak kullanın.
+
+Script ne yapar:
+
+- `C:\FileActivity\` altına yükler
+- Python 3.10+ yoksa 3.11 indirir/kurar
+- `.venv` oluşturur, tüm bağımlılıkları yükler (DuckDB analytics dâhil)
+- Windows Firewall kuralı ekler (8085)
+- Dashboard'u başlatmayı önerir
+- Aynı komutu tekrar koşunca **veri / log / rapor / `config.yaml` korunur**
+
+PowerShell modülü (`powershell\FileActivity\`) otomatik kurulur ve user
+PSModulePath'e eklenir. Yeni session'da `Import-Module FileActivity` ile
+hazırdır.
+
+Dashboard: **http://localhost:8085**
+
+### Alternatif — tek dosya EXE (Releases)
+
+Python gerekmez. Tag'li her sürüm için
+`file-activity-<version>-win64.exe` + `.sha256` yayınlanır.
+EXE'yi bir `config.yaml` yanına koy, çift tıkla. EXE statik bir snapshot —
+otomatik güncelleme istiyorsan kaynak install'u tercih et.
+
+İlgili: README "Quick Setup" bölümü.
+
+---
+
+## Güncelleme (Update)
+
+Kurulum dizininde `update.cmd` yer alır. Çalıştırınca:
+
+1. **Snapshot** — mevcut `data/`, `logs/`, `config.yaml`, ve DB dosyaları
+   `update.cmd` snapshot dizinine kopyalanır. Snapshot yolu `InstallDir`
+   altındadır (35a9c5f sonrası — daha önce yanlışlıkla `$LOCALAPPDATA`
+   kullanılıyordu).
+2. **Git fetch + checkout** — master'ın en güncel commit'i çekilir.
+3. **`pip install -r requirements.txt`** — yeni bağımlılıklar (varsa)
+   eklenir.
+4. **VERSION SHA** — Sidebar üst kısmında `1.9.0-rc1` etiketinin yanında
+   build commit SHA görünür (88fe9c5 sonrası — version display'ine commit
+   SHA eklendi). Operatör hangi build'in koştuğunu kontrol etmek için
+   buraya bakar.
+5. **Dashboard'u yeniden başlat** — manuel; service ise NSSM/Task
+   Scheduler restart edilir.
+
+Beklenenler:
+
+- Veri / config / log korunur
+- Snapshot otomatik tutulur — geri dönmek istersen `InstallDir\snapshots\`
+  altında günlük damga
+- Eğer `requirements.txt` yeni bir paket içeriyorsa pip yükleme süresi
+  artar (1-3 dk)
+
+---
+
+## Sık Karşılaşılan Senaryolar
+
+### 1. WAL şişti, dashboard hung — manuel checkpoint + restart
+
+**Belirti:** `data/file_activity.db-wal` 1 GB üstüne çıkmış, dashboard
+"Yükleniyor..." durumunda kalıyor. Sidebar üstte WAL warning banner görünür
+hale gelir.
+
+**Sebep:** Uzun süreli yazıcı (scan + archive aynı anda), checkpoint
+fırsatı bulamamış.
+
+**Çözüm:**
+
+```powershell
+# 1) Servis duruyorsa direkt CLI; aksi halde önce dashboard'ı kapat:
+Stop-Service FileActivity   # NSSM kurulumu varsa
+# veya dashboard process'i öldür: taskkill /F /IM FileActivity.exe
+
+# 2) WAL checkpoint:
+sqlite3 C:\FileActivity\data\file_activity.db "PRAGMA wal_checkpoint(TRUNCATE);"
+
+# 3) Servisi başlat:
+Start-Service FileActivity
+```
+
+Tekrarlanıyorsa: scan zamanlamasıyla archive zamanlamasını üst üste koyma
+(Scheduling sayfası).
+
+### 2. Snapshot manuel
+
+**Ne zaman:** Riskli bir işlemden önce (büyük cleanup, retention purge,
+compliance modülünde toplu silme). `update.cmd` çalışmadan kendi snapshot'ını
+almak istersen.
+
+**Yol 1 — BackupManager (önerilen):**
+
+```bash
+curl -X POST http://localhost:8085/api/backup/run
+# ya da PowerShell modülünden:
+Invoke-RestMethod -Method Post http://localhost:8085/api/backup/run
+```
+
+`InstallDir\backups\file_activity_<TIMESTAMP>.db` üretir. Hot backup
+(SQLite Online Backup API) — DB kapatmaya gerek yok.
+
+**Yol 2 — File copy (DB kapalıyken):**
+
+```powershell
+Stop-Service FileActivity
+Copy-Item C:\FileActivity\data\file_activity.db `
+          C:\FileActivity\backups\manual-$(Get-Date -Format yyyyMMdd-HHmm).db
+Start-Service FileActivity
+```
+
+Auto-backup retention default 14 gün; `config.yaml` `backup.retention_days`.
+
+### 3. Tarama durdur (#134)
+
+**Belirti:** Dashboard "Tarama devam ediyor" diyor ama operatör
+durdurmak istiyor (yanlış kaynak, prod saatleri, vs.).
+
+**Çözüm:**
+
+```bash
+# REST:
+curl -X POST http://localhost:8085/api/scan/{source_id}/stop
+```
+
+PR #134 sonrası: cancel flag scan worker tarafından her batch sonunda
+kontrol edilir (~5-10 sn içinde durur). Önceden silinmiş satırlar geri
+yüklenmez — `scan_runs.status='cancelled'` işaretlenir.
+
+İlgili: issue #131 (cancel flag), #134 (3 prod bug fix).
+
+### 4. Eski tarama temizliği (`?keep_last=N`)
+
+**Belirti:** `scan_runs` tablosu 100+ satır, DB şişiyor.
+
+**Çözüm — son N taramayı tut:**
+
+```bash
+# keep_last_n_scans alias, query parametresi keep_last destekler:
+curl -X POST "http://localhost:8085/api/scans/cleanup?keep_last=5"
+
+# veya 0 — hepsini sil (#133/#134 ile keep_last=0 422 vermez artık):
+curl -X POST "http://localhost:8085/api/scans/cleanup?keep_last=0"
+```
+
+PR #133 öncesi `keep_last=0` 422 dönerdi (validator min=1). #134 ile
+`keep_last=0` legal — "tüm taramalar temizlensin" anlamı.
+
+**Cron önerisi:** Haftalık scheduled task:
+
+```bash
+0 3 * * 0  curl -X POST "http://localhost:8085/api/scans/cleanup?keep_last=10"
+```
+
+### 5. Quarantine review (#83 + #110)
+
+**Belirti:** Duplicate detection bir sürü dosyayı quarantine'e atmış,
+operatör hangi grupların gerçekten silinebileceğine karar verecek.
+
+**Akış:**
+
+1. Dashboard → **Kopya Dosyalar** sayfası
+2. Phase 1 (#83): "Quarantine-only delete" — dosya gerçekten silinmez,
+   `<archive_root>\.quarantine\` altına taşınır + DB'de `quarantined`
+   işaretlenir
+3. Phase 2 (#110): listede her quarantine grup için **Restore** veya
+   **Hard delete** butonu. Hard delete geri dönüşsüz; restore orijinal
+   path'e geri koyar
+4. Gain reporter (#83): "Bu grupları silersen X GB kazanılır" özeti
+   üst banner'da
+
+**Komut hattı:**
+
+```powershell
+Get-FileActivityDuplicates -SourceId 1 |
+    Where-Object Quarantined -eq $true |
+    Sort-Object WasteSize -Descending |
+    Select-Object -First 20
+```
+
+### 6. Audit chain doğrulama (`/api/audit/verify`)
+
+**Ne için:** Compliance raporları için audit trail'in bütünlüğü
+(satır-satır SHA256 zincir). Tampered kayıt veya silinmiş satır
+varsa zincir kırılır.
+
+**Komut:**
+
+```bash
+curl http://localhost:8085/api/audit/verify
+```
+
+Cevap `{"verified": true, "broken_at_seq": null}` olmalı. PowerShell:
+
+```powershell
+$result = Test-FileActivityAuditChain
+if (-not $result.Verified) {
+    Write-Warning "AUDIT CHAIN BROKEN at seq $($result.BrokenAtSeq)"
+}
+```
+
+Kırılma tespit edilirse: en son backup'tan restore + breakage zamanı
+arasındaki audit eventleri gözden geçir.
+
+---
+
+## Performans Ayarı
+
+### Hyperscan opt-in (Linux)
+
+PII regex tarama default `re` (Python stdlib) kullanır. Linux'ta Hyperscan
+aktif edilebilir — **11x hızlanma** (PR #66 benchmark).
+
+```bash
+pip install -r requirements-accel.txt   # hyperscan + pyhs
+# config.yaml:
+# pii:
+#   engine: hyperscan
+```
+
+**Windows:** Hyperscan binary wheel yok — `re` fallback'inde kalır.
+Aynı sonuç, daha yavaş.
+
+İlgili: #64 (engine), #74 (`HS_FLAG_UCP` drop — bazı pattern'lerde sessiz
+miss yapıyordu).
+
+### MFT vs SMB scanner
+
+İki backend var:
+
+| Backend | Ne zaman | Performans |
+|---|---|---|
+| **MFT scanner** (default, lokal NTFS) | Lokal volume taraması | ~1M dosya / 3 dk, peak ~50 MB |
+| **SMB scanner** (`os.walk`) | Network share / UNC path | ~2.5M dosya / 45 dk |
+
+MFT yalnızca lokal NTFS volume'larda çalışır (`\\?\C:` gibi). UNC path
+otomatik SMB'ye düşer. PR #136 sonrası MFT incremental progress raporu
+verir (5'er saniyede phase + count).
+
+**Tavsiye:** Mümkünse MFT (lokal mount); zorda kalırsan SMB.
+
+---
+
+## Yedekleme + Kurtarma
+
+### BackupManager kullanımı
+
+Auto-backup default açık, `config.yaml`:
+
+```yaml
+backup:
+  enabled: true
+  retention_days: 14
+  schedule_cron: "0 2 * * *"   # her gece 02:00
+  online_backup_pages: 1000    # SQLite Online Backup API page sayısı
+```
+
+Manuel:
+
+```bash
+curl -X POST http://localhost:8085/api/backup/run
+curl http://localhost:8085/api/backup/list
+curl -X POST http://localhost:8085/api/backup/restore/{backup_id}
+```
+
+### Auto-restore (opt-in, #77 Phase 2)
+
+PR #106 ile geldi. **Default kapalı** — bilinçli aktif et.
+
+```yaml
+backup:
+  auto_restore_on_corruption: true   # default false
+```
+
+Ne yapar: Startup'ta SQLite corruption probe (skip/quick/full) çalışır.
+Corruption tespit edilirse en son sağlam backup otomatik restore edilir,
+audit log'a kayıt düşer. Kapalıysa sadece error log + dashboard "DB
+bozuk" banner.
+
+**Riskler:** Yeni eklenen veri (son backup sonrası) restore'da kaybolur.
+Auto-restore sadece "data > zaman" tradeoff'unda kabul edilebilir bir
+seçim.
+
+İlgili: #77 Phase 1 (auto-backup), #77 Phase 2 (auto-restore), #119
+(corruption probe hotfix).
+
+---
+
+## Sorun Giderme
+
+### Corruption probe modları (skip / quick / full)
+
+`config.yaml`:
+
+```yaml
+storage:
+  corruption_check:
+    mode: skip   # default — 4c38376 sonrası
+```
+
+| Mode | Komut | Süre (3.5 GB DB) | Ne zaman |
+|---|---|---|---|
+| `skip` (default) | yok | 0 sn | Default, prod |
+| `quick` | `PRAGMA quick_check` | ~60 sn | Haftalık manuel |
+| `full` | `PRAGMA integrity_check` | 5+ dk | Sadece şüpheli durum |
+
+Önceden default `quick` idi — 3.5 GB prod DB'de startup 60 sn'lik delay
+yaşatıyordu. PR #119 ile `quick_check` + bounded timeout, 4c38376 ile
+default `skip` oldu.
+
+**Manuel full check:**
+
+```bash
+sqlite3 C:\FileActivity\data\file_activity.db "PRAGMA integrity_check;"
+```
+
+`ok` dönmesi beklenir.
+
+### Read/write contention scan sırasında
+
+**Belirti:** Scan koşarken dashboard donuyor, "database is locked"
+hataları log'da.
+
+**Sebep:** Scan worker'lar yazıyor, dashboard read-only sorgu yine de
+WAL'a tutunamıyor.
+
+**Çözüm:** PR #134 ile read-only cursor (`PRAGMA query_only=ON`) tüm
+read endpoint'lerinde aktif. Yine de 3.5 GB+ DB'lerde scan sırasında
+heavy report sayfaları (Treemap, Duplicates) yavaş — alternatif:
+
+- Scan'i gece zamanla
+- Ya da scan sırasında sadece Overview / KPI banner'a bak (cached, hızlı)
+
+### "MFT okunuyor (0 kayıt)" üst banner ile uyumsuz
+
+**Belirti:** Sources kartı + DOSYA KPI "0" gösterirken üst ops banner
+"123,456 dosya işlendi" diyor.
+
+**Sebep:** Eski versiyonda Sources/KPI sadece `scan_runs.summary_json`
+dolduktan sonra güncelleniyordu. Tarama hâlâ koşarken senkronizasyon
+kopuk.
+
+**Çözüm:** PR #137/#138 sonrası `live_count` field'ı ile senkronize.
+**Sürüm kontrolü:** Sidebar üst sol köşedeki version SHA `a556ac7` veya
+sonrası olmalı. Eski build'lerde update et.
+
+### "all zeros during MFT"
+
+**Belirti:** MFT scan koşuyor ama her metric (count, size, owner)
+tamamen sıfır görünüyor.
+
+**Sebep:** MFT okuma henüz `scanned_files` insert noktasına gelmedi —
+USN journal parse aşamasında. Önceden hiçbir progress reporting yoktu;
+operatör "scan donmuş" sanıyordu.
+
+**Çözüm:** PR #136 (issue #135) sonrası phase reporting:
+
+- `phase=mft_read` (USN parse, count artıyor)
+- `phase=enriching` (ACL/owner lookup)
+- `phase=writing` (DB insert)
+- `phase=summary` (final aggregates)
+
+Üst ops banner'da phase görünür. Eğer `phase=mft_read` 5+ dk hareketsizse
+gerçek bir hang — log'a bak.
+
+---
+
+## Cross-link
+
+- Roadmap: [`../ROADMAP.md`](../ROADMAP.md)
+- Release notes: [`release-notes/v1.9.0-rc1.md`](release-notes/v1.9.0-rc1.md)
+- Troubleshooting (decision-tree): [`troubleshooting.md`](troubleshooting.md)
+- MCP server: [`mcp_server.md`](mcp_server.md)
+- Playground: [`playground.md`](playground.md)
+- Üst README: [`../README.md`](../README.md)

--- a/docs/release-notes/v1.9.0-rc1.md
+++ b/docs/release-notes/v1.9.0-rc1.md
@@ -1,0 +1,172 @@
+# v1.9.0-rc1 — Release Candidate
+
+**Tag:** `v1.9.0-rc1`
+**Tarih:** 2026-04-28
+**Kapsam:** 47 PR + 4 direkt commit, customer prod testindeyiz.
+
+> Müşteri prod testine giden ilk RC. Hyperscan PII, auto-backup +
+> opt-in auto-restore, 9 yeni dashboard sayfası, sidebar responsive,
+> MFT incremental, Streamlit playground, two-person approval,
+> chargeback, capacity forecast, pluggable storage backend.
+
+İçindekiler:
+
+- [Highlights](#highlights)
+- [Wave A — Compliance / Security temeli](#wave-a--compliance--security-temeli)
+- [Wave B — Dashboard sayfaları + Bug 1/2/3](#wave-b--dashboard-sayfalari--bug-123)
+- [Wave C — Backup + auto-restore](#wave-c--backup--auto-restore)
+- [Wave D — Test infra + benchmarks](#wave-d--test-infra--benchmarks)
+- [Wave E — Hyperscan PII + MCP](#wave-e--hyperscan-pii--mcp)
+- [Wave F — Approvals + chargeback + forecast](#wave-f--approvals--chargeback--forecast)
+- [Wave G — Duplicates Phase 2 + quarantine](#wave-g--duplicates-phase-2--quarantine)
+- [Wave H — Sidebar + ops banner + cache](#wave-h--sidebar--ops-banner--cache)
+- [Wave I — Prod hotfix + 3 bug fix](#wave-i--prod-hotfix--3-bug-fix)
+- [Wave J — MFT incremental + KPI sync](#wave-j--mft-incremental--kpi-sync)
+- [Direkt commit'ler](#direkt-commitler)
+- [Bilinen sınırlamalar](#bilinen-sinirlamalari)
+- [Yükseltme](#yukseltme)
+
+---
+
+## Highlights
+
+- **Hyperscan PII** — Linux 11x hızlanma; Windows fallback `re`
+- **Auto-backup + opt-in auto-restore** corruption durumunda
+- **9 yeni dashboard sayfası** (Security, Compliance, Integrations, System)
+- **Sidebar responsive** — scroll/collapse/search/narrow + mobile hamburger
+- **MFT scanner incremental progress** + phase reporting
+- **Streamlit analytics playground** (read-only, opt-in)
+- **Two-person approval framework** (#112 Phase 1)
+- **Chargeback / cost-center raporu** (#111 Phase 1)
+- **Quota / capacity forecasting** (#113)
+- **Pluggable storage backend abstraction** (#114 Phase 1)
+- **Read/write contention fix** scan sırasında
+- **XLSX 1M-row cap'i bypass** — multi-sheet split + CSV fallback
+
+---
+
+## Wave A — Compliance / Security temeli
+
+- **PR #62** — GDPR PII detection + retention engine (#58)
+- **PR #61** — Orphan-SID raporu + bulk reassignment (#56)
+- **PR #63** — Legal hold registry: arşiv/retention'dan path freeze (#59)
+- **PR #60** — PowerShell modülü `Import-Module FileActivity` (#57)
+
+## Wave B — Dashboard sayfaları + Bug 1/2/3
+
+9 yeni sayfa (#81), tümü Wave B-1/2/3:
+
+- **PR #99** — Dashboard Security pages (Orphan SIDs, Ransomware, ACL)
+- **PR #100** — Dashboard Compliance pages (PII findings, Retention, Legal Holds)
+- **PR #101** — Dashboard Integrations + System pages (Syslog, MCP, Backups)
+
+Bug fix paketi (#82):
+
+- **PR #85** — `open_folder` remote-client clipboard fallback (#82 Bug 1)
+- **PR #95** — Export buttons: loading spinner + abort + error toast (#82 Bug 3)
+- **PR #96** — AI insights `insight_type` validation: 400 on unknown (#82 Bug 2)
+- **PR #104** — Button audit + dashboard smoke tests (#82 Bug 4)
+- **PR #105** — 6 compliance modal placeholder (#82 Bug 4 baseline orphan)
+- **PR #107** — `loadFolderBrowser()` folder picker (#82 Bug 4 / #105 son orphan)
+- **PR #103** — Dashboard Görsel/Profesyonel mod toggle (#84)
+- **PR #102** — Top-bar load progress + ETA + retry (#79)
+- **PR #98** — Reusable entity-list + XLSX export, mit-naming uygulamalı (#80 Phase 1)
+
+## Wave C — Backup + auto-restore
+
+- **PR #78** — SQLite auto-backup Phase 1 (#77)
+- **PR #106** — Opt-in auto-restore on SQLite corruption (#77 Phase 2)
+
+## Wave D — Test infra + benchmarks
+
+- **PR #92** — Docker test infrastructure (#91 Phase 1)
+- **PR #93** — CI: flaky pip-install yerine Docker runner (#91 Phase 3)
+- **PR #97** — Deterministik synthetic corpus generator (#94, #91 Phase 2 finiş)
+- **PR #73** — Benchmark harness + first finding (#70)
+- **PR #71** — Pytest CI job + advisory Linux/Windows split (#68)
+- **PR #72** — Auto-build single-file Windows EXE on tag (#69)
+
+## Wave E — Hyperscan PII + MCP
+
+- **PR #66** — Hyperscan-accelerated PiiEngine (#64) — Linux 11x
+- **PR #67** — `file-activity-mcp` server (#65)
+- **PR #76** — `HS_FLAG_UCP` drop default Hyperscan flags'tan (#74)
+
+## Wave F — Approvals + chargeback + forecast
+
+- **PR #115** — Two-person approval framework Phase 1 (#112)
+- **PR #116** — Chargeback / cost-center raporu Phase 1 (#111)
+- **PR #120** — Quota / capacity forecasting (#113)
+- **PR #121** — Pluggable storage backend abstraction (#114 Phase 1)
+- **PR #108** — Streamlit analytics playground (#75)
+
+## Wave G — Duplicates Phase 2 + quarantine
+
+- **PR #109** — Quarantine-only delete + gain reporter (#83 Phase 1)
+- **PR #117** — Hard-delete + restore + quarantine UI (#110 Phase 2)
+
+## Wave H — Sidebar + ops banner + cache
+
+- **PR #126** — Responsive sidebar: scroll, search, collapse, narrow,
+  mobile hamburger (#124)
+- **PR #127** — Analyzer cache: frequency/type/size per scan_id (#123)
+- **PR #128** — Auto error reporting Phase 1: GitHub Issues'a otomatik
+  rapor (#118)
+- **PR #129** — "Şu an ne oluyor" status banner + page skeleton (#125)
+- **PR #130** — XLSX streaming + multi-sheet split + CSV fallback (#122)
+
+## Wave I — Prod hotfix + 3 bug fix
+
+- **PR #119** — HOTFIX: corruption check `quick_check` + bounded timeout
+  (prod hang)
+- **PR #134** — 3 prod bug: scan stop + read/write contention + cleanup
+  422 (#131, #132, #133)
+
+## Wave J — MFT incremental + KPI sync
+
+- **PR #136** — MFT incremental progress + phase reporting + streaming
+  (#135)
+- **PR #138** — Sources card + DOSYA KPI banner ile `live_count`
+  senkronizasyonu (#137)
+- **PR #140** — Inline label + bottom status bar live ops count
+
+---
+
+## Direkt commit'ler
+
+PR olmadan master'a giden 4 commit:
+
+1. **`35ab3da`** — `update.cmd` snapshot path: `InstallDir` (önce yanlışlıkla `$LOCALAPPDATA`)
+2. **`4c38376`** — Corruption probe default mode `skip` (önce `quick` — prod 3.5GB DB'de 60s)
+3. **`8a32ad0`** — Corruption + backup test'lerinin mode='skip' default için güncellenmesi (#131 follow-up)
+4. **`9d853d1`** — VERSION bump 1.9.0-rc1
+
+---
+
+## Bilinen sınırlamalar
+
+- Hyperscan **sadece Linux** — Windows wheel yok, `re` fallback'ine düşer
+- Auto-restore **opt-in default kapalı** — bilinçli aktive et (`config.yaml`
+  `backup.auto_restore_on_corruption: true`)
+- MFT scanner **sadece lokal NTFS volume** — UNC path otomatik SMB'ye düşer
+- Streamlit playground **read-only** ve **token-protected** (admin-only)
+
+## Yükseltme
+
+```cmd
+C:\FileActivity\update.cmd
+```
+
+Beklenenler:
+
+- Snapshot otomatik (`InstallDir\snapshots\<TIMESTAMP>\`)
+- Veri / config / log korunur
+- Sidebar üst sol köşede `1.9.0-rc1 (<sha>)` görünür
+- `requirements.txt` yeni paket içeriyor (DuckDB analytics ek modülleri,
+  ops tracker) — pip 1-3 dk
+
+Güncelleme detayları: [`../operator-runbook.md`](../operator-runbook.md)
+§"Güncelleme".
+
+İlgili: [`../../ROADMAP.md`](../../ROADMAP.md) — sonraki sürüm planlaması
+(post-rc1).

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,200 @@
+# FILE ACTIVITY — Sorun Giderme (Decision Tree)
+
+> "X oluyor → Y yap" tarzı hızlı arama. Daha derin senaryolar için
+> [`operator-runbook.md`](operator-runbook.md).
+
+---
+
+## Dashboard yüklenmiyor / boş ekran
+
+**Adım 1 — Sürüm kontrolü.**
+
+Sidebar üst sol köşedeki version etiketine bak. Beklenen: `1.9.0-rc1` +
+commit SHA (örn. `1.9.0-rc1 (a556ac7)`). Eskiyse `update.cmd` çalıştır.
+
+**Adım 2 — Log'a bak.**
+
+```powershell
+Get-Content C:\FileActivity\logs\dashboard.log -Tail 50
+```
+
+Sık nedenler:
+
+| Log mesajı | Anlam | Çözüm |
+|---|---|---|
+| `port 8085 already in use` | Eski process hâlâ çalışıyor | `taskkill /F /IM FileActivity.exe`; service ise `Restart-Service FileActivity` |
+| `database is locked` | Scan + dashboard çakışma | Scan bitmesini bekle; sürekli olursa runbook §"Read/write contention" |
+| `PRAGMA quick_check timeout` | DB corruption probe | Runbook §"Corruption probe modları" — mode'u `skip`'e al |
+| `no such table: scan_runs` | Migration eksik / DB silinmiş | Backup'tan restore (`/api/backup/restore/{id}`) |
+
+**Adım 3 — Ağ kontrolü.**
+
+`http://localhost:8085` lokalde açılıyor ama remote açılmıyor → Windows
+Firewall kuralı. `setup-source.ps1` rolünü atlamış olabilir:
+
+```powershell
+New-NetFirewallRule -DisplayName "FileActivity Dashboard" `
+                    -Direction Inbound -LocalPort 8085 `
+                    -Protocol TCP -Action Allow
+```
+
+---
+
+## Cleanup endpoint 422 dönüyor
+
+**Belirti:**
+
+```
+POST /api/scans/cleanup?keep_last=0
+→ 422 Unprocessable Entity
+```
+
+**Sebep:** Eski validator `keep_last >= 1` zorunlu kılıyordu.
+
+**Çözüm:**
+
+- **Eski build:** En az 1 ile çağır: `?keep_last=1`
+- **Yeni build (PR #133/#134 sonrası):** `keep_last=0` legal — "tüm
+  taramalar temizlensin" anlamı. Ya da yeni alias kullan:
+  `?keep_last_n_scans=0`. Sürüm kontrolü: SHA `1de880c` veya sonrası.
+
+İlgili: #131 (cancel flag), #132 (read-only cursor), #133 (cleanup
+keep_last=0), #134 (3 prod bug fix PR).
+
+---
+
+## "Konuma Git" Explorer açmıyor
+
+**Belirti:** Bir dosya/dizin satırında "Konuma Git" → hiçbir şey olmuyor
+ya da "Bu işlem desteklenmiyor" hatası.
+
+**Adım 1 — Lokal vs remote kontrolü.**
+
+```powershell
+# Dashboard'a aynı host'tan bağlıysan: localhost:8085 → server-side Explorer
+# Remote browser'dan bağlıysan: <server>:8085 → server-side Explorer YANLIŞ
+```
+
+**Sebep:** PR #85 öncesi dashboard her durumda server'da
+`explorer.exe <path>` çalıştırıyordu. Remote bağlandığında server'ın
+masaüstünde Explorer açılıyor, sen göremiyorsun (#82 Bug 1).
+
+**Çözüm:**
+
+- **Yeni build (PR #85 sonrası):** Otomatik tespit. Remote ise path
+  clipboard'a kopyalanır + toast: "Path kopyalandı, kendi makinende
+  Win+R yapıştır". Lokalse Explorer açılır.
+- **Eski build:** `update.cmd` çalıştır. Sürüm kontrolü: SHA `5163724`
+  veya sonrası.
+
+---
+
+## XLSX export 1M+ satırda crash
+
+**Belirti:** Cleanup raporu / Duplicates listesi büyük; XLSX export
+"Excel can't open" diyor ya da export 0-byte dosya üretiyor.
+
+**Sebep:** Excel hard limit: 1,048,576 satır / sheet.
+
+**Çözüm 1 — Multi-sheet (PR #130, #122):**
+
+Yeni build otomatik olarak 1M üzerini birden fazla sheet'e böler
+(`Sheet 1` 1-1M, `Sheet 2` 1M-2M, ...). Sürüm kontrolü: SHA `3d5eb0a`
+veya sonrası. Eski build'de `update.cmd`.
+
+**Çözüm 2 — CSV fallback:**
+
+XLSX yerine CSV iste:
+
+```
+GET /api/reports/duplicates/{id}/export?format=csv
+```
+
+CSV'nin satır limiti yok. Excel açarken büyük CSV'yi Power Query
+import'la (drag-drop büyük dosyada hang olur).
+
+---
+
+## "MFT okunuyor (0 kayıt)" — banner sayıyı gösteriyor ama KPI 0
+
+**Belirti:** Üst ops banner "MFT phase, 234,567 dosya işlendi" diyor
+ama Sources kartı + DOSYA KPI hâlâ "0".
+
+**Adım 1 — Sürüm kontrolü.**
+
+Sidebar version SHA. **Beklenen:** `86fd839` (PR #138) veya sonrası.
+
+| Sürüm | Davranış |
+|---|---|
+| < `b63cbaa` | MFT phase'inde hiçbir progress yok, "0 kayit" tüm scan boyunca |
+| `b63cbaa` (PR #136) | Phase + count banner'da görünür ama Sources/KPI senkronize değil |
+| `86fd839` (PR #138) | Sources + DOSYA KPI `live_count` ile banner'a senkron |
+| `c483041` (PR #140) | Inline label + bottom status bar da senkron |
+
+**Adım 2 — Eski build'de ne yap?**
+
+`update.cmd`. Operasyon kritikse şimdilik banner'ı referans al; KPI
+scan bitince doğru değere oturur.
+
+İlgili: #135 (MFT progress), #137/#138 (Sources/KPI sync), #140
+(inline label).
+
+---
+
+## "Tarama bitiyor, banner sıfırlanmıyor"
+
+**Belirti:** Scan tamamlandı, raporlar geldi, ama üst banner hâlâ
+"Tarama devam ediyor" diyor.
+
+**Sebep:** Ops tracker (PR #129) state cleanup eksiği. Banner state
+ayrı bir endpoint'ten polling yapıyor — bazen final transition kaçıyor.
+
+**Geçici çözüm:** Sayfayı F5 ile yenile.
+
+**Kalıcı çözüm:** SHA `c483041` veya sonrası — live ops count
+tutarsızlık fix.
+
+---
+
+## Sidebar mobile'da görünmüyor / sığmıyor
+
+**Belirti:** Tablet/mobile erişimde menü kayıp ya da içerik üstüne
+düşüyor.
+
+**Çözüm:** PR #126 (SHA `d6efa0a`) ile responsive sidebar:
+- Hamburger menü <768px
+- Scrollable, collapse, search, narrow mode
+
+Eski build'de `update.cmd`.
+
+---
+
+## Audit chain "broken at seq N"
+
+**Belirti:**
+
+```
+GET /api/audit/verify
+→ {"verified": false, "broken_at_seq": 14523}
+```
+
+**Sebep:** Bir audit satırı manuel SILINMIŞ ya da modify edilmiş.
+SHA256 zinciri kırıldı.
+
+**Çözüm:** Geri dönüş yok — zincir append-only sözleşme. Yapılacaklar:
+
+1. Backup'tan en son sağlam state'i restore et (audit dâhil tüm tabloyu
+   geri alır)
+2. Compliance ekibine bildir; tampering window'unu (broken_at_seq
+   timestamp) raporla
+3. Sebep arşivlemesi: kim DB'ye direkt SQL atmış? `audit_events`
+   tablosuna manuel `INSERT`/`DELETE` yasak — sadece API üstünden
+
+İlgili: #59 (legal hold), audit chain SHA256 — runbook §"Audit chain".
+
+---
+
+## Daha fazla
+
+Decision tree'de yoksa: [`operator-runbook.md`](operator-runbook.md) — sık
+senaryolar bölümü daha geniş.


### PR DESCRIPTION
## Summary
Operator-facing docs + Discussions seed posts (since Discussions create API isn't available in this env).

- `docs/README.md` — index
- `docs/operator-runbook.md` — install, update, common scenarios, performance tuning, backup/recovery, troubleshooting
- `docs/troubleshooting.md` — decision-tree style "X happens, do Y"
- `docs/release-notes/v1.9.0-rc1.md` — comprehensive release notes (47 PR + 4 direct commits, grouped Wave A-J)
- `docs/discussions/01-welcome-v1.9.0-rc1.md` — Announcements seed
- `docs/discussions/02-operator-runbook.md` — Q&A seed
- `docs/discussions/03-roadmap-brainstorm.md` — Ideas seed
- `docs/discussions/04-show-and-tell.md` — Show and tell seed
- `docs/discussions/05-performance-benchmarks.md` — General seed

Each discussion seed has YAML frontmatter (`category: ...`, `title: ...`) so operator can `cat` and paste verbatim into GitHub UI without retyping.

## Decisions
- Existing `docs/mcp_server.md` and `docs/playground.md` preserved; linked from new `docs/README.md`
- Release notes link `ROADMAP.md` rather than duplicate content
- All Turkish (project language)

https://claude.ai/code/session_da1e681c-07bf-426c-be53-42b5baa2a1e9

---
_Generated by [Claude Code](https://claude.ai/code/session_01A1UzS1A4DZNk1akoP4uhZ7)_