### PR TITLE
Windows Service mode + tray app + PowerShell cmdlets (closes #151)

### DIFF
--- a/deploy/install_service.ps1
+++ b/deploy/install_service.ps1
@@ -1,0 +1,236 @@
+<#
+.SYNOPSIS
+    Install FILE ACTIVITY as a Windows Service via NSSM (Non-Sucking Service Manager).
+
+.DESCRIPTION
+    Issue #151: customers complain that closing/opening the dashboard via cmd
+    prompts and Task Manager kills is tedious. This script wraps the dashboard
+    entry point as a real Windows service so it:
+
+      - Starts automatically on boot (SERVICE_AUTO_START)
+      - Restarts on crash (AppExit Default Restart)
+      - Logs stdout/stderr to logs\service.out / logs\service.err with rotation
+      - Can be controlled with Start-Service / Stop-Service / Get-Service
+
+    NSSM is downloaded on demand from https://nssm.cc/release/nssm-2.24.zip
+    (BSD-like license, free for commercial use). The 64-bit binary is placed
+    under <InstallDir>\bin\nssm.exe.
+
+    Existing start_dashboard.cmd keeps working for debug / standalone use.
+    Customers who do not run this script see zero behavior change (issue #151
+    backwards compat constraint).
+
+.PARAMETER InstallDir
+    FILE ACTIVITY install root (default C:\FileActivity).
+
+.PARAMETER ServiceName
+    Windows service name (default FileActivity).
+
+.PARAMETER NssmUrl
+    NSSM zip download URL. Override only if your network blocks nssm.cc.
+
+.PARAMETER InstallTray
+    Switch — also drop the optional system tray helper into shell:startup
+    (auto-starts at user logon). Off by default.
+
+.EXAMPLE
+    # Run from elevated PowerShell:
+    powershell -ExecutionPolicy Bypass -File C:\FileActivity\deploy\install_service.ps1
+
+.EXAMPLE
+    # Service + tray auto-start in one shot:
+    powershell -ExecutionPolicy Bypass -File C:\FileActivity\deploy\install_service.ps1 -InstallTray
+
+.NOTES
+    Requires Administrator. Companion: deploy\uninstall_service.ps1.
+#>
+
+[CmdletBinding()]
+param(
+    [string]$InstallDir = "C:\FileActivity",
+    [string]$ServiceName = "FileActivity",
+    [string]$NssmUrl = "https://nssm.cc/release/nssm-2.24.zip",
+    [switch]$InstallTray
+)
+
+$ErrorActionPreference = "Stop"
+
+Write-Host ""
+Write-Host "  +==========================================+" -ForegroundColor Cyan
+Write-Host "  |  FILE ACTIVITY - Service Kurulumu (NSSM) |" -ForegroundColor Cyan
+Write-Host "  +==========================================+" -ForegroundColor Cyan
+Write-Host ""
+
+# --- Yonetici kontrolu ---
+$isAdmin = ([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+if (-not $isAdmin) {
+    Write-Host "  [HATA] Bu script Yonetici olarak calistirilmalidir." -ForegroundColor Red
+    Write-Host "  PowerShell'i sag tikla -> 'Yonetici olarak calistir', sonra tekrar deneyin." -ForegroundColor Yellow
+    exit 1
+}
+
+# --- Install root sanity ---
+$venvPy = Join-Path $InstallDir ".venv\Scripts\python.exe"
+$mainPy = Join-Path $InstallDir "main.py"
+$cfgYaml = Join-Path $InstallDir "config\config.yaml"
+
+if (-not (Test-Path $venvPy)) {
+    Write-Host "  [HATA] $venvPy bulunamadi." -ForegroundColor Red
+    Write-Host "         Once setup-source.ps1 ile kurulum yapin." -ForegroundColor Yellow
+    exit 1
+}
+if (-not (Test-Path $mainPy)) {
+    Write-Host "  [HATA] $mainPy bulunamadi." -ForegroundColor Red
+    exit 1
+}
+if (-not (Test-Path $cfgYaml)) {
+    Write-Host "  [UYARI] $cfgYaml bulunamadi - servis baslatildiginda config hatasi alabilirsiniz." -ForegroundColor Yellow
+}
+
+$binDir = Join-Path $InstallDir "bin"
+$logsDir = Join-Path $InstallDir "logs"
+foreach ($d in @($binDir, $logsDir)) {
+    if (-not (Test-Path $d)) { New-Item -Path $d -ItemType Directory -Force | Out-Null }
+}
+
+# --- 1. nssm.exe hazirla ---
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+$nssmExe = Join-Path $binDir "nssm.exe"
+
+if (-not (Test-Path $nssmExe)) {
+    Write-Host "[1/4] NSSM indiriliyor ($NssmUrl)..." -ForegroundColor Yellow
+    $tmpZip = Join-Path $env:TEMP "nssm-install.zip"
+    $tmpExtract = Join-Path $env:TEMP "nssm-extract"
+    if (Test-Path $tmpZip)     { Remove-Item $tmpZip -Force }
+    if (Test-Path $tmpExtract) { Remove-Item $tmpExtract -Recurse -Force }
+
+    try {
+        Invoke-WebRequest -Uri $NssmUrl -OutFile $tmpZip -UseBasicParsing
+    } catch {
+        Write-Host "  [HATA] NSSM indirilemedi: $_" -ForegroundColor Red
+        Write-Host "         Manuel: $NssmUrl indirip $nssmExe konumuna kopyalayin." -ForegroundColor Yellow
+        exit 1
+    }
+
+    Expand-Archive -Path $tmpZip -DestinationPath $tmpExtract -Force
+
+    # NSSM zip ships win32/ + win64/. Prefer 64-bit on 64-bit OS.
+    $arch = if ([Environment]::Is64BitOperatingSystem) { "win64" } else { "win32" }
+    $extractedNssm = Get-ChildItem -Path $tmpExtract -Recurse -Filter "nssm.exe" |
+        Where-Object { $_.FullName -match "\\$arch\\" } |
+        Select-Object -First 1
+    if (-not $extractedNssm) {
+        # Fallback: any nssm.exe in archive
+        $extractedNssm = Get-ChildItem -Path $tmpExtract -Recurse -Filter "nssm.exe" | Select-Object -First 1
+    }
+    if (-not $extractedNssm) {
+        Write-Host "  [HATA] nssm.exe arsiv icinde bulunamadi." -ForegroundColor Red
+        exit 1
+    }
+    Copy-Item -Path $extractedNssm.FullName -Destination $nssmExe -Force
+    Remove-Item $tmpZip -Force -ErrorAction SilentlyContinue
+    Remove-Item $tmpExtract -Recurse -Force -ErrorAction SilentlyContinue
+    Write-Host "  [OK] nssm.exe -> $nssmExe" -ForegroundColor Green
+} else {
+    Write-Host "[1/4] NSSM zaten mevcut: $nssmExe" -ForegroundColor Green
+}
+
+# --- 2. Existing service varsa once kaldir ---
+$existing = Get-Service -Name $ServiceName -ErrorAction SilentlyContinue
+if ($existing) {
+    Write-Host "[2/4] Mevcut servis bulundu, yeniden olusturmak icin kaldiriliyor..." -ForegroundColor Yellow
+    & $nssmExe stop $ServiceName 2>&1 | Out-Null
+    Start-Sleep -Seconds 2
+    & $nssmExe remove $ServiceName confirm 2>&1 | Out-Null
+    Start-Sleep -Seconds 1
+    Write-Host "  [OK] Eski servis kaldirildi" -ForegroundColor Green
+} else {
+    Write-Host "[2/4] Yeni servis olusturuluyor: $ServiceName" -ForegroundColor Yellow
+}
+
+# --- 3. NSSM ile servisi konfigure et ---
+Write-Host "[3/4] NSSM servis konfigurasyonu..." -ForegroundColor Yellow
+
+$svcOut = Join-Path $logsDir "service.out"
+$svcErr = Join-Path $logsDir "service.err"
+
+# nssm install <name> <bin> <args...>
+& $nssmExe install $ServiceName $venvPy $mainPy "--config" $cfgYaml "dashboard"
+if ($LASTEXITCODE -ne 0) {
+    Write-Host "  [HATA] nssm install basarisiz (exit $LASTEXITCODE)" -ForegroundColor Red
+    exit 1
+}
+
+# Working directory so relative paths in main.py resolve correctly.
+& $nssmExe set $ServiceName AppDirectory $InstallDir | Out-Null
+
+# Log redirection + rotation
+& $nssmExe set $ServiceName AppStdout $svcOut | Out-Null
+& $nssmExe set $ServiceName AppStderr $svcErr | Out-Null
+& $nssmExe set $ServiceName AppRotateFiles 1 | Out-Null
+& $nssmExe set $ServiceName AppRotateOnline 1 | Out-Null
+& $nssmExe set $ServiceName AppRotateBytes 10485760 | Out-Null  # 10 MB
+
+# Start type: auto on boot
+& $nssmExe set $ServiceName Start SERVICE_AUTO_START | Out-Null
+
+# Crash recovery: restart on any unexpected exit, throttle 5s
+& $nssmExe set $ServiceName AppExit Default Restart | Out-Null
+& $nssmExe set $ServiceName AppRestartDelay 5000 | Out-Null
+& $nssmExe set $ServiceName AppThrottle 10000 | Out-Null
+
+# Display name + description
+& $nssmExe set $ServiceName DisplayName "FILE ACTIVITY - File Share Monitor" | Out-Null
+& $nssmExe set $ServiceName Description "Windows File Share Analysis, Monitoring and Archiving Service. Issue #151: NSSM-managed dashboard with auto-start + crash recovery." | Out-Null
+
+Write-Host "  [OK] Servis konfigure edildi" -ForegroundColor Green
+Write-Host "       stdout : $svcOut" -ForegroundColor DarkGray
+Write-Host "       stderr : $svcErr" -ForegroundColor DarkGray
+Write-Host "       restart: 5 sn delay, otomatik" -ForegroundColor DarkGray
+
+# --- 4. Servisi baslat ---
+Write-Host "[4/4] Servis baslatiliyor..." -ForegroundColor Yellow
+& $nssmExe start $ServiceName 2>&1 | Out-Null
+Start-Sleep -Seconds 3
+$svc = Get-Service -Name $ServiceName -ErrorAction SilentlyContinue
+if ($svc -and $svc.Status -eq "Running") {
+    Write-Host "  [OK] Servis calisiyor" -ForegroundColor Green
+} else {
+    Write-Host "  [UYARI] Servis henuz Running degil. Status: $($svc.Status)" -ForegroundColor Yellow
+    Write-Host "          Loglara bakin: $svcErr" -ForegroundColor Yellow
+}
+
+# --- Optional tray app auto-start ---
+if ($InstallTray) {
+    Write-Host ""
+    Write-Host "[+] Tray app auto-start kuruluyor..." -ForegroundColor Yellow
+    $trayInstaller = Join-Path $InstallDir "deploy\install_tray.ps1"
+    if (Test-Path $trayInstaller) {
+        & powershell -ExecutionPolicy Bypass -File $trayInstaller -InstallDir $InstallDir
+    } else {
+        Write-Host "  [UYARI] $trayInstaller bulunamadi - tray app atlandi." -ForegroundColor Yellow
+    }
+}
+
+Write-Host ""
+Write-Host "  +==========================================+" -ForegroundColor Green
+Write-Host "  |  Servis Kurulumu Tamam!                  |" -ForegroundColor Green
+Write-Host "  +==========================================+" -ForegroundColor Green
+Write-Host ""
+Write-Host "  Servis adi : $ServiceName" -ForegroundColor White
+Write-Host "  Dashboard  : http://localhost:8085" -ForegroundColor Yellow
+Write-Host ""
+Write-Host "  Yonetim:" -ForegroundColor White
+Write-Host "    Start-Service $ServiceName       # baslat" -ForegroundColor Cyan
+Write-Host "    Stop-Service $ServiceName        # durdur" -ForegroundColor Cyan
+Write-Host "    Restart-Service $ServiceName     # yeniden baslat" -ForegroundColor Cyan
+Write-Host "    Get-Service $ServiceName         # durum" -ForegroundColor Cyan
+Write-Host ""
+Write-Host "  PowerShell module cmdlet'leri (Import-Module FileActivity):" -ForegroundColor White
+Write-Host "    Start-FileActivityService" -ForegroundColor Cyan
+Write-Host "    Stop-FileActivityService" -ForegroundColor Cyan
+Write-Host "    Restart-FileActivityService" -ForegroundColor Cyan
+Write-Host "    Get-FileActivityServiceStatus" -ForegroundColor Cyan
+Write-Host ""
+Write-Host "  Kaldirma: $InstallDir\deploy\uninstall_service.ps1" -ForegroundColor White
+Write-Host ""

--- a/deploy/install_tray.ps1
+++ b/deploy/install_tray.ps1
@@ -1,0 +1,102 @@
+<#
+.SYNOPSIS
+    Install the FILE ACTIVITY system tray helper (issue #151) and add it to
+    the current user's startup folder so it auto-launches at logon.
+
+.DESCRIPTION
+    1. pip install -r requirements-tray.txt   (pystray + Pillow into venv)
+    2. Drop a launcher batch at <InstallDir>\start_tray.cmd
+    3. Create a Startup folder shortcut so the tray icon comes up at logon
+       (per-user, no Admin needed for the shortcut step itself)
+
+    The tray app talks to the FileActivity Windows service via PowerShell;
+    install_service.ps1 should already have been run.
+
+.PARAMETER InstallDir
+    FILE ACTIVITY install root (default C:\FileActivity).
+
+.PARAMETER ServiceName
+    Windows service name controlled by the tray app (default FileActivity).
+
+.EXAMPLE
+    powershell -ExecutionPolicy Bypass -File C:\FileActivity\deploy\install_tray.ps1
+
+.NOTES
+    Tray is opt-in. To remove: delete <Startup>\FileActivityTray.lnk and
+    optionally pip uninstall pystray Pillow inside the venv.
+#>
+
+[CmdletBinding()]
+param(
+    [string]$InstallDir = "C:\FileActivity",
+    [string]$ServiceName = "FileActivity"
+)
+
+$ErrorActionPreference = "Stop"
+
+Write-Host ""
+Write-Host "  +==========================================+" -ForegroundColor Cyan
+Write-Host "  |  FILE ACTIVITY - Tray App Kurulumu       |" -ForegroundColor Cyan
+Write-Host "  +==========================================+" -ForegroundColor Cyan
+Write-Host ""
+
+$venvPy = Join-Path $InstallDir ".venv\Scripts\python.exe"
+$venvPyW = Join-Path $InstallDir ".venv\Scripts\pythonw.exe"
+$reqTray = Join-Path $InstallDir "requirements-tray.txt"
+
+if (-not (Test-Path $venvPy)) {
+    Write-Host "  [HATA] $venvPy yok. Once setup-source.ps1 calistirin." -ForegroundColor Red
+    exit 1
+}
+if (-not (Test-Path $reqTray)) {
+    Write-Host "  [HATA] $reqTray yok - tray app dosyalari kurulumda eksik." -ForegroundColor Red
+    exit 1
+}
+
+Write-Host "[1/3] pystray + Pillow yukleniyor..." -ForegroundColor Yellow
+$pipTrust = @(
+    "--trusted-host", "pypi.org",
+    "--trusted-host", "files.pythonhosted.org",
+    "--trusted-host", "pypi.python.org"
+)
+& $venvPy -m pip install -r $reqTray --quiet @pipTrust
+if ($LASTEXITCODE -ne 0) {
+    Write-Host "  [HATA] pip install basarisiz" -ForegroundColor Red
+    exit 1
+}
+Write-Host "  [OK] Bagimliliklar kuruldu" -ForegroundColor Green
+
+Write-Host "[2/3] start_tray.cmd olusturuluyor..." -ForegroundColor Yellow
+$trayLauncher = Join-Path $InstallDir "start_tray.cmd"
+# pythonw.exe -> no console window; fallback to python.exe if absent
+$pyExe = if (Test-Path $venvPyW) { $venvPyW } else { $venvPy }
+$trayCmd = @"
+@echo off
+cd /d "$InstallDir"
+start "" "$pyExe" -m src.tray.tray_app --service-name $ServiceName --install-dir "$InstallDir"
+"@
+Set-Content -Path $trayLauncher -Value $trayCmd -Encoding ASCII
+Write-Host "  [OK] $trayLauncher" -ForegroundColor Green
+
+Write-Host "[3/3] Startup klasorune kisayol ekleniyor..." -ForegroundColor Yellow
+$startupDir = [Environment]::GetFolderPath("Startup")
+$shortcutPath = Join-Path $startupDir "FileActivityTray.lnk"
+try {
+    $wsh = New-Object -ComObject WScript.Shell
+    $sc = $wsh.CreateShortcut($shortcutPath)
+    $sc.TargetPath = $trayLauncher
+    $sc.WorkingDirectory = $InstallDir
+    $sc.WindowStyle = 7  # minimized
+    $sc.Description = "FILE ACTIVITY tray icon (issue #151)"
+    $sc.Save()
+    Write-Host "  [OK] $shortcutPath" -ForegroundColor Green
+} catch {
+    Write-Host "  [UYARI] Shortcut olusturulamadi: $_" -ForegroundColor Yellow
+}
+
+Write-Host ""
+Write-Host "  Tray app kuruldu. Simdi baslatmak icin:" -ForegroundColor White
+Write-Host "    $trayLauncher" -ForegroundColor Cyan
+Write-Host ""
+Write-Host "  Bir sonraki logon'da otomatik baslar (Startup klasor kisayolu)." -ForegroundColor White
+Write-Host ""

--- a/deploy/setup-source.ps1
+++ b/deploy/setup-source.ps1
@@ -360,13 +360,56 @@ Write-Host "    $InstallDir\fa.cmd <komut>        - CLI (scan, source, restore .
 Write-Host "    $InstallDir\update.cmd            - En son master'a guncelle" -ForegroundColor Cyan
 Write-Host ""
 
-# --- Otomatik baslatma ---
-$answer = Read-Host "  Dashboard simdi baslasin mi? (E/H) [E]"
-if ($answer -ne "H" -and $answer -ne "h") {
-    Write-Host "  Dashboard baslatiliyor..." -ForegroundColor Cyan
-    Start-Process -FilePath "cmd.exe" -ArgumentList "/c", "`"$InstallDir\start_dashboard.cmd`"" -WindowStyle Normal
-    Start-Sleep -Seconds 3
-    Start-Process "http://localhost:$DashPort"
-    Write-Host "  [OK] Dashboard baslatildi. Tarayici acilmadiysa: http://localhost:$DashPort" -ForegroundColor Green
+# --- Issue #151: Servis modu (NSSM) opt-in ---
+# Default H to preserve current behavior; user must explicitly choose service mode.
+Write-Host ""
+Write-Host "  Hizmet olarak yuklensin mi (Windows Service, otomatik baslatma + crash recovery)?" -ForegroundColor White
+Write-Host "  [E] Evet  [H] Hayir (sadece manuel start_dashboard.cmd ile)" -ForegroundColor White
+$svcAnswer = Read-Host "  Secim (E/H) [H]"
+$serviceInstalled = $false
+if ($svcAnswer -eq "E" -or $svcAnswer -eq "e") {
+    $svcScript = Join-Path $InstallDir "deploy\install_service.ps1"
+    if (Test-Path $svcScript) {
+        Write-Host "  Servis kuruluyor (install_service.ps1)..." -ForegroundColor Cyan
+        & powershell -ExecutionPolicy Bypass -File $svcScript -InstallDir $InstallDir
+        if ($LASTEXITCODE -eq 0) { $serviceInstalled = $true }
+    } else {
+        Write-Host "  [UYARI] $svcScript bulunamadi - servis modu atlandi." -ForegroundColor Yellow
+    }
+}
+
+# --- Issue #151: Sistem tepsisi (tray) opt-in (servis kuruluysa anlamli) ---
+if ($serviceInstalled) {
+    Write-Host ""
+    Write-Host "  Sistem tepsisi simgesi yuklensin mi (durum gostergesi + tek tikla yeniden baslat)?" -ForegroundColor White
+    Write-Host "  [E] Evet  [H] Hayir" -ForegroundColor White
+    $trayAnswer = Read-Host "  Secim (E/H) [H]"
+    if ($trayAnswer -eq "E" -or $trayAnswer -eq "e") {
+        $trayScript = Join-Path $InstallDir "deploy\install_tray.ps1"
+        if (Test-Path $trayScript) {
+            & powershell -ExecutionPolicy Bypass -File $trayScript -InstallDir $InstallDir
+        } else {
+            Write-Host "  [UYARI] $trayScript bulunamadi - tray atlandi." -ForegroundColor Yellow
+        }
+    }
+}
+
+# --- Otomatik baslatma (sadece servis modu secilmediyse) ---
+if ($serviceInstalled) {
+    Write-Host ""
+    Write-Host "  Servis kurulu - dashboard zaten arka planda calisiyor." -ForegroundColor Green
+    Write-Host "  Tarayicida acmak icin: http://localhost:$DashPort" -ForegroundColor Yellow
+    try {
+        Start-Process "http://localhost:$DashPort"
+    } catch {}
+} else {
+    $answer = Read-Host "  Dashboard simdi baslasin mi? (E/H) [E]"
+    if ($answer -ne "H" -and $answer -ne "h") {
+        Write-Host "  Dashboard baslatiliyor..." -ForegroundColor Cyan
+        Start-Process -FilePath "cmd.exe" -ArgumentList "/c", "`"$InstallDir\start_dashboard.cmd`"" -WindowStyle Normal
+        Start-Sleep -Seconds 3
+        Start-Process "http://localhost:$DashPort"
+        Write-Host "  [OK] Dashboard baslatildi. Tarayici acilmadiysa: http://localhost:$DashPort" -ForegroundColor Green
+    }
 }
 Write-Host ""

--- a/deploy/uninstall_service.ps1
+++ b/deploy/uninstall_service.ps1
@@ -1,0 +1,86 @@
+<#
+.SYNOPSIS
+    Remove the FILE ACTIVITY Windows service installed by install_service.ps1.
+
+.DESCRIPTION
+    Issue #151 rollback path: stop the NSSM-managed service and remove its
+    Windows service entry. NSSM binary itself + log files are left in place
+    (under <InstallDir>\bin and <InstallDir>\logs) so the operator can
+    inspect them; delete those manually if you want a clean wipe.
+
+    After uninstall, start_dashboard.cmd is the only way to launch the
+    dashboard — back to the pre-#151 manual flow.
+
+.PARAMETER InstallDir
+    FILE ACTIVITY install root (default C:\FileActivity).
+
+.PARAMETER ServiceName
+    Windows service name (default FileActivity).
+
+.PARAMETER RemoveTrayShortcut
+    Switch — also delete the tray app shortcut from shell:startup. Off by
+    default to avoid surprises (the operator may want to keep it).
+
+.EXAMPLE
+    powershell -ExecutionPolicy Bypass -File C:\FileActivity\deploy\uninstall_service.ps1
+
+.NOTES
+    Requires Administrator. Companion: deploy\install_service.ps1.
+#>
+
+[CmdletBinding()]
+param(
+    [string]$InstallDir = "C:\FileActivity",
+    [string]$ServiceName = "FileActivity",
+    [switch]$RemoveTrayShortcut
+)
+
+$ErrorActionPreference = "Stop"
+
+Write-Host ""
+Write-Host "  +==========================================+" -ForegroundColor Cyan
+Write-Host "  |  FILE ACTIVITY - Service Kaldirma        |" -ForegroundColor Cyan
+Write-Host "  +==========================================+" -ForegroundColor Cyan
+Write-Host ""
+
+$isAdmin = ([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+if (-not $isAdmin) {
+    Write-Host "  [HATA] Bu script Yonetici olarak calistirilmalidir." -ForegroundColor Red
+    exit 1
+}
+
+$nssmExe = Join-Path $InstallDir "bin\nssm.exe"
+$svc = Get-Service -Name $ServiceName -ErrorAction SilentlyContinue
+
+if (-not $svc) {
+    Write-Host "  [BILGI] $ServiceName servisi zaten yok - islem yok." -ForegroundColor Yellow
+} else {
+    if (Test-Path $nssmExe) {
+        Write-Host "  Servis durduruluyor..." -ForegroundColor Yellow
+        & $nssmExe stop $ServiceName 2>&1 | Out-Null
+        Start-Sleep -Seconds 2
+        Write-Host "  Servis kaldiriliyor (nssm remove confirm)..." -ForegroundColor Yellow
+        & $nssmExe remove $ServiceName confirm 2>&1 | Out-Null
+        Write-Host "  [OK] Servis kaldirildi" -ForegroundColor Green
+    } else {
+        # NSSM yoksa SCM ile dene (eski sc create kurulumlari icin de calisir)
+        Write-Host "  [UYARI] $nssmExe yok - sc.exe ile kaldirilmaya calisilacak." -ForegroundColor Yellow
+        & sc.exe stop $ServiceName 2>&1 | Out-Null
+        Start-Sleep -Seconds 2
+        & sc.exe delete $ServiceName 2>&1 | Out-Null
+        Write-Host "  [OK] sc.exe ile kaldirildi" -ForegroundColor Green
+    }
+}
+
+if ($RemoveTrayShortcut) {
+    $startupShortcut = Join-Path ([Environment]::GetFolderPath("Startup")) "FileActivityTray.lnk"
+    if (Test-Path $startupShortcut) {
+        Remove-Item $startupShortcut -Force
+        Write-Host "  [OK] Tray shortcut silindi: $startupShortcut" -ForegroundColor Green
+    }
+}
+
+Write-Host ""
+Write-Host "  Servis kaldirildi. Dashboard'u manuel baslatmak icin:" -ForegroundColor White
+Write-Host "    $InstallDir\start_dashboard.cmd" -ForegroundColor Cyan
+Write-Host ""

--- a/docs/operator-runbook.md
+++ b/docs/operator-runbook.md
@@ -7,6 +7,7 @@
 İçindekiler:
 
 - [Kurulum (Install)](#kurulum-install)
+- [Service Mode Kurulum (issue #151)](#service-mode-kurulum-issue-151)
 - [Güncelleme (Update)](#guncelleme-update)
 - [Sık Karşılaşılan Senaryolar](#sik-karsilasilan-senaryolar)
 - [Performans Ayarı](#performans-ayari)
@@ -54,6 +55,132 @@ EXE'yi bir `config.yaml` yanına koy, çift tıkla. EXE statik bir snapshot —
 otomatik güncelleme istiyorsan kaynak install'u tercih et.
 
 İlgili: README "Quick Setup" bölümü.
+
+---
+
+## Service Mode Kurulum (issue #151)
+
+Operatör şikâyeti: "projeyi kapatmak açmak command prompt'ta işlem yapmak
+zahmetli oluyor". `start_dashboard.cmd` ile cmd penceresi açıp Task
+Manager'dan kapatma akışı dağıtık üretimde kabul edilemez. Service mode
+bu akışı bitirir.
+
+### Mimari
+
+NSSM (Non-Sucking Service Manager, BSD-like license) python.exe + main.py
+`dashboard` subcommand'ını gerçek bir Windows servisi olarak sarar:
+
+- `Start = SERVICE_AUTO_START` — boot'ta otomatik başlar
+- `AppExit Default Restart` — crash sonrası 5 sn delay ile yeniden başlar
+- `AppStdout / AppStderr` — `logs\service.out` ve `logs\service.err`
+  (10 MB'da rotate)
+
+NSSM zip'i `nssm.cc/release/nssm-2.24.zip` adresinden ilk kurulumda
+indirilir, `<InstallDir>\bin\nssm.exe` konumuna düşer.
+
+### Kurulum
+
+`setup-source.ps1` artık iki opt-in soru sorar (default H — geriye dönük
+uyumluluk için davranış değişmemeli):
+
+```
+Hizmet olarak yuklensin mi (Windows Service, otomatik baslatma + crash recovery)?
+[E] Evet  [H] Hayir (sadece manuel start_dashboard.cmd ile)
+```
+
+E seçilirse `deploy\install_service.ps1` çağrılır. Standalone kurmak için
+de manuel:
+
+```powershell
+# Yönetici PowerShell:
+powershell -ExecutionPolicy Bypass -File C:\FileActivity\deploy\install_service.ps1
+```
+
+Tray ikon (opsiyonel — durum göstergesi + sağ tık menü):
+
+```
+Sistem tepsisi simgesi yuklensin mi (durum gostergesi + tek tikla yeniden baslat)?
+[E] Evet  [H] Hayir
+```
+
+E seçilirse `pystray` + `Pillow` venv'e yüklenir, `start_tray.cmd`
+oluşturulur, Startup klasörüne kısayol bırakılır (logon'da otomatik).
+
+### Yönetim — üç yol
+
+**1. Services.msc (klasik):** "FILE ACTIVITY - File Share Monitor" satırı.
+Sağ tık → Start / Stop / Restart.
+
+**2. PowerShell cmdlet'leri** (`Import-Module FileActivity` sonrası):
+
+```powershell
+Start-FileActivityService
+Stop-FileActivityService
+Restart-FileActivityService
+Get-FileActivityServiceStatus    # Status + StartType döner
+
+# Servis kurulu değilse hata fırlatmaz, Status='NotInstalled' döner:
+if ((Get-FileActivityServiceStatus).Status -ne 'Running') {
+    Start-FileActivityService
+}
+```
+
+Her cmdlet yönetici hakkı gerektirir; non-admin session'da Türkçe friendly
+hata döner.
+
+**3. Tray ikon:** Sağ tık → Open Dashboard / Start / Stop / Restart /
+Open Logs Folder / Quit. Status renk kodu:
+
+- yeşil = Running
+- sarı  = StartPending / StopPending / Paused
+- kırmızı = Stopped / NotInstalled
+
+### Loglar
+
+NSSM stdout/stderr ayrı dosyalarda, 10 MB rotation:
+
+- `C:\FileActivity\logs\service.out` — uvicorn / dashboard normal çıktı
+- `C:\FileActivity\logs\service.err` — exception trace, crash detayı
+
+Watchdog/scheduler iç logları yine `config.yaml` `logging.path` altında.
+
+### Geri dönüş (rollback to manual mode)
+
+```powershell
+powershell -ExecutionPolicy Bypass -File C:\FileActivity\deploy\uninstall_service.ps1
+```
+
+NSSM servisi kaldırır. Tray kısayolunu da silmek için:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File C:\FileActivity\deploy\uninstall_service.ps1 -RemoveTrayShortcut
+```
+
+`start_dashboard.cmd` her zaman çalışmaya devam eder — debug / standalone
+senaryolar için saklı.
+
+### Smoke testi (servis kurulduktan sonra)
+
+```powershell
+# 1) Status:
+Get-FileActivityServiceStatus
+# Beklenen: Status=Running, StartType=Automatic
+
+# 2) HTTP probe:
+Invoke-RestMethod http://localhost:8085/api/system/status
+
+# 3) Crash recovery testi (son cümle Run as Admin):
+Stop-Process -Name python -Force
+Start-Sleep -Seconds 8
+Get-FileActivityServiceStatus    # NSSM 5 sn delay + restart sonrası tekrar Running
+
+# 4) Reboot persistence:
+Restart-Computer
+# Boot sonrası: Get-Service FileActivity -> Running (login bile gerekmez)
+```
+
+İlgili: issue #151, `deploy\install_service.ps1`,
+`deploy\uninstall_service.ps1`, `src\tray\tray_app.py`.
 
 ---
 

--- a/powershell/FileActivity/FileActivity.psd1
+++ b/powershell/FileActivity/FileActivity.psd1
@@ -15,7 +15,12 @@
         'Get-FileActivityAudit',
         'Test-FileActivityAuditChain',
         'Set-FileActivityBaseUrl',
-        'Get-FileActivityBaseUrl'
+        'Get-FileActivityBaseUrl',
+        # Issue #151: service control cmdlets
+        'Start-FileActivityService',
+        'Stop-FileActivityService',
+        'Restart-FileActivityService',
+        'Get-FileActivityServiceStatus'
     )
     CmdletsToExport = @()
     VariablesToExport = @()

--- a/powershell/FileActivity/Functions/Get-FileActivityServiceStatus.ps1
+++ b/powershell/FileActivity/Functions/Get-FileActivityServiceStatus.ps1
@@ -1,0 +1,50 @@
+function Get-FileActivityServiceStatus {
+    <#
+    .SYNOPSIS
+        Show current state and start type of the FILE ACTIVITY Windows service.
+
+    .DESCRIPTION
+        Returns Status (Running/Stopped/...) and StartType (Automatic/Manual/
+        Disabled) of the NSSM-managed "FileActivity" service installed by
+        deploy\install_service.ps1 (issue #151). Read-only; non-admin
+        sessions can call it.
+
+        If the service is not installed, returns a PSCustomObject with
+        Status='NotInstalled' rather than throwing — friendlier for
+        scripts that branch on install state.
+
+    .PARAMETER ServiceName
+        Override the service name. Default "FileActivity".
+
+    .EXAMPLE
+        Get-FileActivityServiceStatus
+
+    .EXAMPLE
+        if ((Get-FileActivityServiceStatus).Status -ne 'Running') { Start-FileActivityService }
+
+    .OUTPUTS
+        PSCustomObject with Name, Status, StartType, DisplayName
+    #>
+    [CmdletBinding()]
+    param(
+        [string]$ServiceName = 'FileActivity'
+    )
+    try {
+        $svc = Get-Service -Name $ServiceName -ErrorAction Stop
+        [PSCustomObject]@{
+            Name        = $svc.Name
+            Status      = $svc.Status
+            StartType   = $svc.StartType
+            DisplayName = $svc.DisplayName
+        }
+    } catch [Microsoft.PowerShell.Commands.ServiceCommandException] {
+        [PSCustomObject]@{
+            Name        = $ServiceName
+            Status      = 'NotInstalled'
+            StartType   = $null
+            DisplayName = $null
+        }
+    } catch {
+        Write-Error "Get-FileActivityServiceStatus failed: $_"
+    }
+}

--- a/powershell/FileActivity/Functions/Restart-FileActivityService.ps1
+++ b/powershell/FileActivity/Functions/Restart-FileActivityService.ps1
@@ -1,0 +1,37 @@
+function Restart-FileActivityService {
+    <#
+    .SYNOPSIS
+        Restart the FILE ACTIVITY Windows service.
+
+    .DESCRIPTION
+        Wraps Restart-Service for the NSSM-managed "FileActivity" service
+        (issue #151). Useful after a config change or update.cmd run when
+        you want to bounce the dashboard without dropping to Services.msc.
+
+    .PARAMETER ServiceName
+        Override the service name. Default "FileActivity".
+
+    .EXAMPLE
+        Restart-FileActivityService
+
+    .OUTPUTS
+        Microsoft.PowerShell.Commands.ServiceController
+    #>
+    [CmdletBinding()]
+    param(
+        [string]$ServiceName = 'FileActivity'
+    )
+    try {
+        $svc = Get-Service -Name $ServiceName -ErrorAction Stop
+        Restart-Service -InputObject $svc -Force -ErrorAction Stop
+        Get-Service -Name $ServiceName
+    } catch [System.InvalidOperationException] {
+        if ($_.Exception.Message -match 'access is denied|Access is denied') {
+            Write-Error "Restart-FileActivityService: Yonetici hakki gerekli."
+        } else {
+            Write-Error "Restart-FileActivityService failed: $_"
+        }
+    } catch {
+        Write-Error "Restart-FileActivityService failed: $_"
+    }
+}

--- a/powershell/FileActivity/Functions/Start-FileActivityService.ps1
+++ b/powershell/FileActivity/Functions/Start-FileActivityService.ps1
@@ -1,0 +1,44 @@
+function Start-FileActivityService {
+    <#
+    .SYNOPSIS
+        Start the FILE ACTIVITY Windows service.
+
+    .DESCRIPTION
+        Wraps Start-Service for the NSSM-managed "FileActivity" service
+        installed via deploy\install_service.ps1 (issue #151). Requires the
+        current PowerShell session to run elevated; otherwise Windows
+        rejects the service control request and we surface a friendly
+        error.
+
+    .PARAMETER ServiceName
+        Override the service name. Default "FileActivity" matches what
+        install_service.ps1 creates.
+
+    .EXAMPLE
+        Start-FileActivityService
+
+    .EXAMPLE
+        Start-FileActivityService -ServiceName 'FileActivity-Dev'
+
+    .OUTPUTS
+        Microsoft.PowerShell.Commands.ServiceController
+    #>
+    [CmdletBinding()]
+    param(
+        [string]$ServiceName = 'FileActivity'
+    )
+    try {
+        $svc = Get-Service -Name $ServiceName -ErrorAction Stop
+        Start-Service -InputObject $svc -ErrorAction Stop
+        # Re-fetch so caller sees the updated Status
+        Get-Service -Name $ServiceName
+    } catch [System.InvalidOperationException] {
+        if ($_.Exception.Message -match 'access is denied|Access is denied') {
+            Write-Error "Start-FileActivityService: Yonetici hakki gerekli. PowerShell'i 'Yonetici olarak calistir' ile yeniden acin."
+        } else {
+            Write-Error "Start-FileActivityService failed: $_"
+        }
+    } catch {
+        Write-Error "Start-FileActivityService failed: $_"
+    }
+}

--- a/powershell/FileActivity/Functions/Stop-FileActivityService.ps1
+++ b/powershell/FileActivity/Functions/Stop-FileActivityService.ps1
@@ -1,0 +1,38 @@
+function Stop-FileActivityService {
+    <#
+    .SYNOPSIS
+        Stop the FILE ACTIVITY Windows service.
+
+    .DESCRIPTION
+        Wraps Stop-Service for the NSSM-managed "FileActivity" service
+        (issue #151). Requires elevation; non-admin sessions surface a
+        friendly error. Uses -Force to drop dependent services if any
+        appear in the future.
+
+    .PARAMETER ServiceName
+        Override the service name. Default "FileActivity".
+
+    .EXAMPLE
+        Stop-FileActivityService
+
+    .OUTPUTS
+        Microsoft.PowerShell.Commands.ServiceController
+    #>
+    [CmdletBinding()]
+    param(
+        [string]$ServiceName = 'FileActivity'
+    )
+    try {
+        $svc = Get-Service -Name $ServiceName -ErrorAction Stop
+        Stop-Service -InputObject $svc -Force -ErrorAction Stop
+        Get-Service -Name $ServiceName
+    } catch [System.InvalidOperationException] {
+        if ($_.Exception.Message -match 'access is denied|Access is denied') {
+            Write-Error "Stop-FileActivityService: Yonetici hakki gerekli."
+        } else {
+            Write-Error "Stop-FileActivityService failed: $_"
+        }
+    } catch {
+        Write-Error "Stop-FileActivityService failed: $_"
+    }
+}

--- a/powershell/Tests/FileActivity.Tests.ps1
+++ b/powershell/Tests/FileActivity.Tests.ps1
@@ -22,7 +22,12 @@ Describe 'FileActivity Module' {
             'Get-FileActivityRansomware',
             'Invoke-FileActivityArchive',
             'Get-FileActivityAudit',
-            'Test-FileActivityAuditChain'
+            'Test-FileActivityAuditChain',
+            # Issue #151: service control cmdlets
+            'Start-FileActivityService',
+            'Stop-FileActivityService',
+            'Restart-FileActivityService',
+            'Get-FileActivityServiceStatus'
         )
         foreach ($cmd in $expected) {
             $exports | Should -Contain $cmd

--- a/requirements-tray.txt
+++ b/requirements-tray.txt
@@ -1,0 +1,7 @@
+# Optional dependencies for the system tray app (issue #151).
+# Not part of requirements.txt — install only if you want the tray UI.
+#
+#     pip install -r requirements-tray.txt
+#
+pystray>=0.19.5
+Pillow>=10.0.0

--- a/src/tray/__init__.py
+++ b/src/tray/__init__.py
@@ -1,0 +1,7 @@
+"""Optional system tray app for FILE ACTIVITY.
+
+Issue #151: pystray-based tray icon that lets the operator start/stop/restart
+the FileActivity Windows service and open the dashboard with a single click.
+Tray app is fully optional — pystray + Pillow are NOT in requirements.txt.
+Install with `pip install -r requirements-tray.txt` if you want it.
+"""

--- a/src/tray/tray_app.py
+++ b/src/tray/tray_app.py
@@ -1,0 +1,261 @@
+"""FILE ACTIVITY system tray app (issue #151).
+
+Minimal pystray + Pillow tray icon that wraps the FileActivity Windows service:
+
+    Right-click menu:
+      - Open Dashboard    -> opens http://localhost:8085 in default browser
+      - Start Service
+      - Stop Service
+      - Restart Service
+      - Open Logs Folder  -> explorer.exe <InstallDir>\\logs
+      - Quit
+
+    Status icon:
+      green  = service Running
+      yellow = service StartPending / StopPending / Paused
+      red    = service Stopped / NotInstalled / unknown
+
+The tray app is optional. pystray + Pillow are not in requirements.txt;
+install via requirements-tray.txt. The tray app does NOT itself host the
+dashboard — it only controls the FileActivity service installed by
+deploy/install_service.ps1.
+
+Run:
+    python -m src.tray.tray_app
+
+Service control commands assume the service name "FileActivity" (default
+from install_service.ps1). Override with --service-name.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import subprocess
+import sys
+import threading
+import time
+import webbrowser
+
+logger = logging.getLogger("file_activity.tray")
+
+DEFAULT_SERVICE_NAME = "FileActivity"
+DEFAULT_DASHBOARD_URL = "http://localhost:8085"
+DEFAULT_INSTALL_DIR = r"C:\FileActivity"
+POLL_INTERVAL_SECONDS = 5
+
+
+def _run_powershell(command: str, timeout: int = 15) -> tuple[int, str, str]:
+    """Run a PowerShell one-liner. Returns (exit_code, stdout, stderr).
+
+    We shell out to powershell.exe rather than depend on pywin32 so the tray
+    app remains portable to plain Python venvs.
+    """
+    try:
+        proc = subprocess.run(
+            [
+                "powershell.exe",
+                "-NoProfile",
+                "-NonInteractive",
+                "-ExecutionPolicy", "Bypass",
+                "-Command", command,
+            ],
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+        return proc.returncode, proc.stdout.strip(), proc.stderr.strip()
+    except FileNotFoundError:
+        return 127, "", "powershell.exe not found"
+    except subprocess.TimeoutExpired:
+        return 124, "", f"timeout after {timeout}s"
+
+
+def get_service_status(service_name: str) -> str:
+    """Return one of: Running, Stopped, StartPending, StopPending, Paused,
+    NotInstalled, Unknown."""
+    rc, out, _err = _run_powershell(
+        f"(Get-Service -Name '{service_name}' -ErrorAction SilentlyContinue).Status"
+    )
+    if rc != 0 or not out:
+        return "NotInstalled"
+    return out.strip() or "Unknown"
+
+
+def start_service(service_name: str) -> tuple[bool, str]:
+    rc, out, err = _run_powershell(f"Start-Service -Name '{service_name}'")
+    return rc == 0, err or out
+
+
+def stop_service(service_name: str) -> tuple[bool, str]:
+    rc, out, err = _run_powershell(f"Stop-Service -Name '{service_name}' -Force")
+    return rc == 0, err or out
+
+
+def restart_service(service_name: str) -> tuple[bool, str]:
+    rc, out, err = _run_powershell(f"Restart-Service -Name '{service_name}' -Force")
+    return rc == 0, err or out
+
+
+def _make_icon_image(color: str):
+    """Build a 64x64 RGBA PIL image of a filled circle. Local import so the
+    module can still be imported in environments without Pillow (status checks
+    work without a GUI)."""
+    from PIL import Image, ImageDraw  # type: ignore
+
+    img = Image.new("RGBA", (64, 64), (0, 0, 0, 0))
+    draw = ImageDraw.Draw(img)
+    fill = {
+        "green":  (46, 160, 67, 255),
+        "yellow": (210, 153, 34, 255),
+        "red":    (218, 54, 51, 255),
+    }.get(color, (128, 128, 128, 255))
+    draw.ellipse((6, 6, 58, 58), fill=fill, outline=(20, 20, 20, 255), width=2)
+    return img
+
+
+def _color_for_status(status: str) -> str:
+    if status == "Running":
+        return "green"
+    if status in ("StartPending", "StopPending", "Paused", "PausePending", "ContinuePending"):
+        return "yellow"
+    return "red"
+
+
+class TrayApp:
+    """Wires pystray.Icon to the service control helpers above."""
+
+    def __init__(
+        self,
+        service_name: str = DEFAULT_SERVICE_NAME,
+        dashboard_url: str = DEFAULT_DASHBOARD_URL,
+        install_dir: str = DEFAULT_INSTALL_DIR,
+    ) -> None:
+        self.service_name = service_name
+        self.dashboard_url = dashboard_url
+        self.install_dir = install_dir
+        self._icon = None
+        self._stop_event = threading.Event()
+        self._last_status = "Unknown"
+
+    # --- menu actions ---
+    def _on_open_dashboard(self, _icon=None, _item=None) -> None:
+        try:
+            webbrowser.open(self.dashboard_url)
+        except Exception as e:
+            logger.error("Open dashboard failed: %s", e)
+
+    def _on_start(self, _icon=None, _item=None) -> None:
+        ok, msg = start_service(self.service_name)
+        logger.info("Start-Service %s -> ok=%s msg=%s", self.service_name, ok, msg)
+        self._refresh_status(force=True)
+
+    def _on_stop(self, _icon=None, _item=None) -> None:
+        ok, msg = stop_service(self.service_name)
+        logger.info("Stop-Service %s -> ok=%s msg=%s", self.service_name, ok, msg)
+        self._refresh_status(force=True)
+
+    def _on_restart(self, _icon=None, _item=None) -> None:
+        ok, msg = restart_service(self.service_name)
+        logger.info("Restart-Service %s -> ok=%s msg=%s", self.service_name, ok, msg)
+        self._refresh_status(force=True)
+
+    def _on_open_logs(self, _icon=None, _item=None) -> None:
+        logs_dir = os.path.join(self.install_dir, "logs")
+        try:
+            os.startfile(logs_dir)  # type: ignore[attr-defined]  # Windows-only
+        except Exception as e:
+            logger.error("Open logs folder failed: %s", e)
+
+    def _on_quit(self, icon=None, _item=None) -> None:
+        self._stop_event.set()
+        if icon is not None:
+            icon.stop()
+        elif self._icon is not None:
+            self._icon.stop()
+
+    # --- status polling ---
+    def _refresh_status(self, force: bool = False) -> None:
+        status = get_service_status(self.service_name)
+        if status == self._last_status and not force:
+            return
+        self._last_status = status
+        if self._icon is None:
+            return
+        try:
+            self._icon.icon = _make_icon_image(_color_for_status(status))
+            self._icon.title = f"FILE ACTIVITY ({status})"
+        except Exception as e:
+            logger.debug("Icon refresh failed: %s", e)
+
+    def _poll_loop(self) -> None:
+        while not self._stop_event.is_set():
+            try:
+                self._refresh_status()
+            except Exception as e:
+                logger.debug("Status poll failed: %s", e)
+            self._stop_event.wait(POLL_INTERVAL_SECONDS)
+
+    # --- entry point ---
+    def run(self) -> int:
+        try:
+            import pystray  # type: ignore
+        except ImportError:
+            sys.stderr.write(
+                "pystray not installed. Run: pip install -r requirements-tray.txt\n"
+            )
+            return 2
+
+        menu = pystray.Menu(
+            pystray.MenuItem("Open Dashboard", self._on_open_dashboard, default=True),
+            pystray.MenuItem("Start Service", self._on_start),
+            pystray.MenuItem("Stop Service", self._on_stop),
+            pystray.MenuItem("Restart Service", self._on_restart),
+            pystray.Menu.SEPARATOR,
+            pystray.MenuItem("Open Logs Folder", self._on_open_logs),
+            pystray.Menu.SEPARATOR,
+            pystray.MenuItem("Quit", self._on_quit),
+        )
+
+        initial_status = get_service_status(self.service_name)
+        self._last_status = initial_status
+        self._icon = pystray.Icon(
+            "FileActivity",
+            icon=_make_icon_image(_color_for_status(initial_status)),
+            title=f"FILE ACTIVITY ({initial_status})",
+            menu=menu,
+        )
+
+        poller = threading.Thread(target=self._poll_loop, daemon=True)
+        poller.start()
+        try:
+            self._icon.run()
+        finally:
+            self._stop_event.set()
+        return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="FILE ACTIVITY system tray (issue #151)")
+    parser.add_argument("--service-name", default=DEFAULT_SERVICE_NAME)
+    parser.add_argument("--dashboard-url", default=DEFAULT_DASHBOARD_URL)
+    parser.add_argument("--install-dir", default=DEFAULT_INSTALL_DIR)
+    parser.add_argument("--log-level", default="WARNING")
+    args = parser.parse_args(argv)
+
+    logging.basicConfig(
+        level=getattr(logging, args.log_level.upper(), logging.WARNING),
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    )
+
+    app = TrayApp(
+        service_name=args.service_name,
+        dashboard_url=args.dashboard_url,
+        install_dir=args.install_dir,
+    )
+    return app.run()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_powershell_cmdlets.ps1
+++ b/tests/test_powershell_cmdlets.ps1
@@ -1,0 +1,112 @@
+# Smoke tests for the FileActivity PowerShell module — issue #151 service
+# control cmdlets specifically. Designed to run with or without Pester.
+#
+# With Pester:   Invoke-Pester -Path tests\test_powershell_cmdlets.ps1
+# Without:       powershell -ExecutionPolicy Bypass -File tests\test_powershell_cmdlets.ps1
+#
+# Notes:
+#   - Tests do NOT actually start/stop a real service. They verify the module
+#     loads, the four service cmdlets are exported, and each ships
+#     comment-based help. This is enough to catch the common regression of
+#     forgetting to add a function to FileActivity.psd1's FunctionsToExport.
+#   - Calling the cmdlets without a real "FileActivity" service installed
+#     would surface a Get-Service error — that's a runtime concern, not a
+#     module-shape concern, so we don't exercise it here.
+
+$ErrorActionPreference = 'Stop'
+$repoRoot = Split-Path -Parent $PSScriptRoot
+$modulePath = Join-Path $repoRoot 'powershell\FileActivity\FileActivity.psd1'
+
+$serviceCmdlets = @(
+    'Start-FileActivityService',
+    'Stop-FileActivityService',
+    'Restart-FileActivityService',
+    'Get-FileActivityServiceStatus'
+)
+
+function Invoke-PesterSuite {
+    Describe 'FileActivity service cmdlets (issue #151)' {
+        BeforeAll {
+            Import-Module $modulePath -Force
+        }
+        AfterAll {
+            Remove-Module FileActivity -Force -ErrorAction SilentlyContinue
+        }
+
+        It 'Exports the four service control cmdlets' {
+            $exports = (Get-Module FileActivity).ExportedFunctions.Keys
+            foreach ($cmd in $serviceCmdlets) {
+                $exports | Should -Contain $cmd
+            }
+        }
+
+        It 'Each service cmdlet ships comment-based help' {
+            foreach ($cmd in $serviceCmdlets) {
+                $help = Get-Help $cmd -ErrorAction Stop
+                $help.Synopsis | Should -Not -BeNullOrEmpty
+            }
+        }
+
+        It 'Get-FileActivityServiceStatus returns NotInstalled instead of throwing when service absent' {
+            $result = Get-FileActivityServiceStatus -ServiceName 'FileActivity-NonExistent-Smoke'
+            $result.Status | Should -Be 'NotInstalled'
+        }
+    }
+}
+
+function Invoke-PlainSuite {
+    Write-Host "[smoke] Importing module: $modulePath"
+    Import-Module $modulePath -Force
+
+    $failures = 0
+
+    Write-Host "[smoke] Verifying service cmdlets are exported..."
+    $exports = (Get-Module FileActivity).ExportedFunctions.Keys
+    foreach ($cmd in $serviceCmdlets) {
+        if ($exports -contains $cmd) {
+            Write-Host "  [OK] $cmd"
+        } else {
+            Write-Host "  [FAIL] $cmd not exported" -ForegroundColor Red
+            $failures++
+        }
+    }
+
+    Write-Host "[smoke] Verifying comment-based help..."
+    foreach ($cmd in $serviceCmdlets) {
+        $help = Get-Help $cmd -ErrorAction SilentlyContinue
+        if ($help -and $help.Synopsis) {
+            Write-Host "  [OK] help for $cmd"
+        } else {
+            Write-Host "  [FAIL] no help for $cmd" -ForegroundColor Red
+            $failures++
+        }
+    }
+
+    Write-Host "[smoke] Verifying Get-FileActivityServiceStatus returns NotInstalled for missing service..."
+    try {
+        $result = Get-FileActivityServiceStatus -ServiceName 'FileActivity-NonExistent-Smoke'
+        if ($result.Status -eq 'NotInstalled') {
+            Write-Host "  [OK] Status=NotInstalled"
+        } else {
+            Write-Host "  [FAIL] expected NotInstalled, got: $($result.Status)" -ForegroundColor Red
+            $failures++
+        }
+    } catch {
+        Write-Host "  [FAIL] threw: $_" -ForegroundColor Red
+        $failures++
+    }
+
+    Remove-Module FileActivity -Force -ErrorAction SilentlyContinue
+
+    if ($failures -gt 0) {
+        Write-Host "[smoke] FAILED ($failures errors)" -ForegroundColor Red
+        exit 1
+    }
+    Write-Host "[smoke] All checks passed" -ForegroundColor Green
+}
+
+if (Get-Module -ListAvailable -Name Pester) {
+    Invoke-PesterSuite
+} else {
+    Invoke-PlainSuite
+}


### PR DESCRIPTION
## Summary
Closes #151 — cmd zahmetinden kurtulma. NSSM-based Windows Service + opt-in system tray + 4 PowerShell cmdlets.

### Service mode (NSSM)
- `deploy/install_service.ps1` — admin gate; downloads nssm.exe on demand to `<InstallDir>\bin\nssm.exe`; configures auto-start + AppExit Restart + log rotation
- `deploy/uninstall_service.ps1` — clean removal; `start_dashboard.cmd` continues to work after
- `setup-source.ps1` — opt-in prompt: "Hizmet olarak yuklensin mi? [E/H]" (default **H**, zero behaviour change for existing flow)

### Tray app (opt-in)
- `src/tray/tray_app.py` — pystray + PIL, status icon (green/yellow/red), right-click menu (Start/Stop/Restart/Open Dashboard/Open Logs/Quit)
- `requirements-tray.txt` (NEW) — opt-in deps
- `deploy/install_tray.ps1` — second prompt; copies tray app + Startup folder shortcut

### PowerShell cmdlets (4)
Extends existing `FileActivity` module:
- `Start-FileActivityService`, `Stop-FileActivityService`, `Restart-FileActivityService`, `Get-FileActivityServiceStatus`
- `Get-FileActivityServiceStatus` returns `Status='NotInstalled'` instead of throwing → scripts can branch without try/catch
- All cmdlets have comment-based help

### Documentation
- `docs/operator-runbook.md` — new "Service Mode Kurulum" section (install, status, uninstall, rollback)

## Decisions
- **nssm.exe NOT bundled** — downloaded on demand. Keeps repo lean. `-NssmUrl` parameter lets restricted-network operators substitute. Bundling deferred until customers ask for offline installs.
- **Tray app uses `pythonw.exe`** when available (no console window); falls back to `python.exe`.
- **Default H for both prompts** in setup-source.ps1 — existing customers' flow unchanged.
- **Tray = real value, not overhead** — eliminates "is it running?" trips to Task Manager. Strictly opt-in (separate requirements file, lazy pystray import).

## Test plan (manual on Windows VM, sandbox can't run)
- [ ] Service install + auto-start + crash recovery (NSSM AppExit Restart)
- [ ] Restart-Computer survival
- [ ] PowerShell cmdlet roundtrip
- [ ] Tray icon shows correct status, Restart menu item bounces service
- [ ] Uninstall fully removes service
- [ ] `start_dashboard.cmd` still works post-uninstall

https://claude.ai/code/session_0f8b12be-df27-4551-8160-a87913f51890

---
_Generated by [Claude Code](https://claude.ai/code/session_01A1UzS1A4DZNk1akoP4uhZ7)_