### PR TITLE
fix(install_service): silence NSSM stderr noise, extend poll to 15s

### DIFF
--- a/deploy/install_service.ps1
+++ b/deploy/install_service.ps1
@@ -189,15 +189,35 @@ Write-Host "       stderr : $svcErr" -ForegroundColor DarkGray
 Write-Host "       restart: 5 sn delay, otomatik" -ForegroundColor DarkGray
 
 # --- 4. Servisi baslat ---
+# NSSM'in stderr'e UTF-16 yazdigi "SERVICE_START_PENDING" satiri Windows SCM'in
+# normal cevabidir (asenkron baslatma). PowerShell'in NativeCommandError record'u
+# ile karistirmamak icin Start-Process ile cagiriyor, stdout/stderr'i tamamen yutuyoruz.
+# Sonra Get-Service ile gercek durumu polluyoruz (15 sn'ye kadar) — ilk boot venv +
+# APScheduler nedeniyle 8-15 sn alabilir.
 Write-Host "[4/4] Servis baslatiliyor..." -ForegroundColor Yellow
-& $nssmExe start $ServiceName 2>&1 | Out-Null
-Start-Sleep -Seconds 3
-$svc = Get-Service -Name $ServiceName -ErrorAction SilentlyContinue
+$null = Start-Process -FilePath $nssmExe -ArgumentList "start", $ServiceName `
+    -Wait -NoNewWindow `
+    -RedirectStandardOutput "$env:TEMP\nssm_start.out" `
+    -RedirectStandardError "$env:TEMP\nssm_start.err"
+Remove-Item "$env:TEMP\nssm_start.out", "$env:TEMP\nssm_start.err" -ErrorAction SilentlyContinue
+
+$svc = $null
+for ($i = 0; $i -lt 15; $i++) {
+    Start-Sleep -Seconds 1
+    $svc = Get-Service -Name $ServiceName -ErrorAction SilentlyContinue
+    if ($svc -and $svc.Status -eq "Running") { break }
+}
 if ($svc -and $svc.Status -eq "Running") {
-    Write-Host "  [OK] Servis calisiyor" -ForegroundColor Green
+    Write-Host "  [OK] Servis calisiyor (Status=Running, $($i+1) sn icinde)" -ForegroundColor Green
 } else {
-    Write-Host "  [UYARI] Servis henuz Running degil. Status: $($svc.Status)" -ForegroundColor Yellow
-    Write-Host "          Loglara bakin: $svcErr" -ForegroundColor Yellow
+    $statusText = if ($svc) { $svc.Status } else { "<servis bulunamadi>" }
+    Write-Host "  [UYARI] Servis 15 sn icinde Running'e gecmedi. Status: $statusText" -ForegroundColor Yellow
+    Write-Host "          Son 20 satir log: $svcErr" -ForegroundColor Yellow
+    if (Test-Path $svcErr) {
+        Get-Content $svcErr -Tail 20 | ForEach-Object {
+            Write-Host "            $_" -ForegroundColor DarkGray
+        }
+    }
 }
 
 # --- Optional tray app auto-start ---


### PR DESCRIPTION
## Summary

Customer prod test, 2026-04-28: `update.cmd` → service install showed scary red `NativeCommandError` text mid-install:

```
F i l e A c t i v i t y :   U n e x p e c t e d   s t a t u s   S E R V I C E _ S T A R T _ P E N D I N G
in response to START control.
```

Service was actually starting fine (verified `Get-Service` → `Running`, dashboard reachable on `localhost:8085`). NSSM emits this line on stderr in **UTF-16** — Windows SCM's normal asynchronous-start acknowledgement, NOT an error. The previous `2>&1 | Out-Null` couldn't fully suppress it because PowerShell still surfaces the `NativeCommandError` record at host level.

## Changes

- `& nssm start ... 2>&1 | Out-Null` → `Start-Process -Wait -NoNewWindow -RedirectStandardOutput/Error <tempfile>` then delete tempfiles. Fully silences both UTF-16 noise and the NativeCommandError record.
- Fixed 3s sleep → 15s poll loop (`for $i in 0..14: sleep 1; check Status`). Python venv + APScheduler first-boot can legitimately take 8-15s on slow Windows hosts.
- On timeout: dump last 20 lines of `service.err` inline so the operator doesn't have to go hunting.

## Test plan

- [ ] Run `install_service.ps1` on Windows test box, confirm no red error text mid-install.
- [ ] Confirm `[OK] Servis calisiyor (Status=Running, N sn icinde)` line appears.
- [ ] Confirm dashboard reachable post-install.

Reported by: customer prod test, 2026-04-28.

https://claude.ai/code/session_01A1UzS1A4DZNk1akoP4uhZ7

---
_Generated by [Claude Code](https://claude.ai/code/session_01A1UzS1A4DZNk1akoP4uhZ7)_