### PR TITLE
Security Phase 1: bearer auth + dry_run default + approval safety (closes #158 Phase 1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,34 @@ launch.
 
 Dashboard: **http://localhost:8085**
 
+## Dashboard authentication (issue #158)
+
+Since v1.9.0-rc2 the dashboard ships with a **bearer-token gate enabled by default** and binds to **127.0.0.1** unless the operator explicitly opts into a LAN bind. The token never lives in `config.yaml` — it is read from the `FILEACTIVITY_DASHBOARD_TOKEN` environment variable.
+
+### Local single-host install (no token needed)
+
+`dashboard.auth.allow_unauth_localhost: true` in the default config means callers from `127.0.0.1` / `::1` / `localhost` bypass the gate. Open `http://localhost:8085` from RDP and everything works as before — no token export required.
+
+### Exposing the dashboard on a LAN
+
+1. Generate and export a token (any high-entropy random string):
+   ```powershell
+   $env:FILEACTIVITY_DASHBOARD_TOKEN = [System.Convert]::ToBase64String((1..32 | ForEach-Object { Get-Random -Maximum 256 }))
+   ```
+   Persist it for the service account via `setx FILEACTIVITY_DASHBOARD_TOKEN ...` or your secrets manager — *not* in `config.yaml`.
+2. Start the dashboard with an explicit bind:
+   ```powershell
+   python main.py dashboard --bind 0.0.0.0
+   ```
+3. Hit the API from a remote workstation:
+   ```powershell
+   $tok = $env:FILEACTIVITY_DASHBOARD_TOKEN
+   Invoke-RestMethod -Uri "http://server:8085/api/system/health" `
+                     -Headers @{ Authorization = "Bearer $tok" }
+   ```
+
+If `dashboard.auth.enabled: false` AND `--bind 0.0.0.0` are both set, `main.py` refuses to start unless the operator also passes the deliberately awkward `--i-know-what-im-doing` flag — see `docs/operator-runbook.md` for the rationale.
+
 ## Project Structure
 
 ```

--- a/config.yaml
+++ b/config.yaml
@@ -202,7 +202,12 @@ duplicates:
 
 archiving:
   verify_checksum: true       # SHA-256 doğrulama
-  dry_run: false              # taşımadan sadece raporla
+  # Issue #158 (C-2) — safe-by-default. With dry_run=true the engine
+  # walks the matched fileset, logs the planned moves, and updates the
+  # archive index, but does NOT touch the source files. Operators flip
+  # this off (or pass dry_run=false + confirm=true on the API) only
+  # after they have inspected the dry-run report.
+  dry_run: true               # taşımadan sadece raporla
   cleanup_empty_dirs: true    # boş dizinleri temizle
 
 reports:
@@ -225,8 +230,28 @@ forecast:
   alarm_lead_days: 30              # alarm tarihi bu kadar gun icinde ise digest'e ekle
 
 dashboard:
-  host: "0.0.0.0"
+  # Issue #158 (C-1) — default-bind to loopback. Explicit
+  # ``main.py dashboard --bind 0.0.0.0`` (with auth.enabled=true OR the
+  # ``--i-know-what-im-doing`` opt-out) is required to expose the
+  # dashboard on a LAN.
+  host: "127.0.0.1"
   port: 8085
+  auth:
+    # Bearer-token gate enforced by src.security.dashboard_auth +
+    # FastAPI middleware in src.dashboard.api.create_app.
+    #   * enabled=true   → bearer token required from non-localhost.
+    #   * enabled=false  → legacy unauthenticated mode (NOT recommended
+    #                      with host=0.0.0.0; main.py refuses unless the
+    #                      operator passes --i-know-what-im-doing).
+    # Token NEVER lives in this file — export it via ``token_env`` so a
+    # leaked config does not carry the credential.
+    enabled: true
+    token_env: "FILEACTIVITY_DASHBOARD_TOKEN"
+    # Localhost callers (127.0.0.1 / ::1 / localhost) bypass the bearer
+    # check by default so single-host installs and operator browsing
+    # from RDP keep working without configuration. Set to false to
+    # require the token from localhost too.
+    allow_unauth_localhost: true
 
 security:
   # Fidye yazilimi tespit motoru (#37). Watcher event akisini dinler,

--- a/docs/operator-runbook.md
+++ b/docs/operator-runbook.md
@@ -184,6 +184,118 @@ Restart-Computer
 
 ---
 
+## Dashboard Bearer Token (issue #158)
+
+Customer LAN deployments expose the dashboard to every host on the
+subnet. v1.9.0-rc2 ships authentication ON by default + a 127.0.0.1
+default bind. The two together close finding **C-1** from
+`docs/architecture/security-audit-2026-04-28.md`.
+
+### Konfig hatlari (config.yaml)
+
+```yaml
+dashboard:
+  host: "127.0.0.1"          # default: loopback only
+  port: 8085
+  auth:
+    enabled: true                                 # default ON
+    token_env: "FILEACTIVITY_DASHBOARD_TOKEN"     # NEVER put the token in this file
+    allow_unauth_localhost: true                  # 127.0.0.1 / ::1 / localhost bypass
+```
+
+### Operasyonel modlar
+
+| Mod | host | auth.enabled | Tarayicidan | Token gerekli mi |
+|---|---|---|---|---|
+| Tek-host RDP (default) | 127.0.0.1 | true | http://localhost:8085 | Hayir (localhost bypass) |
+| LAN expose, secure | 0.0.0.0 | true | http://server:8085 | EVET (Authorization: Bearer ...) |
+| LAN expose, unauth | 0.0.0.0 | false | http://server:8085 | REDDEDILIR — `--i-know-what-im-doing` ister |
+
+### Token uretme + export
+
+PowerShell tarafinda hizli bir 32-byte rastgele token:
+
+```powershell
+$tok = [System.Convert]::ToBase64String((1..32 | ForEach-Object { Get-Random -Maximum 256 }))
+# Servis hesabina kalici export (admin gerekir):
+setx /M FILEACTIVITY_DASHBOARD_TOKEN $tok
+# Sadece su anki session icin:
+$env:FILEACTIVITY_DASHBOARD_TOKEN = $tok
+```
+
+NSSM service mode kullaniyorsan: NSSM `AppEnvironmentExtra`
+ayarini kullan (`nssm set FileActivity AppEnvironmentExtra
+FILEACTIVITY_DASHBOARD_TOKEN=...`) — process'in environment'i
+kontrol panelinden setx kadar guvenilir bir kanaldir ve restart
+sonrasi otomatik gelir.
+
+### LAN'dan API cagirma
+
+```powershell
+$headers = @{ Authorization = "Bearer $env:FILEACTIVITY_DASHBOARD_TOKEN" }
+Invoke-RestMethod -Uri "http://server:8085/api/system/health" -Headers $headers
+
+# POST ornegi: dry-run arsiv
+Invoke-RestMethod -Uri "http://server:8085/api/archive/run" `
+                  -Method Post -Headers $headers `
+                  -ContentType "application/json" `
+                  -Body (ConvertTo-Json @{ source_id=1; days=365; dry_run=$true })
+```
+
+### Token rotate
+
+Token cache process-local. Yeni bir token export et + servisi restart et:
+
+```powershell
+setx /M FILEACTIVITY_DASHBOARD_TOKEN <yeni-token>
+Restart-Service FileActivity   # NSSM ile kurulduysa
+```
+
+### `--i-know-what-im-doing` flag — neden boyle bilerek garip?
+
+`main.py dashboard --bind 0.0.0.0` + `dashboard.auth.enabled: false`
+kombinasyonu, tum dashboard endpoint'lerini auth'siz LAN'a aciyor —
+dosya tasi, snapshot restore, AD config write, hepsi. v1.9.0-rc2
+itibariyle bu kombinasyonu tespit edersek `main.py` baslatmayi
+**reddediyor** ve bir CRITICAL log atiyor. Operator bilincli olarak
+istediyse `--i-know-what-im-doing` flag'i ile override edebilir.
+Flag'i komut hafizasinda tutmak guc: amac zaten budur.
+
+Production'da bu modu kullanma. Reverse-proxy/VPN arkasinda zaten
+`auth.enabled=true` + `allow_unauth_localhost=true` (proxy bind'i
+loopback'tir) yeterlidir.
+
+### C-2: archiving.dry_run + confirm gate
+
+Ayni PR'de `archiving.dry_run` default `true` oldu. `/api/archive/run`
+ve `/api/archive/selective` endpoint'leri artik `dry_run=false` icin
+`confirm=true` body alani sart kosuyor. Frontend bunu zaten gonderiyor;
+kendi script'lerin varsa ve "tasimadi" diyorsan once dry-run'da
+ciktisini incele, sonra `dry_run=false, confirm=true` ile gonder.
+
+```powershell
+# Dry-run (tasimaz, sadece raporlar):
+Invoke-RestMethod ... -Body (ConvertTo-Json @{
+    source_id = 1; days = 365; dry_run = $true
+})
+
+# Real run (gercekten tasir):
+Invoke-RestMethod ... -Body (ConvertTo-Json @{
+    source_id = 1; days = 365; dry_run = $false; confirm = $true
+})
+```
+
+### H-2: approvals + identity_source guard
+
+`approvals.enabled: true` ile `approvals.identity_source: client_supplied`
+yan yana KOYULAMAZ. Bu kombo iki-kisi kuralini etkisiz kiliyor (ikinci
+kisi kendi adini istedigi gibi yazabilir). Dashboard bu durumda
+ApprovalRegistry'i `None` ile birakir, CRITICAL loglar, ve approval
+endpoint'leri 503 doner. Cozum: `identity_source`'u `windows` (Windows
+host) veya `header` (auth proxy onunde) olarak ayarla, sonra restart.
+
+---
+
 ## Güncelleme (Update)
 
 Kurulum dizininde `update.cmd` yer alır. Çalıştırınca:

--- a/main.py
+++ b/main.py
@@ -804,17 +804,62 @@ def schedule_remove(ctx, task_id):
 
 @cli.command("dashboard")
 @click.option("--host", "-h", default=None, help="Host adresi")
+@click.option("--bind", "-b", default=None,
+              help="Alias for --host; matches issue #158 docs (e.g. 0.0.0.0).")
 @click.option("--port", "-p", type=int, default=None, help="Port numarası")
+@click.option("--i-know-what-im-doing", "ack_unsafe", is_flag=True, default=False,
+              help="Acknowledge an explicit insecure binding (--bind 0.0.0.0 "
+                   "with auth disabled). DO NOT use in production.")
 @click.pass_context
-def dashboard(ctx, host, port):
+def dashboard(ctx, host, bind, port, ack_unsafe):
     """Web dashboard başlat."""
     import uvicorn
     from src.dashboard.api import create_app
     app = ctx.obj
 
     dash_config = app.config.get("dashboard", {})
-    host = host or dash_config.get("host", "0.0.0.0")
+    # --bind is the documented C-1 flag; --host kept as the existing
+    # alias for backwards compat. CLI > config; --bind > --host.
+    host = bind or host or dash_config.get("host", "127.0.0.1")
     port = port or dash_config.get("port", 8085)
+
+    # ─────────────────────────────────────────────────────────────
+    # Issue #158 (C-1) — refuse 0.0.0.0 + auth disabled.
+    #
+    # ``DashboardAuth.enabled`` defaults true, so the only way to land
+    # in this branch is to have explicitly set
+    # ``dashboard.auth.enabled: false`` in config.yaml AND request a
+    # non-loopback bind. That is the worst-case combination from the
+    # security audit; we refuse to start unless the operator passes
+    # --i-know-what-im-doing AS WELL. The flag is intentionally
+    # awkward — it is meant to be a deliberate choice, not a habit.
+    # ─────────────────────────────────────────────────────────────
+    auth_cfg = (dash_config.get("auth") or {}) if isinstance(dash_config, dict) else {}
+    auth_enabled = bool(auth_cfg.get("enabled", True))
+    is_lan_bind = host not in ("127.0.0.1", "::1", "localhost")
+    if is_lan_bind and not auth_enabled:
+        if not ack_unsafe:
+            logger.critical(
+                "REFUSING TO START: dashboard.auth.enabled=false with host=%r "
+                "exposes every endpoint unauthenticated on the LAN. Either "
+                "enable auth (set dashboard.auth.enabled: true and export "
+                "FILEACTIVITY_DASHBOARD_TOKEN), bind to 127.0.0.1, or pass "
+                "--i-know-what-im-doing if this really is intentional.",
+                host,
+            )
+            click.echo(
+                "REFUSING TO START: --bind {h} with auth disabled is "
+                "unsafe. See logs for guidance, or pass "
+                "--i-know-what-im-doing to override.".format(h=host),
+                err=True,
+            )
+            ctx.exit(2)
+            return
+        logger.critical(
+            "INSECURE START: --bind=%r with auth disabled and "
+            "--i-know-what-im-doing acknowledged. Every endpoint is "
+            "reachable unauthenticated.", host,
+        )
 
     fastapi_app = create_app(app.db, app.config)
     click.echo(t("dashboard_started", host=host, port=port))

--- a/src/archiver/archive_engine.py
+++ b/src/archiver/archive_engine.py
@@ -23,7 +23,11 @@ class ArchiveEngine:
         self.db = db
         self.config = config
         self.verify_checksum = config.get("archiving", {}).get("verify_checksum", True)
-        self.dry_run = config.get("archiving", {}).get("dry_run", False)
+        # Issue #158 (C-2) — dry_run defaults to True (safe). Operators
+        # who want hands-off real archiving must set
+        # archiving.dry_run: false in config.yaml AND the API caller
+        # must pass confirm=true (see /api/archive/run gate).
+        self.dry_run = config.get("archiving", {}).get("dry_run", True)
         self.cleanup_empty = config.get("archiving", {}).get("cleanup_empty_dirs", True)
         # Issue #59: legal hold registry is lazy-built on first use.
         self._hold_registry = None

--- a/src/dashboard/api.py
+++ b/src/dashboard/api.py
@@ -348,6 +348,13 @@ class ArchiveRequest(BaseModel):
     source_id: int
     policy_name: Optional[str] = None
     days: Optional[int] = None
+    # Issue #158 (C-2) — explicit safety gate. ``dry_run`` defaults to
+    # the value in ``archiving.dry_run`` (now true by default); the API
+    # caller can override it to false ONLY when ``confirm=true`` is
+    # also supplied. The endpoint refuses ambiguous requests with HTTP
+    # 400 so a misclick / replay can't move files.
+    dry_run: Optional[bool] = None
+    confirm: Optional[bool] = False
 
 class RestoreRequest(BaseModel):
     archive_id: Optional[int] = None
@@ -539,6 +546,30 @@ def create_app(db, config, analytics=None, ad_lookup=None, email_notifier=None,
         email_notifier = EmailNotifier(db, config)
 
     app = FastAPI(title="FILE ACTIVITY Dashboard", version=APP_VERSION)
+
+    # ─────────────────────────────────────────────────────────────────
+    # Issue #158 (C-1) — bearer-token gate.
+    #
+    # DashboardAuth defaults to enabled=true and bypasses localhost so
+    # existing dev workflows are unaffected. Static assets are
+    # whitelisted ahead of the token check so the frontend can render a
+    # "set FILEACTIVITY_DASHBOARD_TOKEN" hint when the token is missing.
+    # ─────────────────────────────────────────────────────────────────
+    from src.security.dashboard_auth import DashboardAuth
+    app.state.dashboard_auth = DashboardAuth(config)
+
+    @app.middleware("http")
+    async def auth_middleware(request: Request, call_next):
+        # Whitelist: static files + favicon are not gated. Everything
+        # else (including / which serves the dashboard SPA) is.
+        path = request.url.path or ""
+        if path.startswith("/static/") or path == "/favicon.ico":
+            return await call_next(request)
+        gate = getattr(app.state, "dashboard_auth", None)
+        if gate is None or gate.check(request):
+            return await call_next(request)
+        return JSONResponse({"detail": "Unauthorized"}, status_code=401)
+
     app.state.analytics = analytics
     app.state.ad_lookup = ad_lookup
     app.state.email_notifier = email_notifier
@@ -1311,6 +1342,25 @@ def create_app(db, config, analytics=None, ad_lookup=None, email_notifier=None,
         if not scan_id:
             raise HTTPException(400, "Tarama verisi bulunamadi")
 
+        # Issue #158 (C-2) — confirm gate.
+        # dry_run resolution: if the caller passed dry_run explicitly
+        # we honour it; otherwise we use the config default
+        # (archiving.dry_run, now true by default).
+        config_dry_run = bool(
+            (config or {}).get("archiving", {}).get("dry_run", True)
+        )
+        effective_dry_run = (
+            bool(data.dry_run) if data.dry_run is not None else config_dry_run
+        )
+        if (not effective_dry_run) and not bool(data.confirm):
+            raise HTTPException(
+                400,
+                "Real archive run requires confirm=true (issue #158 C-2). "
+                "Re-submit with {\"dry_run\": false, \"confirm\": true} "
+                "after reviewing a dry-run report, or set dry_run=true to "
+                "preview without moving files.",
+            )
+
         policy_engine = ArchivePolicyEngine(db)
 
         if data.policy_name:
@@ -1326,7 +1376,13 @@ def create_app(db, config, analytics=None, ad_lookup=None, email_notifier=None,
             return {"archived": 0, "message": "Arsivlenecek dosya yok"}
 
         engine = ArchiveEngine(db, config)
-        return engine.archive_files(files, src.archive_dest, src.unc_path, src.id, archived_by)
+        # Plumb the resolved dry_run override into the engine so the
+        # API contract is honoured even if the engine's default
+        # (config.archiving.dry_run) drifts later.
+        return engine.archive_files(
+            files, src.archive_dest, src.unc_path, src.id, archived_by,
+            dry_run=effective_dry_run,
+        )
 
     @app.post("/api/archive/dry-run")
     async def archive_dry_run(data: ArchiveRequest):
@@ -2831,7 +2887,7 @@ def create_app(db, config, analytics=None, ad_lookup=None, email_notifier=None,
         return report
 
     @app.post("/api/archive/selective")
-    async def archive_selective(request):
+    async def archive_selective(request: Request):
         """Secili dosyalari arsivle (duplicate cleanup icin)."""
         from src.archiver.archive_engine import ArchiveEngine
         from src.utils.size_formatter import format_size
@@ -2842,6 +2898,23 @@ def create_app(db, config, analytics=None, ad_lookup=None, email_notifier=None,
 
         if not source_id or not file_ids:
             raise HTTPException(400, "source_id ve file_ids gerekli")
+
+        # Issue #158 (C-2) — confirm gate (mirrors /api/archive/run).
+        config_dry_run = bool(
+            (config or {}).get("archiving", {}).get("dry_run", True)
+        )
+        body_dry_run = body.get("dry_run")
+        effective_dry_run = (
+            bool(body_dry_run) if body_dry_run is not None else config_dry_run
+        )
+        confirm = bool(body.get("confirm", False))
+        if (not effective_dry_run) and not confirm:
+            raise HTTPException(
+                400,
+                "Real archive run requires confirm=true (issue #158 C-2). "
+                "Re-submit with dry_run=false + confirm=true after "
+                "reviewing the selection.",
+            )
 
         # Kaynak bilgisi
         source = db.get_source(source_id)
@@ -2869,7 +2942,8 @@ def create_app(db, config, analytics=None, ad_lookup=None, email_notifier=None,
             files, archive_dest, source["unc_path"], source_id,
             archived_by="duplicate_cleanup",
             trigger_type="manual",
-            trigger_detail="duplicate_cleanup"
+            trigger_detail="duplicate_cleanup",
+            dry_run=effective_dry_run,
         )
         return result
 
@@ -5256,7 +5330,26 @@ def create_app(db, config, analytics=None, ad_lookup=None, email_notifier=None,
         InvalidStateError, ApprovalExpiredError, ApprovalError,
     )
     from src.security.identity import resolve_user, warn_if_unsafe
-    app.state.approval_registry = ApprovalRegistry(db, config)
+    # Issue #158 (H-2) — refuse the unsafe combo at boot.
+    #
+    # ApprovalRegistry.__init__ raises RuntimeError when
+    # ``approvals.enabled=true`` AND ``identity_source='client_supplied'``
+    # because the second-person rule degenerates to "any caller can claim
+    # the requester's name" in that mode. We catch the error here, log
+    # CRITICAL, and leave ``app.state.approval_registry = None``. The
+    # approval endpoints below check for None and return HTTP 503 so
+    # callers get a clear "approvals disabled until config fixed" signal
+    # rather than a cryptic 500.
+    try:
+        app.state.approval_registry = ApprovalRegistry(db, config)
+    except RuntimeError as e:
+        logger.critical(
+            "Approval framework disabled: %s. Edit config.yaml to set "
+            "approvals.identity_source to 'windows' or 'header', or "
+            "set approvals.enabled=false, then restart.",
+            e,
+        )
+        app.state.approval_registry = None
     warn_if_unsafe(config)
 
     def _approval_to_json(req) -> dict:
@@ -5276,22 +5369,37 @@ def create_app(db, config, analytics=None, ad_lookup=None, email_notifier=None,
                                 or "client_supplied"),
         }
 
+    # Issue #158 (H-2) helper — every endpoint below dereferences the
+    # registry; this guards against the "unsafe combo refused at boot"
+    # path where the registry is None.
+    _APPROVALS_DISABLED_MSG = (
+        "Approvals framework disabled - check server log for the "
+        "config error (issue #158 H-2). Likely cause: "
+        "approvals.enabled=true with identity_source='client_supplied'."
+    )
+
+    def _require_approval_registry():
+        registry = getattr(app.state, "approval_registry", None)
+        if registry is None:
+            raise HTTPException(503, _APPROVALS_DISABLED_MSG)
+        return registry
+
     @app.get("/api/approvals/pending")
     async def approvals_list_pending():
-        registry = app.state.approval_registry
+        registry = _require_approval_registry()
         rows = registry.list_pending()
         return {"rows": [_approval_to_json(r) for r in rows]}
 
     @app.get("/api/approvals/history")
     async def approvals_history(limit: int = Query(50, ge=1, le=1000)):
-        registry = app.state.approval_registry
+        registry = _require_approval_registry()
         rows = registry.list_history(limit=limit)
         return {"rows": [_approval_to_json(r) for r in rows]}
 
     @app.post("/api/approvals/{approval_id}/approve")
     async def approvals_approve(approval_id: int, body: dict, request: Request):
         body = body or {}
-        registry = app.state.approval_registry
+        registry = _require_approval_registry()
         approved_by = (body.get("approved_by")
                        or resolve_user(request, config, body))
         try:
@@ -5311,7 +5419,7 @@ def create_app(db, config, analytics=None, ad_lookup=None, email_notifier=None,
     @app.post("/api/approvals/{approval_id}/reject")
     async def approvals_reject(approval_id: int, body: dict, request: Request):
         body = body or {}
-        registry = app.state.approval_registry
+        registry = _require_approval_registry()
         rejected_by = (body.get("rejected_by")
                        or resolve_user(request, config, body))
         reason = (body.get("reason") or "").strip()
@@ -5335,7 +5443,7 @@ def create_app(db, config, analytics=None, ad_lookup=None, email_notifier=None,
         pre-stage support.
         """
         body = body or {}
-        registry = app.state.approval_registry
+        registry = _require_approval_registry()
         try:
             req = registry.get(approval_id)
         except ApprovalNotFound:

--- a/src/security/approvals.py
+++ b/src/security/approvals.py
@@ -146,6 +146,20 @@ class ApprovalRegistry:
         self.config = config or {}
         cfg = (self.config.get("approvals") or {}) if isinstance(self.config, dict) else {}
         self.enabled = bool(cfg.get("enabled", False))
+        # Issue #158 (H-2) — refuse the structurally-unsafe combo of
+        # ``approvals.enabled=true`` with ``identity_source='client_supplied'``.
+        # In that combo any caller can claim the requester's username on the
+        # second leg of the two-person rule, defeating the gate. We raise
+        # at construction time so the dashboard refuses to boot rather than
+        # silently shipping a bypass.
+        identity_source = (cfg.get("identity_source") or "client_supplied").strip().lower()
+        if self.enabled and identity_source == "client_supplied":
+            raise RuntimeError(
+                "approvals.enabled=true is incompatible with "
+                "identity_source='client_supplied' - this combination allows "
+                "trivial self-approval bypass. Set identity_source to "
+                "'windows' or 'header' before enabling approvals."
+            )
         try:
             self.expiry_hours = int(cfg.get("expiry_hours", 24))
         except (TypeError, ValueError):

--- a/src/security/dashboard_auth.py
+++ b/src/security/dashboard_auth.py
@@ -1,0 +1,124 @@
+"""Dashboard bearer-token authentication (issue #158, finding C-1).
+
+The FastAPI dashboard previously bound to ``0.0.0.0:8085`` with no
+authentication, no CSRF, no CORS — every state-mutating endpoint
+(archive, restore, quarantine, retention apply, snapshot restore, AD
+config write, …) was reachable from anyone on the LAN. On a customer
+production-test deployment this is the dominant finding in the security
+audit (`docs/architecture/security-audit-2026-04-28.md`).
+
+This module contributes the *authentication* half of the C-1 fix:
+
+* Bearer-token comparison via :func:`hmac.compare_digest` so wrong
+  guesses don't leak via timing.
+* ``allow_unauth_localhost`` defaults true so existing dev/local
+  workflows ("hit http://localhost:8085 from a browser on the same
+  host") continue to work without configuration. Set to ``false`` to
+  require the token even from localhost.
+* Token is sourced from an environment variable (default
+  ``FILEACTIVITY_DASHBOARD_TOKEN``); we deliberately do **not** read it
+  from ``config.yaml`` — keeping it out of the file means a leaked
+  config does not carry the credential.
+* ``enabled`` defaults *true* — the safer default. Existing operators
+  whose dashboards live behind a reverse-proxy / VPN and prefer the
+  pre-1.9 unauth behaviour can opt out by flipping
+  ``dashboard.auth.enabled: false`` (and getting the matching CRITICAL
+  log line + the ``--bind 0.0.0.0`` refusal in :mod:`main`).
+
+The middleware that calls :meth:`DashboardAuth.check` is registered in
+:func:`src.dashboard.api.create_app`; the static-file whitelist is
+applied there too so the login UI / CSS / JS load before the user has a
+token.
+"""
+
+from __future__ import annotations
+
+import hmac
+import logging
+import os
+from typing import Any
+
+logger = logging.getLogger("file_activity.security.dashboard_auth")
+
+
+_LOCAL_HOSTS = frozenset({"127.0.0.1", "::1", "localhost"})
+
+
+class DashboardAuth:
+    """Per-process bearer-token gate for the FastAPI dashboard.
+
+    Construction is cheap and side-effect-free; the env var is read
+    once at startup so rotating the token requires a process restart.
+    Tests can construct one directly with a synthetic config dict.
+    """
+
+    def __init__(self, config: Any) -> None:
+        cfg_dash = (config.get("dashboard") if isinstance(config, dict) else None) or {}
+        cfg = (cfg_dash.get("auth") if isinstance(cfg_dash, dict) else None) or {}
+
+        # Default ON — see module docstring rationale.
+        self.enabled: bool = bool(cfg.get("enabled", True))
+        self.token_env: str = str(
+            cfg.get("token_env") or "FILEACTIVITY_DASHBOARD_TOKEN"
+        )
+        self.token: str = os.environ.get(self.token_env, "") or ""
+        self.allow_unauth_localhost: bool = bool(
+            cfg.get("allow_unauth_localhost", True)
+        )
+
+        if self.enabled and not self.token:
+            # Token missing means *every* remote request will 401.
+            # Localhost may still pass when allow_unauth_localhost=true,
+            # which is fine for a single-host install. Loud warning so
+            # the operator notices before customers do.
+            logger.warning(
+                "DashboardAuth: enabled=true but %s is unset — remote "
+                "callers will get 401 until the env var is exported "
+                "(localhost%s gated)",
+                self.token_env,
+                "" if self.allow_unauth_localhost else " also",
+            )
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def check(self, request: Any) -> bool:
+        """Return True iff the request is authorized to proceed.
+
+        ``request`` is a Starlette/FastAPI ``Request``-like object —
+        anything with ``.client.host`` and ``.headers.get`` works, so
+        unit tests can pass a tiny stand-in.
+        """
+        if not self.enabled:
+            return True
+
+        client_host = ""
+        client = getattr(request, "client", None)
+        if client is not None:
+            client_host = getattr(client, "host", "") or ""
+
+        if self.allow_unauth_localhost and client_host in _LOCAL_HOSTS:
+            return True
+
+        headers = getattr(request, "headers", None)
+        if headers is None:
+            return False
+        try:
+            auth_header = headers.get("Authorization", "") or ""
+        except Exception:
+            return False
+
+        if not auth_header.startswith("Bearer "):
+            return False
+        if not self.token:
+            # No server-side token configured — refuse. Without this
+            # check an attacker could send `Authorization: Bearer ` and
+            # match the empty server token via compare_digest.
+            return False
+
+        provided = auth_header[len("Bearer "):]
+        try:
+            return hmac.compare_digest(provided, self.token)
+        except Exception:
+            return False

--- a/tests/test_approval_safety.py
+++ b/tests/test_approval_safety.py
@@ -1,0 +1,152 @@
+"""Tests for issue #158 H-2: refuse the unsafe approvals combo.
+
+ApprovalRegistry must refuse construction when
+``approvals.enabled=true`` AND ``identity_source='client_supplied'``.
+That combo lets any caller claim the requester's username on the
+second leg of the two-person rule, which defeats the gate entirely.
+
+Coverage:
+  * enabled=true + client_supplied -> RuntimeError at construction.
+  * enabled=true + windows -> ok.
+  * enabled=true + header -> ok.
+  * enabled=false + client_supplied -> ok (no enforcement).
+  * enabled=false + (any other identity_source) -> ok.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+import pytest
+
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if REPO_ROOT not in sys.path:
+    sys.path.insert(0, REPO_ROOT)
+
+from src.security.approvals import ApprovalRegistry  # noqa: E402
+from src.storage.database import Database  # noqa: E402
+
+
+def _db(tmp_path) -> Database:
+    db = Database({"path": str(tmp_path / "approvals.db")})
+    db.connect()
+    return db
+
+
+# ---------------------------------------------------------------------------
+# Refusal path: the structurally-unsafe combo.
+# ---------------------------------------------------------------------------
+
+
+def test_enabled_with_client_supplied_raises(tmp_path):
+    db = _db(tmp_path)
+    cfg = {"approvals": {
+        "enabled": True,
+        "identity_source": "client_supplied",
+        "require_for": ["snapshot_restore"],
+    }}
+    with pytest.raises(RuntimeError) as exc:
+        ApprovalRegistry(db, cfg)
+    msg = str(exc.value)
+    assert "client_supplied" in msg
+    assert "self-approval" in msg.lower() or "bypass" in msg.lower()
+
+
+def test_enabled_with_default_identity_source_raises(tmp_path):
+    """When ``identity_source`` is omitted entirely, identity.py defaults
+    to ``client_supplied`` — same unsafe combo, must also be refused."""
+    db = _db(tmp_path)
+    cfg = {"approvals": {
+        "enabled": True,
+        "require_for": ["snapshot_restore"],
+        # identity_source intentionally absent
+    }}
+    with pytest.raises(RuntimeError):
+        ApprovalRegistry(db, cfg)
+
+
+# ---------------------------------------------------------------------------
+# Allowed combinations.
+# ---------------------------------------------------------------------------
+
+
+def test_enabled_with_windows_ok(tmp_path):
+    db = _db(tmp_path)
+    cfg = {"approvals": {
+        "enabled": True,
+        "identity_source": "windows",
+        "require_for": ["snapshot_restore"],
+    }}
+    reg = ApprovalRegistry(db, cfg)
+    assert reg.enabled is True
+    assert reg.is_required("snapshot_restore") is True
+
+
+def test_enabled_with_header_ok(tmp_path):
+    db = _db(tmp_path)
+    cfg = {"approvals": {
+        "enabled": True,
+        "identity_source": "header",
+        "identity_header": "X-Forwarded-User",
+        "require_for": ["snapshot_restore"],
+    }}
+    reg = ApprovalRegistry(db, cfg)
+    assert reg.enabled is True
+
+
+def test_disabled_with_client_supplied_ok(tmp_path):
+    """When the framework is disabled we don't enforce the safety check
+    — every existing endpoint runs straight through anyway, so the
+    config is benign even if it would be unsafe to flip enabled=true."""
+    db = _db(tmp_path)
+    cfg = {"approvals": {
+        "enabled": False,
+        "identity_source": "client_supplied",
+    }}
+    reg = ApprovalRegistry(db, cfg)
+    assert reg.enabled is False
+
+
+def test_disabled_with_default_identity_source_ok(tmp_path):
+    db = _db(tmp_path)
+    cfg = {"approvals": {"enabled": False}}
+    reg = ApprovalRegistry(db, cfg)
+    assert reg.enabled is False
+
+
+def test_disabled_with_windows_ok(tmp_path):
+    db = _db(tmp_path)
+    cfg = {"approvals": {
+        "enabled": False,
+        "identity_source": "windows",
+    }}
+    reg = ApprovalRegistry(db, cfg)
+    assert reg.enabled is False
+
+
+# ---------------------------------------------------------------------------
+# Case-insensitivity / whitespace tolerance: configs in YAML often have
+# stray casing. We normalise via strip().lower() so 'CLIENT_SUPPLIED'
+# and ' client_supplied ' must also be refused.
+# ---------------------------------------------------------------------------
+
+
+def test_enabled_with_uppercase_client_supplied_raises(tmp_path):
+    db = _db(tmp_path)
+    cfg = {"approvals": {
+        "enabled": True,
+        "identity_source": "CLIENT_SUPPLIED",
+    }}
+    with pytest.raises(RuntimeError):
+        ApprovalRegistry(db, cfg)
+
+
+def test_enabled_with_padded_client_supplied_raises(tmp_path):
+    db = _db(tmp_path)
+    cfg = {"approvals": {
+        "enabled": True,
+        "identity_source": "  client_supplied  ",
+    }}
+    with pytest.raises(RuntimeError):
+        ApprovalRegistry(db, cfg)

--- a/tests/test_approvals.py
+++ b/tests/test_approvals.py
@@ -51,7 +51,11 @@ def _make_registry(tmp_path, **overrides) -> tuple[Database, ApprovalRegistry]:
             "enabled": True,
             "require_for": ["snapshot_restore"],
             "expiry_hours": 24,
-            "identity_source": "client_supplied",
+            # Issue #158 H-2: enabled=true + identity_source=
+            # 'client_supplied' is now refused at construction. Tests
+            # that don't care about identity routing use 'windows'
+            # which falls back to env vars on Linux CI runners.
+            "identity_source": "windows",
         }
     }
     cfg["approvals"].update(overrides)
@@ -210,14 +214,31 @@ def _make_app(tmp_path, *, enabled=False, require_for=None):
     import importlib
 
     db = _make_db(tmp_path)
+    # Issue #158 H-2: enabled=true + identity_source='client_supplied'
+    # is now refused at boot. Tests that exercise the approval-routed
+    # path must use a safe identity_source; keeping this branch in the
+    # fixture (instead of in every caller) avoids cascading edits.
+    if enabled:
+        identity_source = "header"
+    else:
+        # When approvals are disabled the registry doesn't enforce the
+        # safety check, so we can keep the legacy "client_supplied"
+        # value to mirror the legacy default config and prove the
+        # endpoint still falls through to immediate execution.
+        identity_source = "client_supplied"
     cfg = {
         "database": {"path": db.db_path},
         "backup": {"enabled": False},  # we stub the manager below
+        # Issue #158 C-1: dashboard auth defaults ON. Disable it for
+        # the integration tests since we want to drive the snapshot
+        # endpoints directly with TestClient (no Bearer header).
+        "dashboard": {"auth": {"enabled": False}},
         "approvals": {
             "enabled": enabled,
             "require_for": list(require_for or []),
             "expiry_hours": 24,
-            "identity_source": "client_supplied",
+            "identity_source": identity_source,
+            "identity_header": "X-Forwarded-User",
         },
         "analytics": {"enabled": False},
         "active_directory": {"enabled": False},
@@ -275,9 +296,13 @@ def test_snapshot_restore_routes_through_approval_when_enabled(tmp_path):
     client = TestClient(app, raise_server_exceptions=False)
 
     # Step 1: alice requests the restore — gets a pending id back.
+    # Issue #158 H-2: identity_source is now 'header' (the safe value
+    # for tests that flip enabled=true), so we send the requester's
+    # name via X-Forwarded-User instead of body['username'].
     r = client.post(
         "/api/system/backups/restore/snap-abc",
-        json={"confirm": True, "username": "alice"},
+        json={"confirm": True},
+        headers={"X-Forwarded-User": "alice"},
     )
     assert r.status_code == 200, r.text
     body = r.json()

--- a/tests/test_archive_confirm_gate.py
+++ b/tests/test_archive_confirm_gate.py
@@ -1,0 +1,260 @@
+"""Tests for issue #158 C-2: archive confirm gate.
+
+Coverage:
+  * /api/archive/run: dry-run without confirm -> ok.
+  * /api/archive/run: real run without confirm -> 400 (refused).
+  * /api/archive/run: real run with confirm=true -> ok (engine called
+    with dry_run=False).
+  * /api/archive/selective: dry-run without confirm -> ok.
+  * /api/archive/selective: real run without confirm -> 400.
+  * /api/archive/selective: real run with confirm=true -> ok.
+
+The test patches ``ArchiveEngine.archive_files`` so we don't actually
+move files; we just assert the kwargs the endpoint passes.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+import pytest
+from fastapi.testclient import TestClient
+
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if REPO_ROOT not in sys.path:
+    sys.path.insert(0, REPO_ROOT)
+
+from src.dashboard.api import create_app  # noqa: E402
+from src.storage.database import Database  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Stubbed dependencies — same pattern as test_dashboard_smoke.py.
+# ---------------------------------------------------------------------------
+
+
+class _StubADLookup:
+    available = False
+
+    def lookup(self, name, force_refresh=False):
+        return {"username": name, "email": None, "display_name": None,
+                "found": False, "source": "live"}
+
+    def health(self):
+        return {"available": False, "configured": False}
+
+
+class _StubEmailNotifier:
+    available = False
+
+    def send(self, *a, **kw):
+        return False
+
+    def health(self):
+        return {"available": False, "configured": False}
+
+
+class _StubAnalytics:
+    available = False
+
+    def health(self):
+        return {"available": False, "configured": False}
+
+    def close(self):  # pragma: no cover - defensive
+        pass
+
+
+def _base_config(*, dry_run_default: bool = True) -> dict:
+    return {
+        "dashboard": {"auth": {"enabled": False}},
+        "archiving": {
+            "verify_checksum": False,
+            "dry_run": dry_run_default,
+            "cleanup_empty_dirs": False,
+        },
+        "security": {
+            "ransomware": {"enabled": False},
+            "orphan_sid": {"enabled": False},
+        },
+        "analytics": {},
+        "backup": {"enabled": False, "dir": "/tmp/_no_backups",
+                   "keep_last_n": 1, "keep_weekly": 0},
+        "integrations": {"syslog": {"enabled": False}},
+    }
+
+
+@pytest.fixture
+def client(tmp_path, monkeypatch):
+    """Boot a real ``create_app`` with a tiny seeded SQLite + an
+    ArchiveEngine.archive_files stub that records kwargs."""
+    db_path = tmp_path / "archive.db"
+    db = Database({"path": str(db_path)})
+    db.connect()
+
+    # Seed: one source with archive_dest, one completed scan, one file.
+    archive_dest = str(tmp_path / "archive")
+    os.makedirs(archive_dest, exist_ok=True)
+    with db.get_cursor() as cur:
+        cur.execute(
+            "INSERT INTO sources (name, unc_path, archive_dest) "
+            "VALUES ('s1', '/share', ?)",
+            (archive_dest,),
+        )
+        cur.execute(
+            "INSERT INTO scan_runs (source_id, status, completed_at) "
+            "VALUES (1, 'completed', '2026-01-01 00:00:00')"
+        )
+        cur.execute(
+            "INSERT INTO scanned_files "
+            "(source_id, scan_id, file_path, relative_path, file_name, "
+            " file_size, last_access_time) "
+            "VALUES (1, 1, '/share/a.txt', 'a.txt', 'a.txt', 100, "
+            "        '2020-01-01 00:00:00')"
+        )
+
+    # Capture every archive_files invocation so tests can assert the
+    # endpoint's confirm/dry_run plumbing.
+    calls: list[dict] = []
+
+    def fake_archive_files(self, files, archive_dest_, source_unc,
+                           source_id, archived_by="manual",
+                           dry_run=None, trigger_type="manual",
+                           trigger_detail=None):
+        calls.append({
+            "files_count": len(files),
+            "archive_dest": archive_dest_,
+            "source_id": source_id,
+            "archived_by": archived_by,
+            "dry_run": dry_run,
+            "trigger_type": trigger_type,
+            "trigger_detail": trigger_detail,
+        })
+        return {
+            "archived": len(files),
+            "failed": 0,
+            "total_size": 100,
+            "total_size_formatted": "100 B",
+            "errors": [],
+            "dry_run": bool(dry_run),
+        }
+
+    from src.archiver import archive_engine as _ae
+    monkeypatch.setattr(_ae.ArchiveEngine, "archive_files", fake_archive_files)
+
+    # Also patch the policy engine to return our seeded file regardless
+    # of its access age — saves us mocking out the freshness logic.
+    from src.archiver import archive_policy as _ap
+
+    def fake_get_files_by_days(self, source_id, scan_id, days):
+        return [{
+            "id": 1, "source_id": 1, "scan_id": 1,
+            "file_path": "/share/a.txt", "file_name": "a.txt",
+            "file_size": 100, "relative_path": "a.txt",
+        }]
+
+    monkeypatch.setattr(
+        _ap.ArchivePolicyEngine, "get_files_by_days", fake_get_files_by_days,
+    )
+
+    # The /api/archive/selective endpoint calls a legacy
+    # ``db.get_source(source_id)`` method that exists nowhere in
+    # ``src/storage/database.py`` — it predates this PR and is tracked
+    # separately. For the confirm-gate tests we shim it onto our
+    # Database instance so the happy path can run end-to-end.
+    def _get_source_shim(source_id):
+        src_obj = db.get_source_by_id(source_id)
+        if not src_obj:
+            return None
+        return {
+            "id": src_obj.id, "name": src_obj.name,
+            "unc_path": src_obj.unc_path,
+            "archive_dest": src_obj.archive_dest,
+        }
+
+    db.get_source = _get_source_shim  # type: ignore[attr-defined]
+
+    cfg = _base_config(dry_run_default=True)
+    app = create_app(
+        db,
+        cfg,
+        analytics=_StubAnalytics(),
+        ad_lookup=_StubADLookup(),
+        email_notifier=_StubEmailNotifier(),
+    )
+    tc = TestClient(app)
+    tc.archive_calls = calls  # piggy-back the call recorder onto the client
+    return tc
+
+
+# ---------------------------------------------------------------------------
+# /api/archive/run
+# ---------------------------------------------------------------------------
+
+
+def test_run_dry_run_without_confirm_ok(client):
+    resp = client.post("/api/archive/run", json={
+        "source_id": 1, "days": 30, "dry_run": True,
+    })
+    assert resp.status_code == 200, resp.text
+    assert client.archive_calls, "engine should have been invoked"
+    assert client.archive_calls[-1]["dry_run"] is True
+
+
+def test_run_real_without_confirm_blocked(client):
+    resp = client.post("/api/archive/run", json={
+        "source_id": 1, "days": 30, "dry_run": False,
+    })
+    assert resp.status_code == 400
+    assert "confirm=true" in resp.text
+    assert not client.archive_calls, (
+        "engine must NOT be called when confirm gate refuses"
+    )
+
+
+def test_run_real_with_confirm_ok(client):
+    resp = client.post("/api/archive/run", json={
+        "source_id": 1, "days": 30, "dry_run": False, "confirm": True,
+    })
+    assert resp.status_code == 200, resp.text
+    assert client.archive_calls[-1]["dry_run"] is False
+
+
+def test_run_default_dry_run_from_config(client):
+    """No explicit dry_run -> falls back to config (true) -> ok."""
+    resp = client.post("/api/archive/run", json={
+        "source_id": 1, "days": 30,
+    })
+    assert resp.status_code == 200, resp.text
+    assert client.archive_calls[-1]["dry_run"] is True
+
+
+# ---------------------------------------------------------------------------
+# /api/archive/selective
+# ---------------------------------------------------------------------------
+
+
+def test_selective_dry_run_without_confirm_ok(client):
+    resp = client.post("/api/archive/selective", json={
+        "source_id": 1, "file_ids": [1], "dry_run": True,
+    })
+    assert resp.status_code == 200, resp.text
+    assert client.archive_calls[-1]["dry_run"] is True
+
+
+def test_selective_real_without_confirm_blocked(client):
+    resp = client.post("/api/archive/selective", json={
+        "source_id": 1, "file_ids": [1], "dry_run": False,
+    })
+    assert resp.status_code == 400
+    assert "confirm=true" in resp.text
+    assert not client.archive_calls
+
+
+def test_selective_real_with_confirm_ok(client):
+    resp = client.post("/api/archive/selective", json={
+        "source_id": 1, "file_ids": [1],
+        "dry_run": False, "confirm": True,
+    })
+    assert resp.status_code == 200, resp.text
+    assert client.archive_calls[-1]["dry_run"] is False

--- a/tests/test_dashboard_auth.py
+++ b/tests/test_dashboard_auth.py
@@ -1,0 +1,206 @@
+"""Tests for issue #158 C-1: bearer-token dashboard auth.
+
+Coverage:
+  * Localhost (127.0.0.1) without token -> 200 (allow_unauth_localhost).
+  * Remote without token -> 401.
+  * Remote with correct bearer token -> 200.
+  * Remote with wrong bearer token -> 401.
+  * enabled=false -> all calls 200 (explicit opt-out, backwards compat).
+  * Static files always accessible (whitelist), even unauth + remote.
+  * allow_unauth_localhost=false also gates localhost.
+  * Empty token + empty Authorization header still rejected (anti-trick).
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Optional
+
+import pytest
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse
+from fastapi.testclient import TestClient
+
+from src.security.dashboard_auth import DashboardAuth
+
+
+def _build_app(
+    config: dict,
+    *,
+    force_client_host: Optional[str] = None,
+) -> FastAPI:
+    """Build a minimal FastAPI app that mirrors create_app's middleware
+    wiring without dragging in the entire dashboard.
+
+    Note on middleware order: Starlette runs ``@app.middleware`` handlers
+    in LIFO order (the LAST decorated runs OUTERMOST / first). To make
+    the client-host override visible to the auth check we must register
+    the auth middleware FIRST and the override SECOND.
+    """
+    app = FastAPI()
+    app.state.dashboard_auth = DashboardAuth(config)
+
+    @app.middleware("http")
+    async def auth_mw(request: Request, call_next):
+        path = request.url.path or ""
+        if path.startswith("/static/") or path == "/favicon.ico":
+            return await call_next(request)
+        gate = app.state.dashboard_auth
+        if gate.check(request):
+            return await call_next(request)
+        return JSONResponse({"detail": "Unauthorized"}, status_code=401)
+
+    if force_client_host is not None:
+        @app.middleware("http")
+        async def _override_client(request: Request, call_next):
+            request.scope["client"] = (force_client_host, 0)
+            return await call_next(request)
+
+    @app.get("/api/ping")
+    async def ping():
+        return {"ok": True}
+
+    @app.get("/static/app.js")
+    async def static_asset():
+        return {"asset": "ok"}
+
+    return app
+
+
+# ---------------------------------------------------------------------------
+# Defaults: enabled=true, allow_unauth_localhost=true.
+# ---------------------------------------------------------------------------
+
+
+def _default_cfg() -> dict:
+    return {"dashboard": {"auth": {"enabled": True}}}
+
+
+def test_localhost_without_token_passes(monkeypatch):
+    monkeypatch.delenv("FILEACTIVITY_DASHBOARD_TOKEN", raising=False)
+    app = _build_app(_default_cfg(), force_client_host="127.0.0.1")
+    client = TestClient(app)
+    resp = client.get("/api/ping")
+    assert resp.status_code == 200
+    assert resp.json() == {"ok": True}
+
+
+def test_remote_without_token_blocked(monkeypatch):
+    monkeypatch.setenv("FILEACTIVITY_DASHBOARD_TOKEN", "s3cret")
+    app = _build_app(_default_cfg(), force_client_host="10.0.0.5")
+    client = TestClient(app)
+    resp = client.get("/api/ping")
+    assert resp.status_code == 401
+    assert resp.json() == {"detail": "Unauthorized"}
+
+
+def test_remote_with_correct_bearer_passes(monkeypatch):
+    monkeypatch.setenv("FILEACTIVITY_DASHBOARD_TOKEN", "s3cret")
+    app = _build_app(_default_cfg(), force_client_host="10.0.0.5")
+    client = TestClient(app)
+    resp = client.get(
+        "/api/ping", headers={"Authorization": "Bearer s3cret"}
+    )
+    assert resp.status_code == 200
+    assert resp.json() == {"ok": True}
+
+
+def test_remote_with_wrong_bearer_blocked(monkeypatch):
+    monkeypatch.setenv("FILEACTIVITY_DASHBOARD_TOKEN", "s3cret")
+    app = _build_app(_default_cfg(), force_client_host="10.0.0.5")
+    client = TestClient(app)
+    resp = client.get(
+        "/api/ping", headers={"Authorization": "Bearer wrong"}
+    )
+    assert resp.status_code == 401
+
+
+def test_remote_with_empty_bearer_blocked_when_token_unset(monkeypatch):
+    """Anti-trick: server has no token configured; an attacker sending
+    `Authorization: Bearer ` should NOT match the empty string."""
+    monkeypatch.delenv("FILEACTIVITY_DASHBOARD_TOKEN", raising=False)
+    app = _build_app(_default_cfg(), force_client_host="10.0.0.5")
+    client = TestClient(app)
+    resp = client.get(
+        "/api/ping", headers={"Authorization": "Bearer "}
+    )
+    assert resp.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# enabled=false -> behaves exactly like the pre-1.9 unauth dashboard.
+# ---------------------------------------------------------------------------
+
+
+def test_disabled_lets_all_calls_through(monkeypatch):
+    monkeypatch.delenv("FILEACTIVITY_DASHBOARD_TOKEN", raising=False)
+    cfg = {"dashboard": {"auth": {"enabled": False}}}
+    app = _build_app(cfg, force_client_host="10.0.0.5")
+    client = TestClient(app)
+    assert client.get("/api/ping").status_code == 200
+    assert client.get(
+        "/api/ping", headers={"Authorization": "Bearer anything"}
+    ).status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# Static files / favicon are never gated.
+# ---------------------------------------------------------------------------
+
+
+def test_static_files_pass_unauth_remote(monkeypatch):
+    monkeypatch.delenv("FILEACTIVITY_DASHBOARD_TOKEN", raising=False)
+    app = _build_app(_default_cfg(), force_client_host="10.0.0.5")
+    client = TestClient(app)
+    resp = client.get("/static/app.js")
+    assert resp.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# allow_unauth_localhost=false also gates localhost.
+# ---------------------------------------------------------------------------
+
+
+def test_localhost_gated_when_bypass_disabled(monkeypatch):
+    monkeypatch.setenv("FILEACTIVITY_DASHBOARD_TOKEN", "s3cret")
+    cfg = {
+        "dashboard": {
+            "auth": {
+                "enabled": True,
+                "allow_unauth_localhost": False,
+            }
+        }
+    }
+    app = _build_app(cfg, force_client_host="127.0.0.1")
+    client = TestClient(app)
+    # No header -> 401 even from localhost.
+    assert client.get("/api/ping").status_code == 401
+    # Correct bearer still works.
+    resp = client.get(
+        "/api/ping", headers={"Authorization": "Bearer s3cret"}
+    )
+    assert resp.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# Custom token_env name is honoured.
+# ---------------------------------------------------------------------------
+
+
+def test_custom_token_env_name(monkeypatch):
+    monkeypatch.delenv("FILEACTIVITY_DASHBOARD_TOKEN", raising=False)
+    monkeypatch.setenv("MY_DASH_TOKEN", "custom-tok")
+    cfg = {
+        "dashboard": {
+            "auth": {
+                "enabled": True,
+                "token_env": "MY_DASH_TOKEN",
+            }
+        }
+    }
+    app = _build_app(cfg, force_client_host="10.0.0.5")
+    client = TestClient(app)
+    resp = client.get(
+        "/api/ping", headers={"Authorization": "Bearer custom-tok"}
+    )
+    assert resp.status_code == 200

--- a/tests/test_dashboard_security_pages.py
+++ b/tests/test_dashboard_security_pages.py
@@ -72,6 +72,13 @@ class _StubAnalytics:
 
 
 _BASE_CONFIG = {
+    # Issue #158 C-1: dashboard auth defaults ON. TestClient's
+    # ``client.host`` is the literal "testclient" which isn't on the
+    # localhost bypass list, so every endpoint would 401. Disable auth
+    # here so the integration tests below drive endpoints without
+    # juggling Bearer tokens — auth itself is covered by
+    # ``tests/test_dashboard_auth.py``.
+    "dashboard": {"auth": {"enabled": False}},
     "security": {
         "ransomware": {
             "enabled": True,

--- a/tests/test_dashboard_smoke.py
+++ b/tests/test_dashboard_smoke.py
@@ -113,6 +113,11 @@ class _StubAnalytics:
 
 
 _BASE_CONFIG: dict[str, Any] = {
+    # Issue #158 C-1: smoke test drives endpoints via TestClient,
+    # whose ``client.host`` ("testclient") isn't on the localhost
+    # bypass list. Disable auth here; auth itself is covered by
+    # ``tests/test_dashboard_auth.py``.
+    "dashboard": {"auth": {"enabled": False}},
     "security": {
         "ransomware": {
             "enabled": True,

--- a/tests/test_legal_hold.py
+++ b/tests/test_legal_hold.py
@@ -236,8 +236,11 @@ def test_archive_files_skips_held_and_audits(tmp_path):
     # Hold matches the finance file only.
     reg.add_hold(str(src_root / "finance" / "*"), "audit", "C1", "alice")
 
+    # Issue #158 C-2: ArchiveEngine.dry_run now defaults True. This
+    # test exercises real-archive plumbing, so opt back in explicitly.
     engine = ArchiveEngine(db, {"archiving": {"verify_checksum": False,
-                                              "cleanup_empty_dirs": False}})
+                                              "cleanup_empty_dirs": False,
+                                              "dry_run": False}})
     files = [
         {
             "file_path": str(held_file),

--- a/tests/test_mft_progress.py
+++ b/tests/test_mft_progress.py
@@ -303,6 +303,10 @@ def test_scan_progress_endpoint_returns_phase(tmp_path) -> None:
     config = {
         "scanner": {"batch_size": 10},
         "database": {"path": str(db_path)},
+        # Issue #158 C-1: TestClient.client.host is "testclient",
+        # not on the localhost bypass — disable auth for this smoke
+        # test of the scan-progress endpoint.
+        "dashboard": {"auth": {"enabled": False}},
     }
     app = create_app(db, config)
     client = TestClient(app)

--- a/tests/test_partial_summary.py
+++ b/tests/test_partial_summary.py
@@ -203,7 +203,13 @@ def _make_app(database):
     """
     from fastapi.testclient import TestClient  # noqa: WPS433
     from src.dashboard.api import create_app
-    cfg = {"dashboard": {"host": "127.0.0.1", "port": 0}}
+    cfg = {
+        "dashboard": {
+            "host": "127.0.0.1", "port": 0,
+            # Issue #158 C-1: disable auth for TestClient runs.
+            "auth": {"enabled": False},
+        },
+    }
     app = create_app(database, cfg)
     return TestClient(app)
 

--- a/tests/test_scan_progress_sync.py
+++ b/tests/test_scan_progress_sync.py
@@ -79,6 +79,8 @@ class _StubAnalytics:
 
 
 _BASE_CONFIG = {
+    # Issue #158 C-1: disable auth for TestClient runs.
+    "dashboard": {"auth": {"enabled": False}},
     "security": {
         "ransomware": {"enabled": False},
         "orphan_sid": {"enabled": False},

--- a/tests/test_system_status_endpoint.py
+++ b/tests/test_system_status_endpoint.py
@@ -61,6 +61,8 @@ class _StubAnalytics:
 
 
 _BASE_CONFIG = {
+    # Issue #158 C-1: disable auth for TestClient runs.
+    "dashboard": {"auth": {"enabled": False}},
     "security": {
         "ransomware": {"enabled": False},
         "orphan_sid": {"enabled": False},


### PR DESCRIPTION
## Summary
Closes #158 Phase 1 — 2 Critical + 1 High audit findings (out of 5 total). H-1 (XSS sweep) + H-3 (audit chain privatize) follow in separate PRs (cross-cutting + careful migration needed).

### C-1 — Bearer auth + default-bind 127.0.0.1
- **`src/security/dashboard_auth.py`** (NEW): `DashboardAuth` class with localhost bypass + bearer token compare via `hmac.compare_digest`
- FastAPI middleware in `create_app` returns 401 for unauthenticated remote callers
- **`config.yaml`**: `dashboard.host: "127.0.0.1"` (was `0.0.0.0`); new `dashboard.auth` block (`enabled: true`, `token_env: FILEACTIVITY_DASHBOARD_TOKEN`, `allow_unauth_localhost: true`)
- **`main.py`**: refuses to start when `--bind 0.0.0.0` + `dashboard.auth.enabled: false` unless `--i-know-what-im-doing` is also passed
- README + `docs/operator-runbook.md`: bearer token usage, LAN exposure procedure

### C-2 — `archiving.dry_run: true` default + confirm gate
- **`config.yaml`**: `archiving.dry_run: true` (was `false`)
- `/api/archive/run` + `/api/archive/selective`: real run requires both `dry_run=False` + `confirm=True` in body, else 400 with helpful message

### H-2 — Approval framework safety
- `ApprovalRegistry.__init__` raises `RuntimeError` when `enabled=true` AND `identity_source='client_supplied'` (the trivial bypass combo)
- `create_app` catches + logs CRITICAL + leaves registry as None; dedicated `/api/approvals/*` endpoints return 503 with remediation message; existing snapshot-restore still works (registry-None falls through to direct execution per existing semantics)

## Backwards compat
- RDP-into-host workflow (`http://localhost:8085`) **unchanged** — `allow_unauth_localhost: true` default
- Existing scripts hitting `/api/archive/run` with no body now get dry-run (safer default); to restore real-archive: `{"dry_run": false, "confirm": true}`
- Test fixtures migrated off `client_supplied` to a safe combo

## Test plan
- [x] 25 new tests pass: 9 auth + 7 confirm gate + 9 approval safety
- [x] Full suite: 410 passed, 6 skipped (4 pre-existing test_mft_progress unrelated)
- [x] Manual: bearer cycle (`localhost OK, remote 401, remote+token 200, wrong token 401`)
- [x] `python main.py dashboard --help` shows `--bind` + `--i-know-what-im-doing`

## Decisions
- **`--i-know-what-im-doing` flag**: deliberately verbose so operators don't muscle-memory it. Refusal only when BOTH `--bind 0.0.0.0` AND `auth.enabled: false` — pure suicide combo.
- **`--bind` alias** added alongside existing `--host` so audit doc + runbook match CLI verbatim.
- **Approvals → 503 instead of boot crash**: cleaner. Snapshot-restore falls through to existing direct-execution semantics when registry is None.

## Out of scope (separate PRs)
- H-1 XSS innerHTML sweep (~10 sites + CSP middleware)
- H-3 audit chain privatize (~6 callers, careful migration)
- Phase 2 (M-1..M-4)

## Latent bug spotted
`/api/archive/selective` calls `db.get_source(source_id)` which doesn't exist (only `get_source_by_id`). Filed as separate issue. Out of scope here; tests use a small shim.

https://claude.ai/code/session_0f8b12be-df27-4551-8160-a87913f51890

---
_Generated by [Claude Code](https://claude.ai/code/session_01A1UzS1A4DZNk1akoP4uhZ7)_