### PR TITLE
fix(scanner): mask NTFS FRN sequence number so paths resolve on real volumes

### DIFF
--- a/src/scanner/backends/_ntfs_records.py
+++ b/src/scanner/backends/_ntfs_records.py
@@ -48,8 +48,16 @@ _OFF_FILE_NAME_OFFSET = 58
 # Minimum size of a fixed USN_RECORD_V2 header (filename starts at +60).
 _MIN_RECORD_SIZE = 60
 
-# NTFS volume root always has FRN 5.
+# NTFS volume root always has FRN segment number 5.
 NTFS_ROOT_FRN = 5
+
+# NTFS FRN encoding: lower 48 bits = MFT segment number (the actual entry
+# index), upper 16 bits = sequence number (incremented when an entry is
+# reused after deletion). For path reconstruction we ONLY care about the
+# segment number — sequence numbers cause parent-chain lookups to miss
+# whenever the volume has had any churn, which manifested in prod as
+# "3M kayit toplandi → 0 dosya yayildi" (issue #144 follow-up).
+_FRN_SEGMENT_MASK = (1 << 48) - 1
 
 # FILE_ATTRIBUTE_DIRECTORY bit — used by callers to filter directories.
 FILE_ATTRIBUTE_DIRECTORY = 0x10
@@ -91,8 +99,14 @@ def parse_usn_records(buf: bytes, offset: int = 8) -> Iterator[dict]:
             offset += record_length
             continue
 
-        (frn,) = struct.unpack_from("<Q", buf, offset + _OFF_FRN)
-        (parent_frn,) = struct.unpack_from("<Q", buf, offset + _OFF_PARENT_FRN)
+        (frn_raw,) = struct.unpack_from("<Q", buf, offset + _OFF_FRN)
+        (parent_frn_raw,) = struct.unpack_from("<Q", buf, offset + _OFF_PARENT_FRN)
+        # Mask off the sequence number (upper 16 bits) so children whose
+        # parent_frn carries a non-zero sequence number still match the
+        # parent record's key in the {frn: rec} dict. See _FRN_SEGMENT_MASK
+        # comment above for the prod failure mode.
+        frn = frn_raw & _FRN_SEGMENT_MASK
+        parent_frn = parent_frn_raw & _FRN_SEGMENT_MASK
         (usn,) = struct.unpack_from("<q", buf, offset + _OFF_USN)
         (attributes,) = struct.unpack_from(
             "<I", buf, offset + _OFF_FILE_ATTRIBUTES

--- a/tests/test_ntfs_mft_backend.py
+++ b/tests/test_ntfs_mft_backend.py
@@ -160,6 +160,29 @@ def test_parse_empty_buffer() -> None:
     assert list(parse_usn_records(buf, offset=8)) == []
 
 
+def test_parse_masks_frn_sequence_number() -> None:
+    """Real-world FRNs carry a 16-bit sequence number in the upper bits.
+    The parser must mask it off so child.parent_frn matches parent.frn
+    after dict-keyed lookup. Customer prod regression: 3.1M kayit → 0
+    dosya yayildi, traced to a sequence-number mismatch.
+    """
+    from src.scanner.backends._ntfs_records import parse_usn_records
+
+    # Sequence=0x0005 in upper 16 bits, segment=5 in lower 48 bits.
+    root_full_frn = (0x0005 << 48) | 5
+    rec = _build_record(
+        frn=(0x0010 << 48) | 100,
+        parent_frn=root_full_frn,
+        file_name="x.txt",
+    )
+    buf = _wrap_buffer(rec)
+    parsed = list(parse_usn_records(buf, offset=8))
+    assert len(parsed) == 1
+    # Both FRN and parent_frn must be masked to lower 48 bits.
+    assert parsed[0]["frn"] == 100
+    assert parsed[0]["parent_frn"] == 5
+
+
 # ---------------------------------------------------------------------------
 # reconstruct_paths
 # ---------------------------------------------------------------------------
@@ -219,6 +242,45 @@ def test_reconstruct_paths_orphan_parent() -> None:
 
     paths = reconstruct_paths(records, root_frn=5)
     assert paths.get(99) is None
+
+
+def test_reconstruct_paths_real_world_frns_via_parser() -> None:
+    """End-to-end regression for the prod '0 dosya yayildi' bug:
+    feed records with non-zero sequence numbers through the parser into
+    reconstruct_paths and assert paths resolve. Without the FRN mask,
+    the children's parent chain misses the root and every path is None.
+    """
+    from src.scanner.backends._ntfs_records import (
+        parse_usn_records,
+        reconstruct_paths,
+    )
+
+    # All three records carry non-zero sequence numbers, mirroring an
+    # NTFS volume that has been through allocate/free cycles.
+    rec_root = _build_record(
+        frn=(0x0005 << 48) | 5,
+        parent_frn=(0x0005 << 48) | 5,
+        file_name="",
+        attributes=0x10,  # directory
+    )
+    rec_dir = _build_record(
+        frn=(0x0010 << 48) | 100,
+        parent_frn=(0x0005 << 48) | 5,
+        file_name="docs",
+        attributes=0x10,
+    )
+    rec_file = _build_record(
+        frn=(0x0020 << 48) | 200,
+        parent_frn=(0x0010 << 48) | 100,
+        file_name="report.txt",
+    )
+    buf = _wrap_buffer(rec_root + rec_dir + rec_file)
+
+    records = {r["frn"]: r for r in parse_usn_records(buf, offset=8)}
+    paths = reconstruct_paths(records, root_frn=5)
+
+    assert paths.get(100) == "docs"
+    assert paths.get(200) == "docs\\report.txt"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## PROD HOTFIX

Customer test (2026-04-28, MFT scan on `E:\`) repeatedly emitted:

```
MFT taramasi: 3116867 kayit toplandi, yollar olusturuluyor
MFT taramasi tamamlandi: 0 dosya yayildi
Tarama tamamlandi: 0 dosya | 0 B | 27 saniye | 0 dosya/sn | 0 hata
```

Every file's parent chain failed to resolve.

## Root cause

NTFS FRNs are 64-bit values:
- **Lower 48 bits**: MFT segment number (the actual entry index)
- **Upper 16 bits**: sequence number (incremented when an entry is reused after delete)

On any NTFS volume with churn, the sequence number is non-zero. The parser stored records keyed by the full 64-bit FRN, but `reconstruct_paths` seeded `cache = {root_frn: ""}` with the bare constant `5`. Real records' `parent_frn` looked like `0x00050000_00000005`. Lookup missed, root resolved to `None` via the self-parent cycle guard (`parent == frn` but `frn != 5`), every child inherited `None`, emit dropped to zero.

Tests passed because the test fixtures used clean integer FRNs (5, 100, 200) without sequence numbers.

## Fix

Mask both `frn` and `parent_frn` to the lower 48 bits at parse time in `_ntfs_records.py`. The sequence number isn't useful for any of our consumers — we don't do stale-handle detection.

## Test plan

- [x] `pytest tests/test_ntfs_mft_backend.py` — 16/16 passing including 2 new regressions
- [x] `test_parse_masks_frn_sequence_number` — verifies parser masks
- [x] `test_reconstruct_paths_real_world_frns_via_parser` — end-to-end regression with sequence-numbered records (without the fix this test fails with `paths.get(200) == None`, mirroring the prod symptom exactly)
- [ ] Customer to re-run scan on E:\ post-update; expect non-zero `dosya yayildi`

Reported by: customer prod test, 2026-04-28.

https://claude.ai/code/session_01A1UzS1A4DZNk1akoP4uhZ7

---
_Generated by [Claude Code](https://claude.ai/code/session_01A1UzS1A4DZNk1akoP4uhZ7)_