### PR TITLE
Security Phase 2 + Phase 3 bundle + latent bug fix (#158)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -47,6 +47,13 @@ jobs:
         uses: github/codeql-action/init@v3
         with:
           languages: ${{ matrix.language }}
+          # Audit M-4: pull in the security-extended + security-and-quality
+          # query packs so the first scan covers the broader rule set we
+          # plan to baseline against. ``continue-on-error: true`` above
+          # stays in place until that baseline is triaged — see the
+          # CodeQL integration plan in
+          # docs/architecture/security-audit-2026-04-28.md.
+          queries: security-extended,security-and-quality
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v3

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -47,6 +47,28 @@ Out of scope:
 - Attacks against shares the tool is configured to scan (those are the
   domain of the underlying Windows ACL / SMB configuration)
 
+## Production deployment
+
+The dashboard is designed for trusted operator use. The defaults assume a
+single-host RDP-only deployment; LAN exposure requires opt-in hardening.
+The audit notes in `docs/architecture/security-audit-2026-04-28.md` give
+the full rationale per setting.
+
+- **Default bind 127.0.0.1 + bearer token**. Do not expose the dashboard
+  to a network without first enabling the bearer-token middleware. See
+  the operator runbook for the exact env var and rotation cadence
+  (`docs/runbooks/dashboard-token.md`).
+- **LAN exposure procedure**: start with `--bind 0.0.0.0` *and* export
+  `FILEACTIVITY_DASHBOARD_TOKEN=<secret>` in the same shell. Without the
+  token the server refuses to bind to a non-loopback interface.
+- **Audit chain**: set `audit.chain_enabled: true` so every audit row is
+  cryptographically linked to the previous row. Tamper detection is
+  available only when this is on.
+- **Approval framework**: set `approvals.identity_source: 'windows'` (AD
+  / SSPI) or `'header'` (reverse-proxy injected). Never use
+  `'client_supplied'` outside development — it lets the same operator
+  approve their own request.
+
 ## Safe harbor
 
 Good-faith security research is welcome. If you follow the policy above

--- a/config.yaml
+++ b/config.yaml
@@ -80,7 +80,8 @@ analytics:
     # Yonetici ad-hoc SQL sorgu paneli (#48). DuckDB uzerinden SQLite'a
     # salt-okunur calisir, whitelist tablolar disindaki tum sorgulari
     # reddeder. Audit log'a sorgu kaydi yazilir (event_type=sql_query).
-    enabled: true
+    # Opt-in: SQL ad-hoc panel exposes whitelisted tables to LAN; enable only on hardened deployments.
+    enabled: false
     max_rows: 10000
     timeout_seconds: 30
 

--- a/src/dashboard/api.py
+++ b/src/dashboard/api.py
@@ -2917,11 +2917,15 @@ def create_app(db, config, analytics=None, ad_lookup=None, email_notifier=None,
             )
 
         # Kaynak bilgisi
-        source = db.get_source(source_id)
+        # NOTE: ``db.get_source(...)`` did not exist — historical typo.
+        # ``get_source_by_id`` returns a ``Source`` dataclass (attribute
+        # access, not dict access). See latent-bug fix bundled with
+        # security-audit-2026-04-28.
+        source = db.get_source_by_id(source_id)
         if not source:
             raise HTTPException(404, "Kaynak bulunamadi")
 
-        archive_dest = source.get("archive_dest")
+        archive_dest = source.archive_dest
         if not archive_dest:
             raise HTTPException(400, "Arsiv hedefi tanimli degil")
 
@@ -2939,7 +2943,7 @@ def create_app(db, config, analytics=None, ad_lookup=None, email_notifier=None,
 
         engine = ArchiveEngine(db, config)
         result = engine.archive_files(
-            files, archive_dest, source["unc_path"], source_id,
+            files, archive_dest, source.unc_path, source_id,
             archived_by="duplicate_cleanup",
             trigger_type="manual",
             trigger_detail="duplicate_cleanup",
@@ -4709,7 +4713,9 @@ def create_app(db, config, analytics=None, ad_lookup=None, email_notifier=None,
     async def restore_snapshot(snapshot_id: str, body: dict, request: Request):
         """Restore the live DB from ``snapshot_id``. Refuses if a live
         connection holds the DB lock — the caller must stop the dashboard
-        first. Body must include ``confirm: true``.
+        first. Body must include ``confirm: true`` and
+        ``safety_token: "RESTORE"`` (audit M-3, mirrors the PURGE /
+        QUARANTINE triple-gate from PR #109/#110).
 
         When ``approvals.enabled=true`` AND ``'snapshot_restore'`` is in
         ``approvals.require_for``, this endpoint queues a pending
@@ -4721,6 +4727,13 @@ def create_app(db, config, analytics=None, ad_lookup=None, email_notifier=None,
         body = body or {}
         if not bool(body.get("confirm", False)):
             raise HTTPException(400, "confirm: true required")
+        # Defence-in-depth: even with confirm=true, an attacker who can
+        # forge a request still has to know the literal "RESTORE" token.
+        # Mirrors PURGE_SAFETY_TOKEN_VALUE in DuplicateCleaner.
+        if body.get("safety_token", "") != "RESTORE":
+            raise HTTPException(
+                400, "safety_token must equal 'RESTORE'"
+            )
 
         # Route through approvals when gated. The framework is opt-in;
         # default config keeps this branch dormant.

--- a/src/playground/data_access.py
+++ b/src/playground/data_access.py
@@ -116,7 +116,9 @@ def open_duckdb_readonly(db_path: Path, memory_limit: str = "512MB",
 
     conn = duckdb.connect(database=":memory:")
     try:
+        # CODEQL-SAFE: value is config-derived, never from request handlers. See audit I-3.
         conn.execute(f"SET memory_limit='{memory_limit}'")
+        # CODEQL-SAFE: value is config-derived, never from request handlers. See audit I-3.
         conn.execute(f"SET threads={int(threads)}")
         try:
             conn.execute("INSTALL sqlite")
@@ -126,6 +128,7 @@ def open_duckdb_readonly(db_path: Path, memory_limit: str = "512MB",
         conn.execute("LOAD sqlite")
         # Try the explicit READ_ONLY form first; some duckdb builds use
         # a different keyword casing.
+        # CODEQL-SAFE: value is config-derived, never from request handlers. See audit I-3.
         attach_variants = [
             f"ATTACH '{db_path}' AS sqlite_db (TYPE SQLITE, READ_ONLY)",
             f"ATTACH '{db_path}' AS sqlite_db (TYPE SQLITE)",

--- a/src/scheduler/win_task_scheduler.py
+++ b/src/scheduler/win_task_scheduler.py
@@ -2,62 +2,25 @@
 
 Windows Task Scheduler üzerinden görevleri kaydetmeye ve kaldırmaya yarar.
 Bu sayede uygulama kapalıyken bile görevler tetiklenebilir.
+
+Audit L-2 (security-audit-2026-04-28):
+``create_windows_task`` was the only schtasks ``/TR`` builder in this
+module and had **zero callers** anywhere in ``src/``. It built a command
+line by interpolating ``command_args`` directly into the ``/TR`` value,
+which is the canonical CodeQL ``py/command-line-injection`` pattern. We
+deleted it instead of guarding it — the right substitute when scheduling
+is needed is either Windows-side configuration or the in-process APScheduler
+path that ``main.py`` already wires up.
 """
+
+from __future__ import annotations
 
 import logging
 import subprocess
-import os
-import sys
 
 logger = logging.getLogger("file_activity.scheduler.win")
 
 TASK_PREFIX = "FileActivity_"
-
-
-def create_windows_task(task_name: str, cron_expression: str, command_args: str,
-                        python_exe: str = None, script_path: str = None):
-    """Windows Task Scheduler'a görev ekle.
-
-    Args:
-        task_name: Görev adı (önek otomatik eklenir)
-        cron_expression: Cron ifadesi (basit dönüşüm yapılır)
-        command_args: main.py'ye geçilecek argümanlar
-        python_exe: Python yolu (varsayılan: sys.executable)
-        script_path: main.py yolu (varsayılan: otomatik algıla)
-    """
-    python_exe = python_exe or sys.executable
-    script_path = script_path or os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(__file__))), "main.py")
-
-    full_name = f"{TASK_PREFIX}{task_name}"
-
-    # Cron -> schtasks dönüşümü (basitleştirilmiş)
-    schedule_args = _cron_to_schtasks(cron_expression)
-    if not schedule_args:
-        logger.error(f"Cron dönüştürülemedi: {cron_expression}")
-        return False, "Cron ifadesi Windows Task Scheduler'a dönüştürülemedi"
-
-    cmd = [
-        "schtasks", "/Create",
-        "/TN", full_name,
-        "/TR", f'"{python_exe}" "{script_path}" {command_args}',
-        *schedule_args,
-        "/F"  # Mevcut görevi üzerine yaz
-    ]
-
-    try:
-        result = subprocess.run(
-            cmd, capture_output=True, text=True, timeout=30
-        )
-        if result.returncode == 0:
-            logger.info(f"Windows görevi oluşturuldu: {full_name}")
-            return True, f"Görev oluşturuldu: {full_name}"
-        else:
-            logger.error(f"schtasks hatası: {result.stderr}")
-            return False, f"Hata: {result.stderr.strip()}"
-    except subprocess.TimeoutExpired:
-        return False, "Zaman aşımı"
-    except Exception as e:
-        return False, str(e)
 
 
 def remove_windows_task(task_name: str):
@@ -100,56 +63,3 @@ def list_windows_tasks():
         return []
 
 
-def _cron_to_schtasks(cron_expression: str):
-    """Basit cron -> schtasks dönüşümü.
-
-    Desteklenen desenler:
-    - * * * * *     -> /SC MINUTE /MO 1
-    - 0 * * * *     -> /SC HOURLY
-    - 0 2 * * *     -> /SC DAILY /ST 02:00
-    - 0 2 * * 0     -> /SC WEEKLY /D SUN /ST 02:00
-    - 0 2 1 * *     -> /SC MONTHLY /D 1 /ST 02:00
-    """
-    parts = cron_expression.strip().split()
-    if len(parts) != 5:
-        return None
-
-    minute, hour, dom, month, dow = parts
-
-    day_map = {"0": "SUN", "1": "MON", "2": "TUE", "3": "WED",
-               "4": "THU", "5": "FRI", "6": "SAT", "7": "SUN"}
-
-    # Her dakika
-    if all(p == "*" for p in parts):
-        return ["/SC", "MINUTE", "/MO", "1"]
-
-    # Her saat
-    if minute != "*" and hour == "*" and dom == "*" and month == "*" and dow == "*":
-        return ["/SC", "HOURLY"]
-
-    time_str = f"{int(hour):02d}:{int(minute):02d}" if hour != "*" and minute != "*" else "00:00"
-
-    # Haftalık
-    if dow != "*" and dom == "*":
-        days = []
-        for d in dow.split(","):
-            d = d.strip()
-            if d in day_map:
-                days.append(day_map[d])
-            elif "-" in d:
-                start, end = d.split("-")
-                for i in range(int(start), int(end) + 1):
-                    if str(i) in day_map:
-                        days.append(day_map[str(i)])
-        if days:
-            return ["/SC", "WEEKLY", "/D", ",".join(days), "/ST", time_str]
-
-    # Aylık
-    if dom != "*" and month == "*" and dow == "*":
-        return ["/SC", "MONTHLY", "/D", dom, "/ST", time_str]
-
-    # Günlük (varsayılan)
-    if dom == "*" and month == "*" and dow == "*" and hour != "*":
-        return ["/SC", "DAILY", "/ST", time_str]
-
-    return None

--- a/src/storage/analytics.py
+++ b/src/storage/analytics.py
@@ -64,7 +64,9 @@ class AnalyticsEngine:
     def _open(self):
         """DuckDB baglantisini ac, SQLite'i salt-okunur ATTACH et."""
         conn = duckdb.connect(database=":memory:")
+        # CODEQL-SAFE: value is config-derived, never from request handlers. See audit I-3.
         conn.execute(f"SET memory_limit='{self.memory_limit}'")
+        # CODEQL-SAFE: value is config-derived, never from request handlers. See audit I-3.
         conn.execute(f"SET threads={self.threads}")
 
         # sqlite_scanner extension'i yukle (duckdb paketiyle beraber gelir)
@@ -77,6 +79,7 @@ class AnalyticsEngine:
 
         # SQLite'i salt-okunur attach et. Bazi surumlerde parametre adi
         # READ_ONLY, digerlerinde read_only olabilir; ikincide fallback dene.
+        # CODEQL-SAFE: value is config-derived, never from request handlers. See audit I-3.
         attach_sql_variants = [
             f"ATTACH '{self.db_path}' AS sqlite_db (TYPE SQLITE, READ_ONLY)",
             f"ATTACH '{self.db_path}' AS sqlite_db (TYPE SQLITE)",

--- a/src/storage/backup_manager.py
+++ b/src/storage/backup_manager.py
@@ -267,6 +267,7 @@ class BackupManager:
             # Quote the path safely — VACUUM INTO uses string literal
             # syntax; double single-quotes inside the literal.
             quoted = out_path.replace("'", "''")
+            # CODEQL-SAFE: value is config-derived, never from request handlers. See audit I-3.
             conn.execute(f"VACUUM INTO '{quoted}'")
         finally:
             conn.close()
@@ -446,9 +447,18 @@ class BackupManager:
             )
 
         # Verify integrity of the snapshot file before clobbering the
-        # live DB. SHA-256 from manifest must match disk.
+        # live DB. SHA-256 from manifest must match disk. An empty
+        # manifest sha256 is treated as a hard failure (audit M-1):
+        # historically we silently skipped the check, which means a
+        # tampered manifest or a pre-#77 snapshot could be restored
+        # without integrity proof. Operators must verify by hand.
         actual = self._sha256_file(meta.path)
-        if meta.sha256 and actual != meta.sha256:
+        if not meta.sha256:
+            raise RuntimeError(
+                f"Snapshot {meta.id} has no sha256 sidecar — refusing to restore "
+                "(manifest tampering or pre-#77 snapshot). Manually verify integrity first."
+            )
+        if actual != meta.sha256:
             raise RuntimeError(
                 f"snapshot {snapshot_id} sha256 mismatch — refusing "
                 f"to restore (manifest={meta.sha256[:12]}, "

--- a/src/storage/database.py
+++ b/src/storage/database.py
@@ -217,7 +217,7 @@ class Database:
                         logger.info(
                             f"WAL checkpoint baslatiliyor ({wal_size / 1048576:.1f} MB, mode={mode})..."
                         )
-                        conn.execute(f"PRAGMA wal_checkpoint({mode})")
+                        conn.execute(f"PRAGMA wal_checkpoint({mode})")  # noqa: S608
                         wal_after = os.path.getsize(wal_path) if os.path.exists(wal_path) else 0
                         logger.info(
                             f"WAL checkpoint tamamlandi: {wal_size / 1048576:.1f} MB "
@@ -566,7 +566,7 @@ class Database:
         ):
             col_name = col_def.split()[0]
             try:
-                cur.execute(f"ALTER TABLE scan_runs ADD COLUMN {col_def}")
+                cur.execute(f"ALTER TABLE scan_runs ADD COLUMN {col_def}")  # noqa: S608
                 logger.info("scan_runs tablosuna %s kolonu eklendi", col_name)
             except sqlite3.OperationalError as e:
                 if "duplicate column name" not in str(e).lower():
@@ -1489,7 +1489,7 @@ class Database:
                 WHERE {where}
                 ORDER BY last_access_time ASC
                 LIMIT ?
-            """, params)
+            """, params)  # noqa: S608
             return cur.fetchall()
 
     # ──────────────────────────────────────────────
@@ -1562,7 +1562,7 @@ class Database:
 
         with self.get_cursor() as cur:
             # Toplam sayi
-            cur.execute(f"SELECT COUNT(*) as cnt FROM archived_files WHERE {where}", params)
+            cur.execute(f"SELECT COUNT(*) as cnt FROM archived_files WHERE {where}", params)  # noqa: S608
             total = cur.fetchone()["cnt"]
 
             # Sayfalanmis sonuclar
@@ -1571,7 +1571,7 @@ class Database:
                 WHERE {where}
                 ORDER BY archived_at DESC
                 LIMIT ? OFFSET ?
-            """, params + [page_size, offset])
+            """, params + [page_size, offset])  # noqa: S608
             rows = cur.fetchall()
 
         return {"total": total, "page": page, "page_size": page_size, "results": rows}
@@ -1730,7 +1730,7 @@ class Database:
                 GROUP BY username
                 ORDER BY access_count DESC
                 LIMIT ?
-            """, params)
+            """, params)  # noqa: S608
             return cur.fetchall()
 
     def get_user_activity(self, username: str, days: int = 30) -> dict:
@@ -1843,7 +1843,7 @@ class Database:
                 WHERE {where}
                 GROUP BY dow, hour
                 ORDER BY dow, hour
-            """, params)
+            """, params)  # noqa: S608
             return cur.fetchall()
 
     def get_access_timeline(self, source_id: int = None, days: int = 30) -> list:
@@ -1867,7 +1867,7 @@ class Database:
                 WHERE {where}
                 GROUP BY DATE(access_time)
                 ORDER BY date
-            """, params)
+            """, params)  # noqa: S608
             return cur.fetchall()
 
     # ──────────────────────────────────────────────
@@ -1926,7 +1926,7 @@ class Database:
                 SELECT * FROM anomaly_alerts
                 WHERE {where}
                 ORDER BY detected_at DESC
-            """, params)
+            """, params)  # noqa: S608
             return cur.fetchall()
 
     def acknowledge_anomaly(self, anomaly_id: int, by_user: str):
@@ -1984,12 +1984,12 @@ class Database:
         where = f"source_id = ? AND scan_id = ? AND {owner_cond}"
 
         with self.get_cursor() as cur:
-            cur.execute(f"SELECT COUNT(*) as cnt FROM scanned_files WHERE {where}", params_base)
+            cur.execute(f"SELECT COUNT(*) as cnt FROM scanned_files WHERE {where}", params_base)  # noqa: S608
             total = cur.fetchone()["cnt"]
             cur.execute(f"""
                 SELECT * FROM scanned_files WHERE {where}
                 ORDER BY file_size DESC LIMIT ? OFFSET ?
-            """, params_base + [limit, offset])
+            """, params_base + [limit, offset])  # noqa: S608
             files = [dict(r) for r in cur.fetchall()]
         return {"total": total, "files": files}
 
@@ -2014,12 +2014,12 @@ class Database:
         where = " AND ".join(conditions)
 
         with self.get_cursor() as cur:
-            cur.execute(f"SELECT COUNT(*) as cnt FROM scanned_files WHERE {where}", params)
+            cur.execute(f"SELECT COUNT(*) as cnt FROM scanned_files WHERE {where}", params)  # noqa: S608
             total = cur.fetchone()["cnt"]
             cur.execute(f"""
                 SELECT * FROM scanned_files WHERE {where}
                 ORDER BY last_access_time ASC LIMIT ? OFFSET ?
-            """, params + [limit, offset])
+            """, params + [limit, offset])  # noqa: S608
             files = [dict(r) for r in cur.fetchall()]
         return {"total": total, "files": files}
 
@@ -2034,12 +2034,12 @@ class Database:
         where = f"source_id = ? AND scan_id = ? AND {ext_cond}"
 
         with self.get_cursor() as cur:
-            cur.execute(f"SELECT COUNT(*) as cnt FROM scanned_files WHERE {where}", params_base)
+            cur.execute(f"SELECT COUNT(*) as cnt FROM scanned_files WHERE {where}", params_base)  # noqa: S608
             total = cur.fetchone()["cnt"]
             cur.execute(f"""
                 SELECT * FROM scanned_files WHERE {where}
                 ORDER BY file_size DESC LIMIT ? OFFSET ?
-            """, params_base + [limit, offset])
+            """, params_base + [limit, offset])  # noqa: S608
             files = [dict(r) for r in cur.fetchall()]
         return {"total": total, "files": files}
 
@@ -2057,12 +2057,12 @@ class Database:
         where = " AND ".join(conditions)
 
         with self.get_cursor() as cur:
-            cur.execute(f"SELECT COUNT(*) as cnt FROM scanned_files WHERE {where}", params)
+            cur.execute(f"SELECT COUNT(*) as cnt FROM scanned_files WHERE {where}", params)  # noqa: S608
             total = cur.fetchone()["cnt"]
             cur.execute(f"""
                 SELECT * FROM scanned_files WHERE {where}
                 ORDER BY file_size DESC LIMIT ? OFFSET ?
-            """, params + [limit, offset])
+            """, params + [limit, offset])  # noqa: S608
             files = [dict(r) for r in cur.fetchall()]
         return {"total": total, "files": files}
 
@@ -2177,13 +2177,13 @@ class Database:
         offset = (page - 1) * page_size
 
         with self.get_cursor() as cur:
-            cur.execute(f"SELECT COUNT(*) as cnt FROM file_audit_events WHERE {where}", params)
+            cur.execute(f"SELECT COUNT(*) as cnt FROM file_audit_events WHERE {where}", params)  # noqa: S608
             total = cur.fetchone()["cnt"]
 
             cur.execute(f"""
                 SELECT * FROM file_audit_events WHERE {where}
                 ORDER BY event_time DESC LIMIT ? OFFSET ?
-            """, params + [page_size, offset])
+            """, params + [page_size, offset])  # noqa: S608
             events = [dict(r) for r in cur.fetchall()]
 
         return {"total": total, "events": events, "page": page}
@@ -2200,7 +2200,7 @@ class Database:
                 SELECT event_type, COUNT(*) as cnt
                 FROM file_audit_events {cond}
                 GROUP BY event_type ORDER BY cnt DESC
-            """, params)
+            """, params)  # noqa: S608
             by_type = [dict(r) for r in cur.fetchall()]
 
             cur.execute(f"""
@@ -2208,10 +2208,10 @@ class Database:
                        SUM(CASE WHEN event_type='delete' THEN 1 ELSE 0 END) as deletes
                 FROM file_audit_events {cond}
                 GROUP BY username ORDER BY cnt DESC LIMIT 20
-            """, params)
+            """, params)  # noqa: S608
             by_user = [dict(r) for r in cur.fetchall()]
 
-            cur.execute(f"SELECT COUNT(*) as cnt FROM file_audit_events {cond}", params)
+            cur.execute(f"SELECT COUNT(*) as cnt FROM file_audit_events {cond}", params)  # noqa: S608
             total = cur.fetchone()["cnt"]
 
         return {"total": total, "by_type": by_type, "by_user": by_user}
@@ -2256,7 +2256,7 @@ class Database:
             cur.execute(f"""
                 SELECT * FROM archive_operations {where}
                 ORDER BY started_at DESC LIMIT ?
-            """, params)
+            """, params)  # noqa: S608
             return [dict(r) for r in cur.fetchall()]
 
     def get_archive_operation_detail(self, op_id):
@@ -2352,13 +2352,13 @@ class Database:
         offset = (page - 1) * page_size
 
         with self.get_cursor() as cur:
-            cur.execute(f"SELECT COUNT(*) as cnt FROM archive_operations {where}", params)
+            cur.execute(f"SELECT COUNT(*) as cnt FROM archive_operations {where}", params)  # noqa: S608
             total = cur.fetchone()["cnt"]
 
             cur.execute(f"""
                 SELECT * FROM archive_operations {where}
                 ORDER BY started_at DESC LIMIT ? OFFSET ?
-            """, params + [page_size, offset])
+            """, params + [page_size, offset])  # noqa: S608
             rows = [dict(r) for r in cur.fetchall()]
 
         return {
@@ -3389,9 +3389,9 @@ class Database:
                     old_run_ids = [r["id"] for r in cur.fetchall()]
                     if old_run_ids:
                         placeholders = ','.join(['?'] * len(old_run_ids))
-                        cur.execute(f"DELETE FROM scanned_files WHERE scan_id IN ({placeholders})", old_run_ids)
+                        cur.execute(f"DELETE FROM scanned_files WHERE scan_id IN ({placeholders})", old_run_ids)  # noqa: S608
                         deleted_files += cur.rowcount
-                        cur.execute(f"DELETE FROM scan_runs WHERE id IN ({placeholders})", old_run_ids)
+                        cur.execute(f"DELETE FROM scan_runs WHERE id IN ({placeholders})", old_run_ids)  # noqa: S608
                         deleted_runs += cur.rowcount
 
                 # Orphan satirlari da temizle (silinmis scan_run'lara ait dosyalar)
@@ -3480,7 +3480,7 @@ class Database:
             with self.get_cursor() as cur:
                 for table in ["scanned_files", "scan_runs", "archived_files", "user_access_logs", "sources"]:
                     try:
-                        cur.execute(f"SELECT COUNT(*) as cnt FROM {table}")
+                        cur.execute(f"SELECT COUNT(*) as cnt FROM {table}")  # noqa: S608
                         stats[f"{table}_count"] = cur.fetchone()["cnt"]
                     except Exception:
                         stats[f"{table}_count"] = 0

--- a/tests/test_approvals.py
+++ b/tests/test_approvals.py
@@ -277,7 +277,8 @@ def test_snapshot_restore_executes_immediately_when_disabled(tmp_path):
     client = TestClient(app, raise_server_exceptions=False)
     r = client.post(
         "/api/system/backups/restore/snap-xyz",
-        json={"confirm": True},
+        # Audit M-3: safety_token now required alongside confirm.
+        json={"confirm": True, "safety_token": "RESTORE"},
     )
     assert r.status_code == 200, r.text
     body = r.json()
@@ -301,7 +302,9 @@ def test_snapshot_restore_routes_through_approval_when_enabled(tmp_path):
     # name via X-Forwarded-User instead of body['username'].
     r = client.post(
         "/api/system/backups/restore/snap-abc",
-        json={"confirm": True},
+        # Audit M-3: safety_token now required alongside confirm.
+        # H-2 (#159): identity_source 'header', so requester via X-Forwarded-User.
+        json={"confirm": True, "safety_token": "RESTORE"},
         headers={"X-Forwarded-User": "alice"},
     )
     assert r.status_code == 200, r.text

--- a/tests/test_backup_endpoints.py
+++ b/tests/test_backup_endpoints.py
@@ -95,6 +95,12 @@ def _build_backups_app(tmp_path: Path, enabled: bool = True) -> FastAPI:
         body = body or {}
         if not bool(body.get("confirm", False)):
             raise HTTPException(400, "confirm: true required")
+        # Audit M-3: mirror PURGE / QUARANTINE — confirm alone is not
+        # enough; the literal token must match.
+        if body.get("safety_token", "") != "RESTORE":
+            raise HTTPException(
+                400, "safety_token must equal 'RESTORE'"
+            )
         if not mgr.enabled:
             raise HTTPException(400, "backup feature disabled")
         try:
@@ -182,9 +188,21 @@ def test_restore_requires_confirm(tmp_path: Path):
     assert "confirm" in resp.json()["detail"].lower()
 
 
-def test_restore_unknown_id_returns_404(tmp_path: Path):
+def test_restore_requires_safety_token(tmp_path: Path):
+    """Audit M-3: confirm: true without safety_token is now rejected."""
     client = TestClient(_build_backups_app(tmp_path))
     resp = client.post("/api/system/backups/restore/20990101_000000",
                        json={"confirm": True})
+
+    assert resp.status_code == 400
+    assert "safety_token" in resp.json()["detail"].lower()
+
+
+def test_restore_unknown_id_returns_404(tmp_path: Path):
+    client = TestClient(_build_backups_app(tmp_path))
+    resp = client.post(
+        "/api/system/backups/restore/20990101_000000",
+        json={"confirm": True, "safety_token": "RESTORE"},
+    )
 
     assert resp.status_code == 404

--- a/tests/test_no_sql_injection_paths.py
+++ b/tests/test_no_sql_injection_paths.py
@@ -1,0 +1,174 @@
+"""Audit L-1: assert the f-string SQL/DuckDB call *sites* flagged as
+"config-derived only" are not reachable from any FastAPI request
+handler.
+
+The audit lists these sites:
+
+* ``src/storage/backup_manager.py:~270`` — ``VACUUM INTO`` literal
+* ``src/storage/analytics.py:67-68 81-82`` — DuckDB ``SET`` + ``ATTACH``
+* ``src/playground/data_access.py:119-120 130-131`` — DuckDB ``SET`` + ``ATTACH``
+
+The test below is intentionally a static, grep-shaped reachability
+proxy — full call-graph analysis would over-fit, while this catches
+the practical regression (a new request handler that wires user input
+into one of these modules' f-string code paths).
+
+We only care about *module-level* imports: a request-handler module
+that imports a protected module at the top level means the protected
+module is loaded for free on every request. Function-local imports
+(the dashboard's pattern, ``from src.storage.backup_manager import
+BackupManager`` inside ``_get_backup_manager``) are deliberately
+exempt — they are intentional, lazy, and inspected here separately
+via the ``CODEQL-SAFE`` marker on each f-string call site.
+
+When this test breaks, *don't* just allow-list the new caller — read
+the audit (``docs/architecture/security-audit-2026-04-28.md``, L-1)
+first. If user-controlled data really has reached one of these
+sites, the f-string must be rewritten to use parameter binding.
+"""
+
+from __future__ import annotations
+
+import ast
+import os
+from pathlib import Path
+from typing import Set
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SRC = REPO_ROOT / "src"
+
+# Files (module dotted paths) that hold the audited f-string SQL sites.
+PROTECTED_MODULES = {
+    "src.storage.backup_manager",
+    "src.storage.analytics",
+    "src.playground.data_access",
+}
+
+
+# Markers we accept as "this module hosts request handlers".
+REQUEST_HANDLER_MARKERS = (
+    "@app.get",
+    "@app.post",
+    "@app.put",
+    "@app.delete",
+    "@app.patch",
+    "@router.get",
+    "@router.post",
+    "@router.put",
+    "@router.delete",
+    "@router.patch",
+)
+
+
+def _module_name(py_path: Path) -> str:
+    rel = py_path.relative_to(REPO_ROOT).with_suffix("")
+    return ".".join(rel.parts)
+
+
+def _is_request_handler_module(py_path: Path) -> bool:
+    try:
+        text = py_path.read_text(encoding="utf-8")
+    except OSError:
+        return False
+    return any(marker in text for marker in REQUEST_HANDLER_MARKERS)
+
+
+def _module_level_imports(py_path: Path) -> Set[str]:
+    """Return dotted module names imported at *module level* only.
+
+    Walks the AST and looks at top-level Import / ImportFrom nodes,
+    skipping anything nested inside a function or class definition.
+    """
+    try:
+        text = py_path.read_text(encoding="utf-8")
+    except OSError:
+        return set()
+    try:
+        tree = ast.parse(text, filename=str(py_path))
+    except SyntaxError:
+        return set()
+    out: Set[str] = set()
+    for node in tree.body:  # only direct module-level statements
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                out.add(alias.name)
+        elif isinstance(node, ast.ImportFrom):
+            if node.module:
+                out.add(node.module)
+    return out
+
+
+def _all_python_files() -> list[Path]:
+    return [p for p in SRC.rglob("*.py") if "__pycache__" not in p.parts]
+
+
+def _module_to_path(module: str) -> Path:
+    rel = module.replace(".", os.sep) + ".py"
+    return REPO_ROOT / rel
+
+
+def _import_closure_module_level(start_modules: Set[str]) -> Set[str]:
+    """BFS through *module-level* imports, restricted to ``src.*``."""
+    seen: Set[str] = set()
+    stack = list(start_modules)
+    while stack:
+        mod = stack.pop()
+        if mod in seen:
+            continue
+        seen.add(mod)
+        path = _module_to_path(mod)
+        if not path.exists():
+            continue
+        for imp in _module_level_imports(path):
+            if imp.startswith("src.") and imp not in seen:
+                stack.append(imp)
+    return seen
+
+
+def test_protected_modules_not_reachable_from_request_handlers():
+    """No request-handler module under ``src/`` may import (at module
+    level, transitively through other module-level imports) any of the
+    modules with config-only f-string SQL.
+
+    Function-local imports (the dashboard's pattern) are deliberately
+    NOT counted — the comment ``CODEQL-SAFE: value is config-derived``
+    on each call site documents the manual review.
+    """
+    request_handler_files = [
+        p for p in _all_python_files() if _is_request_handler_module(p)
+    ]
+    assert request_handler_files, (
+        "test scaffolding broken: expected at least one request-handler "
+        "module under src/"
+    )
+
+    violations: list[tuple[str, str]] = []
+    for handler_path in request_handler_files:
+        handler_mod = _module_name(handler_path)
+        closure = _import_closure_module_level({handler_mod})
+        bad = closure & PROTECTED_MODULES
+        for hit in bad:
+            violations.append((handler_mod, hit))
+
+    assert not violations, (
+        "audit L-1 regression: request-handler modules now import "
+        "config-only-SQL modules at module level:\n  "
+        + "\n  ".join(f"{h} -> {p}" for h, p in violations)
+        + "\nLazy imports (inside a function body) are fine; review "
+        "docs/architecture/security-audit-2026-04-28.md before "
+        "allow-listing a top-level edge."
+    )
+
+
+def test_protected_files_carry_codeql_safe_marker():
+    """Belt-and-braces: every protected module must contain the
+    ``CODEQL-SAFE`` marker comment that documents *why* the f-string
+    is acceptable. If someone deletes the comment we want to know."""
+    expected_marker = "CODEQL-SAFE: value is config-derived"
+    for mod in PROTECTED_MODULES:
+        path = _module_to_path(mod)
+        text = path.read_text(encoding="utf-8")
+        assert expected_marker in text, (
+            f"audit L-1: {mod} is missing the CODEQL-SAFE marker "
+            "that documents the justification for its f-string SQL"
+        )

--- a/tests/test_security_phase_2.py
+++ b/tests/test_security_phase_2.py
@@ -1,0 +1,311 @@
+"""Security audit Phase 2 + Phase 3 + latent-bug bundle.
+
+Covers:
+
+* M-1 — ``BackupManager.restore`` hard-fails on empty manifest sha256.
+* M-2 — ``config.yaml`` ships ``analytics.query_panel.enabled: false``.
+* M-3 — ``POST /api/system/backups/restore/{id}`` requires
+  ``safety_token: "RESTORE"`` in addition to ``confirm: true``.
+* L-2 — dead ``create_windows_task`` schtasks builder is gone.
+* Latent bug — ``/api/archive/selective`` no longer calls the
+  non-existent ``db.get_source(...)``; uses ``get_source_by_id`` and
+  attribute access.
+
+The endpoint tests re-host the handler bodies (mirroring
+``test_backup_endpoints.py``) so we don't have to boot the full
+``create_app`` factory and its full DB / analytics / AD chain.
+"""
+
+from __future__ import annotations
+
+import os
+import sqlite3
+import sys
+from pathlib import Path
+from typing import Optional
+
+import pytest
+import yaml
+from fastapi import FastAPI, HTTPException, Request
+from fastapi.testclient import TestClient
+
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if REPO_ROOT not in sys.path:
+    sys.path.insert(0, REPO_ROOT)
+
+from src.storage.backup_manager import BackupManager  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Helpers shared with the existing backup-endpoint tests
+# ---------------------------------------------------------------------------
+
+
+def _seed_db(path: Path) -> None:
+    conn = sqlite3.connect(str(path))
+    try:
+        conn.execute(
+            "CREATE TABLE t (id INTEGER PRIMARY KEY, payload TEXT)"
+        )
+        conn.executemany(
+            "INSERT INTO t (payload) VALUES (?)",
+            [(f"row-{i}",) for i in range(20)],
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def _build_restore_app(tmp_path: Path) -> tuple[FastAPI, BackupManager]:
+    """Mirror the restore endpoint after M-3: confirm + safety_token."""
+    db_path = tmp_path / "live.db"
+    _seed_db(db_path)
+    cfg = {
+        "database": {"path": str(db_path)},
+        "backup": {
+            "enabled": True,
+            "dir": str(tmp_path / "backups"),
+            "keep_last_n": 10,
+            "keep_weekly": 4,
+        },
+    }
+    mgr = BackupManager(str(db_path), cfg)
+
+    app = FastAPI()
+
+    @app.post("/api/system/backups/restore/{snapshot_id}")
+    async def restore_snapshot(snapshot_id: str, body: dict):
+        body = body or {}
+        if not bool(body.get("confirm", False)):
+            raise HTTPException(400, "confirm: true required")
+        if body.get("safety_token", "") != "RESTORE":
+            raise HTTPException(
+                400, "safety_token must equal 'RESTORE'"
+            )
+        if not mgr.enabled:
+            raise HTTPException(400, "backup feature disabled")
+        try:
+            mgr.restore(snapshot_id)
+        except KeyError:
+            raise HTTPException(404, f"unknown: {snapshot_id}")
+        except RuntimeError as e:
+            raise HTTPException(409, str(e))
+        return {"ok": True, "restored": snapshot_id}
+
+    return app, mgr
+
+
+# ---------------------------------------------------------------------------
+# M-1: empty sha256 hard-fails
+# ---------------------------------------------------------------------------
+
+
+def test_m1_restore_refuses_when_manifest_sha256_is_empty(tmp_path: Path):
+    """A snapshot whose manifest row has no sha256 must be rejected
+    rather than silently restored — that was the silent-skip bug
+    fixed by audit M-1.
+    """
+    db_path = tmp_path / "live.db"
+    _seed_db(db_path)
+    cfg = {
+        "database": {"path": str(db_path)},
+        "backup": {
+            "enabled": True,
+            "dir": str(tmp_path / "backups"),
+            "keep_last_n": 10,
+            "keep_weekly": 4,
+        },
+    }
+    mgr = BackupManager(str(db_path), cfg)
+    meta = mgr.snapshot(reason="seed-for-empty-sha-test")
+    assert meta.sha256  # sanity — fresh snapshot must have one
+
+    # Tamper with the manifest: zero the sha256.
+    import json
+    with open(mgr.manifest_path, "r", encoding="utf-8") as f:
+        rows = json.load(f)
+    assert rows
+    rows[0]["sha256"] = ""
+    with open(mgr.manifest_path, "w", encoding="utf-8") as f:
+        json.dump(rows, f)
+
+    with pytest.raises(RuntimeError, match="no sha256 sidecar"):
+        mgr.restore(meta.id)
+
+
+# ---------------------------------------------------------------------------
+# M-2: query_panel default
+# ---------------------------------------------------------------------------
+
+
+def test_m2_default_config_query_panel_disabled():
+    """``analytics.query_panel.enabled`` ships False — opt-in only."""
+    cfg_path = Path(REPO_ROOT) / "config.yaml"
+    with open(cfg_path, "r", encoding="utf-8") as f:
+        cfg = yaml.safe_load(f)
+    qp = cfg["analytics"]["query_panel"]
+    assert qp["enabled"] is False, (
+        "audit M-2: config.yaml must ship query_panel.enabled=false"
+    )
+
+
+# ---------------------------------------------------------------------------
+# M-3: safety_token on restore
+# ---------------------------------------------------------------------------
+
+
+def test_m3_restore_without_safety_token_returns_400(tmp_path: Path):
+    app, _ = _build_restore_app(tmp_path)
+    client = TestClient(app)
+    resp = client.post(
+        "/api/system/backups/restore/20990101_000000",
+        json={"confirm": True},
+    )
+    assert resp.status_code == 400
+    assert "safety_token" in resp.json()["detail"].lower()
+
+
+def test_m3_restore_with_wrong_safety_token_returns_400(tmp_path: Path):
+    app, _ = _build_restore_app(tmp_path)
+    client = TestClient(app)
+    resp = client.post(
+        "/api/system/backups/restore/20990101_000000",
+        json={"confirm": True, "safety_token": "purge"},
+    )
+    assert resp.status_code == 400
+    assert "safety_token" in resp.json()["detail"].lower()
+
+
+def test_m3_restore_with_correct_token_succeeds(tmp_path: Path):
+    """Happy path: confirm + correct token + real snapshot id → 200."""
+    app, mgr = _build_restore_app(tmp_path)
+    meta = mgr.snapshot(reason="m3-happy-path")
+
+    client = TestClient(app)
+    resp = client.post(
+        f"/api/system/backups/restore/{meta.id}",
+        json={"confirm": True, "safety_token": "RESTORE"},
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["ok"] is True
+    assert body["restored"] == meta.id
+
+
+# ---------------------------------------------------------------------------
+# L-2: dead schtasks builder removed
+# ---------------------------------------------------------------------------
+
+
+def test_l2_create_windows_task_removed():
+    """``create_windows_task`` had zero callers; importing it must fail
+    so a future caller can't silently resurrect the command-injection
+    pattern."""
+    from src.scheduler import win_task_scheduler
+
+    assert not hasattr(win_task_scheduler, "create_windows_task"), (
+        "audit L-2: create_windows_task must be removed from "
+        "src.scheduler.win_task_scheduler"
+    )
+    # Module surface still exposes the safe operations.
+    assert hasattr(win_task_scheduler, "remove_windows_task")
+    assert hasattr(win_task_scheduler, "list_windows_tasks")
+
+
+# ---------------------------------------------------------------------------
+# Latent bug: /api/archive/selective used the non-existent db.get_source
+# ---------------------------------------------------------------------------
+
+
+class _FakeCursor:
+    def __init__(self):
+        self._rows: list[dict] = []
+
+    def execute(self, sql, params=()):
+        # We don't actually run SQL; the test only cares that the
+        # endpoint reaches this point with a valid Source object.
+        self._rows = []
+        return self
+
+    def fetchall(self):
+        return []
+
+
+class _FakeCursorCtx:
+    def __enter__(self):
+        return _FakeCursor()
+
+    def __exit__(self, *args):
+        return False
+
+
+class _FakeDB:
+    """Records get_source_by_id calls and exposes the surface
+    ``/api/archive/selective`` actually uses."""
+
+    def __init__(self, source: Optional[object]):
+        self._source = source
+        self.calls: list[tuple[str, tuple]] = []
+
+    def get_source_by_id(self, source_id: int):
+        self.calls.append(("get_source_by_id", (source_id,)))
+        return self._source
+
+    # If the buggy code were still in place this would be reached and
+    # the test would fail — see assertion in the smoke test.
+    def get_source(self, source_id: int):  # pragma: no cover
+        self.calls.append(("get_source", (source_id,)))
+        raise AssertionError(
+            "regression: /api/archive/selective must call "
+            "get_source_by_id, not get_source"
+        )
+
+    def get_cursor(self):
+        return _FakeCursorCtx()
+
+
+def test_latent_bug_archive_selective_uses_get_source_by_id(tmp_path: Path):
+    """Smoke: replicate the corrected archive_selective handler body and
+    confirm it goes through ``get_source_by_id``. The fake raises if
+    the typo'd ``get_source`` is invoked."""
+    from src.storage.models import Source
+
+    fake_source = Source(
+        id=1,
+        name="test",
+        unc_path=r"\\srv\share",
+        archive_dest=None,  # forces the "archive_dest tanimli degil" branch
+        enabled=True,
+    )
+    db = _FakeDB(fake_source)
+    app = FastAPI()
+
+    @app.post("/api/archive/selective")
+    async def archive_selective(request: Request):
+        body = await request.json()
+        source_id = body.get("source_id")
+        file_ids = body.get("file_ids", [])
+
+        if not source_id or not file_ids:
+            raise HTTPException(400, "source_id ve file_ids gerekli")
+
+        source = db.get_source_by_id(source_id)
+        if not source:
+            raise HTTPException(404, "Kaynak bulunamadi")
+
+        archive_dest = source.archive_dest
+        if not archive_dest:
+            raise HTTPException(400, "Arsiv hedefi tanimli degil")
+        return {"ok": True}
+
+    client = TestClient(app)
+    resp = client.post(
+        "/api/archive/selective",
+        json={"source_id": 1, "file_ids": [10, 11]},
+    )
+    # 400 because archive_dest is None — the important thing is we
+    # reached that branch via get_source_by_id, not get_source.
+    assert resp.status_code == 400, resp.text
+    assert "Arsiv" in resp.json()["detail"]
+    # Exactly one call, to the right method.
+    assert db.calls == [("get_source_by_id", (1,))]


### PR DESCRIPTION
## Summary
Closes #158 Phase 2 + Phase 3 + latent bug. 9 small fixes bundled.

### Phase 2
- **M-1** `BackupManager.restore`: hard-fail on empty `meta.sha256` (was silently skipped — manifest tampering)
- **M-2** `analytics.query_panel.enabled: false` default (was true — exposed whitelisted tables to LAN)
- **M-3** `/api/system/backups/restore/{id}` requires `safety_token: "RESTORE"` body field alongside `confirm: true` (mirrors PURGE/QUARANTINE)
- **M-4** CodeQL workflow uses `queries: security-extended,security-and-quality` (was default suite)

### Phase 3
- **L-1** `# CODEQL-SAFE` comments on the 5 config-only SQL/DuckDB f-string sites (`backup_manager.py:270`, `analytics.py:67-68/81-82`, `playground/data_access.py:119-120/130-131`)
- **L-2** Deleted dead `create_windows_task` + `_cron_to_schtasks` helper from `win_task_scheduler.py`
- **I-1** `SECURITY.md` "Production deployment" section: bearer auth, LAN exposure, audit chain, approvals identity_source guidance
- **I-3** 28× `# noqa: S608` annotations on f-string SQL in `database.py` (suppresses CodeQL false positives)

### Latent bug fix
`/api/archive/selective` was calling `db.get_source(source_id)` which **does not exist** on Database (only `get_source_by_id`). Would have 500'd in production. Fixed; also fixed dependent `source.get(...)` / `source[...]` to dataclass attribute access.

## Tests
- `tests/test_security_phase_2.py` (NEW, 7 tests): M-1 empty sha, M-2 default, M-3 missing/wrong/correct token, L-2 dead-fn removed, latent-bug smoke
- `tests/test_no_sql_injection_paths.py` (NEW, 2 tests): module-level reachability + CODEQL-SAFE marker presence
- `tests/test_approvals.py` updated for M-3 token + #159 identity_source change
- `tests/test_backup_endpoints.py` extended with safety_token assertions

## Test plan
- [x] 16/16 new + modified tests pass
- [x] 97/97 across approvals, backup_manager, dashboard, quarantine, sql_query, audit_chain, playground, smoke
- [x] Full suite: 456 passed, 6 skipped, 4 pre-existing test_mft_progress unrelated
- [x] Rebase resolution: merged X-Forwarded-User identity (#159) + safety_token (#158 M-3) into single test path

## Decisions
- **Multi-line f-string `# noqa`**: placed on closing `""", params)` line — putting it on opening line breaks the SQL literal (caught + reverted during impl)
- **`_cron_to_schtasks` removed alongside `create_windows_task`**: was orphan helper
- **L-1 reachability test uses `ast` not regex**: doesn't false-flag intentional lazy `from src.storage.backup_manager import BackupManager` inside `_get_backup_manager`

https://claude.ai/code/session_0f8b12be-df27-4551-8160-a87913f51890

---
_Generated by [Claude Code](https://claude.ai/code/session_01A1UzS1A4DZNk1akoP4uhZ7)_