### PR TITLE
feat(#114): Phase 2 — ElasticsearchBackend MVP

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -67,7 +67,13 @@ database:
 # 'elasticsearch' option (ElasticsearchBackend); Phase 3 rewires the
 # dashboard query layer to call backend methods instead of raw SQL.
 storage:
-  backend: "sqlite"   # phase 1: only sqlite. phase 2: add 'elasticsearch'.
+  backend: "sqlite"
+  # Phase 2 (#114): switch to "elasticsearch" once the cluster is provisioned.
+  # elasticsearch:
+  #   hosts: ["https://es.internal:9200"]
+  #   api_key: "${FILEACTIVITY_ES_API_KEY}"
+  #   verify_certs: true
+  #   request_timeout: 30
 
 analytics:
   # DuckDB tabanli analitik motor. SQLite dosyasini salt-okunur ATTACH eder,

--- a/docs/operator-runbook.md
+++ b/docs/operator-runbook.md
@@ -473,6 +473,39 @@ arasındaki audit eventleri gözden geçir.
 
 ---
 
+## Switching to Elasticsearch (optional)
+
+Phase 2 of issue #114 ships an optional ``ElasticsearchBackend`` so
+large deployments can offload dashboard queries to an ES cluster
+(Phase 3 wires the dashboard query layer; Phase 4 ships the SQLite ->
+ES backfill / migration tool). SQLite remains the default.
+
+```bash
+# 1) Install the optional client (SQLite-only deployments skip this).
+pip install -r requirements-elastic.txt
+
+# 2) config.yaml — flip backend and uncomment the connection block:
+# storage:
+#   backend: "elasticsearch"
+#   elasticsearch:
+#     hosts: ["https://es.internal:9200"]
+#     api_key: "${FILEACTIVITY_ES_API_KEY}"
+#     verify_certs: true
+#     request_timeout: 30
+
+# 3) Provide the API key out-of-band (env var).
+export FILEACTIVITY_ES_API_KEY="..."
+
+# 4) Restart the service / dashboard. The ops banner will reflect
+#    the active backend; ``health_check`` never raises, so a missing
+#    cluster shows up as a banner, not a crash.
+```
+
+**Migration of existing SQLite data is NOT in this release** — the
+backfill tool ships in Phase 4 of #114. Until then, switching backends
+on a populated install means new scans land in ES while historical
+scans remain queryable only via the SQLite tool.
+
 ## Performans Ayarı
 
 ### Hyperscan opt-in (Linux)

--- a/requirements-elastic.txt
+++ b/requirements-elastic.txt
@@ -1,0 +1,1 @@
+elasticsearch>=8.0,<9.0

--- a/src/storage/backends/__init__.py
+++ b/src/storage/backends/__init__.py
@@ -1,0 +1,35 @@
+"""Storage backend package (issue #114).
+
+Phase 1 introduced the :class:`StorageBackend` Protocol and the
+:class:`SqliteBackend` shim; Phase 2 adds the optional
+:class:`ElasticsearchBackend`. The ES backend is exposed via a lazy
+factory (``get_elasticsearch_backend``) so importing this package
+never pulls in the ``elasticsearch`` client — SQLite-only deployments
+must stay deployable without the new dependency.
+"""
+
+from __future__ import annotations
+
+from .manager import StorageManager
+from .sqlite_backend import SqliteBackend
+
+
+def get_elasticsearch_backend():  # pragma: no cover - thin lazy loader
+    """Lazily import + return the ``ElasticsearchBackend`` class.
+
+    Kept as a function so ``import src.storage.backends`` never
+    triggers the ``elasticsearch`` client import. Callers that want
+    the class do ``cls = get_elasticsearch_backend(); cls(db, cfg)``;
+    the more common path is via :class:`StorageManager`, which lazy-
+    imports it itself.
+    """
+    from .elasticsearch_backend import ElasticsearchBackend
+
+    return ElasticsearchBackend
+
+
+__all__ = [
+    "StorageManager",
+    "SqliteBackend",
+    "get_elasticsearch_backend",
+]

--- a/src/storage/backends/elasticsearch_backend.py
+++ b/src/storage/backends/elasticsearch_backend.py
@@ -1,0 +1,463 @@
+"""Elasticsearch-backed implementation of :class:`StorageBackend`.
+
+Phase 2 of issue #114. Mirrors the validation discipline of
+:mod:`sqlite_backend` and shares its whitelists by importing them —
+same DSL, same validation, two backends. Phase 3 will rewire the
+dashboard query layer to call the active backend through
+:class:`StorageManager`; Phase 4 ships the SQLite -> ES backfill
+tool. This module is intentionally narrow: it does not touch the
+dashboard, does not auto-migrate, and does not refresh indices in
+production paths (refresh is a per-shard cluster-load anti-pattern at
+scale — tests can call ``client.indices.refresh(...)`` explicitly).
+
+Index layout (see :mod:`es_mapping`):
+
+    scanned_files-{source_id}-{scan_id}
+
+The Protocol scopes by ``scan_id`` only, so the backend resolves
+``source_id`` through the SQLite :class:`Database` instance passed to
+the constructor. That keeps the Protocol surface unchanged across
+backends; Phase 3 callers continue to pass a single ``scan_id``.
+"""
+
+from __future__ import annotations
+
+import copy
+import logging
+import time
+from typing import Any, Iterator
+
+from .es_mapping import INDEX_BODY, index_name
+from .sqlite_backend import (
+    _ALLOWED_FILTER_KEYS,
+    _ALLOWED_GROUP_BY,
+    _ALLOWED_METRICS,
+)
+
+logger = logging.getLogger("file_activity.storage.elasticsearch_backend")
+
+
+# Lazy-imported at construction time so importing this module on a
+# host without the ``elasticsearch`` client doesn't blow up at import
+# (e.g. tooling that only needs ``index_name``). The constructor will
+# raise a clean ImportError if the dep is missing.
+_ES_IMPORT_ERROR: Exception | None = None
+try:  # pragma: no cover - import guard
+    from elasticsearch import Elasticsearch  # type: ignore
+    from elasticsearch import helpers as es_helpers  # type: ignore
+except Exception as _e:  # pragma: no cover - import guard
+    Elasticsearch = None  # type: ignore[assignment]
+    es_helpers = None  # type: ignore[assignment]
+    _ES_IMPORT_ERROR = _e
+
+
+class ElasticsearchBackend:
+    """Elasticsearch implementation of :class:`StorageBackend`.
+
+    Constructor takes the same SQLite ``Database`` the SqliteBackend
+    takes — used for ``source_id`` lookup so the Protocol can keep
+    its ``scan_id``-only signature. This is intentional: callers must
+    not be forced to thread ``source_id`` through every read.
+    """
+
+    name = "elasticsearch"
+
+    def __init__(self, db: Any, cfg: dict) -> None:
+        if Elasticsearch is None:
+            raise ImportError(
+                "elasticsearch client not installed. "
+                "pip install -r requirements-elastic.txt "
+                f"(underlying error: {_ES_IMPORT_ERROR!r})"
+            )
+        self.db = db
+        self.config = cfg or {}
+        es_cfg = ((self.config.get("storage") or {}).get("elasticsearch")) or {}
+
+        hosts = es_cfg.get("hosts") or ["http://localhost:9200"]
+        api_key = es_cfg.get("api_key")
+        verify_certs = bool(es_cfg.get("verify_certs", True))
+        request_timeout = int(es_cfg.get("request_timeout", 30))
+
+        client_kwargs: dict[str, Any] = {
+            "hosts": hosts,
+            "verify_certs": verify_certs,
+            "request_timeout": request_timeout,
+        }
+        if api_key:
+            client_kwargs["api_key"] = api_key
+
+        self.client = Elasticsearch(**client_kwargs)
+        # Cache resolved source_ids per scan_id so we don't hit SQLite
+        # on every read. scan_id -> source_id is immutable for a given
+        # scan, so the cache never goes stale.
+        self._source_id_cache: dict[int, int] = {}
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def _resolve_source_id(self, scan_id: int) -> int:
+        """Resolve ``source_id`` for ``scan_id`` via the SQLite catalog.
+
+        Callers pass only ``scan_id`` (Protocol contract); ES indices
+        are partitioned by ``(source_id, scan_id)``, so we look up the
+        owning source via ``scan_runs``.
+        """
+        cached = self._source_id_cache.get(scan_id)
+        if cached is not None:
+            return cached
+        with self.db.get_cursor() as cur:
+            cur.execute(
+                "SELECT source_id FROM scan_runs WHERE id = ?",
+                (scan_id,),
+            )
+            row = cur.fetchone()
+            if row is None:
+                raise ValueError(
+                    f"ElasticsearchBackend: unknown scan_id={scan_id} "
+                    f"(no row in scan_runs)"
+                )
+            source_id = int(row["source_id"])
+        self._source_id_cache[scan_id] = source_id
+        return source_id
+
+    def _index_for(self, scan_id: int) -> str:
+        return index_name(self._resolve_source_id(scan_id), scan_id)
+
+    def _ensure_index(self, index: str) -> None:
+        """Create the index with the canonical mapping if it doesn't
+        exist. Cheap idempotent call — ES will 400 if it already
+        exists, which we swallow."""
+        try:
+            if not self.client.indices.exists(index=index):
+                body = copy.deepcopy(INDEX_BODY)
+                self.client.indices.create(index=index, body=body)
+        except Exception as e:  # pragma: no cover - race-conditional
+            # Race: another writer created it between exists() and
+            # create(). Idempotent — log and continue.
+            logger.debug("index create race for %s: %s", index, e)
+
+    def _build_filter_query(
+        self, scan_id: int, filter_dsl: dict
+    ) -> dict:
+        """Translate a whitelisted SQLite-style filter DSL to an ES
+        ``bool/filter`` query. Validation matches the SqliteBackend
+        exactly — same allowlist, same error message style."""
+        if filter_dsl is None:
+            filter_dsl = {}
+        unknown = set(filter_dsl) - _ALLOWED_FILTER_KEYS
+        if unknown:
+            raise ValueError(
+                f"query_files: unsupported filter keys: {sorted(unknown)}. "
+                f"Allowed: {sorted(_ALLOWED_FILTER_KEYS)}"
+            )
+
+        filters: list[dict] = [{"term": {"scan_id": int(scan_id)}}]
+
+        if "extension" in filter_dsl:
+            filters.append({"term": {"extension": filter_dsl["extension"]}})
+        if "owner" in filter_dsl:
+            filters.append({"term": {"owner": filter_dsl["owner"]}})
+        size_range: dict[str, Any] = {}
+        if "min_size" in filter_dsl:
+            size_range["gte"] = filter_dsl["min_size"]
+        if "max_size" in filter_dsl:
+            size_range["lte"] = filter_dsl["max_size"]
+        if size_range:
+            filters.append({"range": {"size_bytes": size_range}})
+        mtime_range: dict[str, Any] = {}
+        if "min_mtime" in filter_dsl:
+            mtime_range["gte"] = filter_dsl["min_mtime"]
+        if "max_mtime" in filter_dsl:
+            mtime_range["lte"] = filter_dsl["max_mtime"]
+        if mtime_range:
+            filters.append({"range": {"mtime": mtime_range}})
+        if "directory_prefix" in filter_dsl:
+            # Use prefix on the keyword sub-field so we don't get
+            # token-level prefix surprises.
+            filters.append(
+                {
+                    "prefix": {
+                        "file_path.keyword": str(filter_dsl["directory_prefix"])
+                    }
+                }
+            )
+
+        return {"bool": {"filter": filters}}
+
+    # ------------------------------------------------------------------
+    # Writes
+    # ------------------------------------------------------------------
+
+    def insert_scanned_files(self, scan_id: int, rows: list[dict]) -> int:
+        """Bulk insert via ``helpers.bulk`` with retry + exponential
+        backoff. Returns successful insert count.
+
+        ``raise_on_error=False`` — partial failures don't poison the
+        whole batch; the caller gets the success count and we log
+        the rest.
+        """
+        if not rows:
+            return 0
+        index = self._index_for(scan_id)
+        self._ensure_index(index)
+
+        actions = []
+        for r in rows:
+            doc = {
+                "scan_id": int(scan_id),
+                "source_id": int(
+                    r.get("source_id") or self._resolve_source_id(scan_id)
+                ),
+                "file_path": r.get("file_path"),
+                "extension": r.get("extension"),
+                "owner": r.get("owner"),
+                "size_bytes": r.get("file_size") or r.get("size_bytes") or 0,
+                "mtime": r.get("last_modify_time") or r.get("mtime"),
+                "directory_path": r.get("directory_path")
+                or self._derive_directory(r),
+            }
+            actions.append({"_index": index, "_source": doc})
+
+        # Retry with backoff: 1s, 2s, 4s. ``helpers.bulk`` already
+        # batches; this loop wraps the whole call for transient
+        # connectivity hiccups.
+        last_err: Exception | None = None
+        for attempt in range(3):
+            try:
+                success, errors = es_helpers.bulk(
+                    self.client,
+                    actions,
+                    refresh="false",
+                    raise_on_error=False,
+                    raise_on_exception=False,
+                )
+                if errors:
+                    logger.warning(
+                        "bulk insert had %d errors (sample: %s)",
+                        len(errors),
+                        errors[:1],
+                    )
+                return int(success)
+            except Exception as e:  # pragma: no cover - network path
+                last_err = e
+                logger.warning(
+                    "bulk insert attempt %d failed: %s", attempt + 1, e
+                )
+                time.sleep(2 ** attempt)
+        # All retries exhausted.
+        raise RuntimeError(
+            f"ElasticsearchBackend.insert_scanned_files failed: {last_err!r}"
+        )
+
+    @staticmethod
+    def _derive_directory(row: dict) -> str | None:
+        """Best-effort directory_path derivation when the producer
+        didn't supply it. SQLite shim does the same trick at query
+        time; we precompute on write so ES aggregations can group_by
+        ``directory_path`` as a keyword."""
+        path = row.get("file_path")
+        name = row.get("file_name")
+        if not path:
+            return None
+        if name and path.endswith(name):
+            return path[: len(path) - len(name)]
+        # Fallback: trim after the last separator.
+        for sep in ("\\", "/"):
+            idx = path.rfind(sep)
+            if idx >= 0:
+                return path[: idx + 1]
+        return path
+
+    def delete_scan(self, scan_id: int) -> int:
+        """Delete the scan's index outright. Cheaper and cleaner than
+        delete-by-query, and the index is single-purpose. Returns the
+        approximate doc count that was deleted (best-effort)."""
+        index = self._index_for(scan_id)
+        try:
+            count = int(
+                self.client.count(index=index).get("count", 0)
+            )
+        except Exception:
+            count = 0
+        try:
+            # delete-by-query keeps the index around for
+            # subsequent inserts; that matches SqliteBackend, which
+            # keeps the table.
+            res = self.client.delete_by_query(
+                index=index,
+                body={"query": {"term": {"scan_id": int(scan_id)}}},
+                refresh=False,
+                conflicts="proceed",
+            )
+            return int(res.get("deleted", count) or count)
+        except Exception as e:
+            logger.warning("delete_by_query failed for %s: %s", index, e)
+            return 0
+
+    # ------------------------------------------------------------------
+    # Reads
+    # ------------------------------------------------------------------
+
+    def count_scanned_files(self, scan_id: int) -> int:
+        index = self._index_for(scan_id)
+        try:
+            res = self.client.count(
+                index=index,
+                body={"query": {"term": {"scan_id": int(scan_id)}}},
+            )
+            return int(res.get("count", 0))
+        except Exception as e:
+            logger.debug("count failed for %s: %s", index, e)
+            return 0
+
+    def query_files(
+        self,
+        scan_id: int,
+        filter_dsl: dict,
+        limit: int = 1000,
+    ) -> list[dict]:
+        """Filter-DSL search. Validates against the shared whitelist
+        before constructing the ES query; same error message style as
+        the SQLite shim."""
+        query = self._build_filter_query(scan_id, filter_dsl or {})
+        index = self._index_for(scan_id)
+        res = self.client.search(
+            index=index,
+            body={"query": query, "size": int(limit)},
+        )
+        return [hit.get("_source", {}) for hit in res["hits"]["hits"]]
+
+    def aggregate(
+        self,
+        scan_id: int,
+        group_by: str,
+        metric: str = "count",
+    ) -> list[dict]:
+        """Terms aggregation. Validates ``group_by`` and ``metric``
+        against the shared whitelist before issuing the query."""
+        if group_by not in _ALLOWED_GROUP_BY:
+            raise ValueError(
+                f"aggregate: unsupported group_by={group_by!r}. "
+                f"Allowed: {sorted(_ALLOWED_GROUP_BY)}"
+            )
+        if metric not in _ALLOWED_METRICS:
+            raise ValueError(
+                f"aggregate: unsupported metric={metric!r}. "
+                f"Allowed: {sorted(_ALLOWED_METRICS)}"
+            )
+
+        index = self._index_for(scan_id)
+        # All aggregation fields are indexed as keyword (or are
+        # already keyword type), so terms agg is direct.
+        terms_field = group_by  # extension/owner/directory_path are all keyword.
+
+        body: dict[str, Any] = {
+            "size": 0,
+            "query": {"term": {"scan_id": int(scan_id)}},
+            "aggs": {
+                "g": {
+                    "terms": {"field": terms_field, "size": 10_000},
+                }
+            },
+        }
+        if metric == "sum_size":
+            body["aggs"]["g"]["aggs"] = {
+                "m": {"sum": {"field": "size_bytes"}}
+            }
+
+        res = self.client.search(index=index, body=body)
+        buckets = res.get("aggregations", {}).get("g", {}).get("buckets", [])
+
+        out: list[dict] = []
+        if metric == "count":
+            for b in buckets:
+                out.append({group_by: b["key"], "count": int(b["doc_count"])})
+        else:
+            for b in buckets:
+                out.append(
+                    {
+                        group_by: b["key"],
+                        "sum_size": int(b.get("m", {}).get("value") or 0),
+                    }
+                )
+        # Sort matches the SqliteBackend convention (ORDER BY metric DESC).
+        sort_key = "count" if metric == "count" else "sum_size"
+        out.sort(key=lambda r: r[sort_key], reverse=True)
+        return out
+
+    def search_text(
+        self,
+        scan_id: int,
+        query: str,
+        limit: int = 100,
+    ) -> list[dict]:
+        """Full-text search on the analyzed ``file_path`` field.
+        This is the place ES outshines SQLite's LIKE — proper
+        tokenisation + relevance scoring."""
+        index = self._index_for(scan_id)
+        body = {
+            "size": int(limit),
+            "query": {
+                "bool": {
+                    "filter": [{"term": {"scan_id": int(scan_id)}}],
+                    "must": [{"match": {"file_path": query or ""}}],
+                }
+            },
+        }
+        res = self.client.search(index=index, body=body)
+        return [hit.get("_source", {}) for hit in res["hits"]["hits"]]
+
+    def iterate_scan(
+        self,
+        scan_id: int,
+        batch_size: int = 1000,
+    ) -> Iterator[list[dict]]:
+        """Stream the whole scan via the ``scan`` helper. Used by
+        Phase 4 backfill / migration tooling and by heavy reports."""
+        if batch_size <= 0:
+            raise ValueError("batch_size must be positive")
+        index = self._index_for(scan_id)
+        gen = es_helpers.scan(
+            self.client,
+            index=index,
+            query={"query": {"term": {"scan_id": int(scan_id)}}},
+            size=int(batch_size),
+            preserve_order=False,
+        )
+        batch: list[dict] = []
+        for hit in gen:
+            batch.append(hit.get("_source", {}))
+            if len(batch) >= batch_size:
+                yield batch
+                batch = []
+        if batch:
+            yield batch
+
+    def health_check(self) -> dict:
+        """Cluster ping + basic info. NEVER raises — the dashboard
+        ops banner depends on this returning a usable dict even when
+        ES is down."""
+        try:
+            ping_ok = bool(self.client.ping())
+            details: dict[str, Any] = {"ping": ping_ok}
+            if ping_ok:
+                try:
+                    info = self.client.info()
+                    details["cluster_name"] = info.get("cluster_name")
+                    details["version"] = (info.get("version") or {}).get(
+                        "number"
+                    )
+                except Exception as e:  # pragma: no cover - defensive
+                    details["info_error"] = str(e)
+            return {
+                "name": self.name,
+                "available": ping_ok,
+                "details": details,
+            }
+        except Exception as e:
+            return {
+                "name": self.name,
+                "available": False,
+                "details": {"error": str(e)},
+            }

--- a/src/storage/backends/es_mapping.py
+++ b/src/storage/backends/es_mapping.py
@@ -1,0 +1,65 @@
+"""Elasticsearch index mapping + settings for ``scanned_files`` docs.
+
+Phase 2 of issue #114. Centralised so the backend, the migration tool
+(Phase 4), and any ad-hoc tooling all use the exact same mapping.
+
+Index naming convention (defined in ``elasticsearch_backend``):
+
+    scanned_files-{source_id}-{scan_id}
+
+Defaults below assume a single-node dev/staging cluster
+(``number_of_replicas: 0``). Production clusters should override
+``number_of_shards`` / ``number_of_replicas`` via index templates —
+this module's literal is the conservative default. The backend does
+NOT mutate this dict; copy with ``copy.deepcopy`` before patching.
+"""
+
+from __future__ import annotations
+
+# Single source of truth for the mapping. Kept as a plain dict so it
+# round-trips through ``json.dumps`` without surprises and so other
+# tools (Phase 4 migrator, ops scripts) can ``from es_mapping import
+# INDEX_BODY`` without pulling the ES client.
+INDEX_BODY: dict = {
+    "settings": {
+        "number_of_shards": 1,
+        # Single-node default. Multi-node clusters should set this to
+        # at least 1 via an index template before pointing the backend
+        # at them.
+        "number_of_replicas": 0,
+        "refresh_interval": "1s",
+    },
+    "mappings": {
+        # Strict so a typo in the doc producer surfaces at index time
+        # rather than as a silent ignored field at query time.
+        "dynamic": "strict",
+        "properties": {
+            "scan_id": {"type": "long"},
+            "source_id": {"type": "long"},
+            # ``file_path`` is the workhorse field for full-text search
+            # (search_text) and exact-match / prefix queries (filter
+            # DSL ``directory_prefix``). Multi-field gives us both.
+            "file_path": {
+                "type": "text",
+                "fields": {
+                    "keyword": {"type": "keyword", "ignore_above": 1024},
+                },
+            },
+            "extension": {"type": "keyword"},
+            "owner": {"type": "keyword"},
+            "size_bytes": {"type": "long"},
+            "mtime": {"type": "date"},
+            "directory_path": {"type": "keyword"},
+        },
+    },
+}
+
+
+def index_name(source_id: int, scan_id: int) -> str:
+    """Return the canonical index name for a (source, scan) pair.
+
+    Kept here so the backend and any future tooling never disagree on
+    the format. A drift between producer and reader silently loses
+    data.
+    """
+    return f"scanned_files-{int(source_id)}-{int(scan_id)}"

--- a/src/storage/backends/manager.py
+++ b/src/storage/backends/manager.py
@@ -22,9 +22,10 @@ class StorageManager:
     dashboard endpoints to read from this instead of ``db.execute(...)``.
 
     The active backend is selected from ``config.storage.backend``;
-    default is ``"sqlite"``. Unknown backends raise ``ValueError``;
-    Phase 2's ``"elasticsearch"`` raises ``NotImplementedError`` (the
-    contract is here, the impl isn't).
+    default is ``"sqlite"``. Unknown backends raise ``ValueError``.
+    Phase 2 (#114) wires the ``"elasticsearch"`` option; the ES client
+    is imported lazily so SQLite-only deployments don't need the
+    ``elasticsearch`` package.
     """
 
     def __init__(self, db: Any, config: dict) -> None:
@@ -38,9 +39,11 @@ class StorageManager:
 
             self.backend = SqliteBackend(db, config or {})
         elif backend_name == "elasticsearch":
-            raise NotImplementedError(
-                "Elasticsearch backend lands in #114 Phase 2"
-            )
+            # Lazy import so SQLite-only deployments don't pay for
+            # the ``elasticsearch`` client import.
+            from .elasticsearch_backend import ElasticsearchBackend
+
+            self.backend = ElasticsearchBackend(db, config or {})
         else:
             raise ValueError(
                 f"Unknown storage.backend: {backend_name!r}"

--- a/tests/test_elasticsearch_backend.py
+++ b/tests/test_elasticsearch_backend.py
@@ -1,0 +1,337 @@
+"""Integration tests for :class:`ElasticsearchBackend` (issue #114, Phase 2).
+
+Skips cleanly when:
+  - the ``elasticsearch`` client is not installed, or
+  - ``testcontainers[elasticsearch]`` is not installed, or
+  - Docker is not reachable on the host.
+
+This is by design: the Phase 2 PR ships the backend as an optional
+component. CI hosts without Docker (or without the optional deps)
+should still get a green pytest run for the rest of the suite.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+
+import pytest
+
+# ---- Optional-dep gating ---------------------------------------------------
+elasticsearch = pytest.importorskip(
+    "elasticsearch", reason="elasticsearch client not installed"
+)
+
+try:
+    from testcontainers.elasticsearch import ElasticSearchContainer  # type: ignore
+except Exception:  # pragma: no cover - import guard
+    ElasticSearchContainer = None  # type: ignore[assignment]
+
+
+from src.storage.backends.elasticsearch_backend import ElasticsearchBackend
+from src.storage.database import Database
+
+
+# ---- Fixtures --------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def es_container():
+    """Spin up a single-node ES container for the module.
+
+    Skips the entire module if testcontainers / Docker is unavailable.
+    """
+    if ElasticSearchContainer is None:
+        pytest.skip("Docker / testcontainers unavailable")
+    try:
+        # ES 8.x; ``ElasticSearchContainer`` defaults to a recent tag
+        # but pin if the user supplied one via env.
+        image = os.environ.get(
+            "FILEACTIVITY_TEST_ES_IMAGE",
+            "docker.elastic.co/elasticsearch/elasticsearch:8.11.0",
+        )
+        container = ElasticSearchContainer(image)
+        # Single-node, no security so the test client doesn't need
+        # certs / api_key. Production config in operator-runbook.md.
+        container.with_env("xpack.security.enabled", "false")
+        container.start()
+    except Exception as e:  # pragma: no cover - host-dependent
+        pytest.skip(f"Docker / testcontainers unavailable: {e!r}")
+    try:
+        yield container
+    finally:
+        try:
+            container.stop()
+        except Exception:
+            pass
+
+
+@pytest.fixture
+def db(tmp_path):
+    db_path = tmp_path / "phase2.db"
+    inst = Database({"path": str(db_path)})
+    inst.connect()
+    yield inst
+    try:
+        inst.close()
+    except Exception:
+        pass
+
+
+@pytest.fixture
+def seeded(db, es_container):
+    """Insert one source + one scan_run, build the backend, and
+    return ``(backend, source_id, scan_id)``."""
+    with db.get_cursor() as cur:
+        cur.execute(
+            "INSERT INTO sources (name, unc_path) VALUES ('s1', '/share')"
+        )
+        source_id = cur.lastrowid
+        cur.execute(
+            "INSERT INTO scan_runs (source_id, status) VALUES (?, 'completed')",
+            (source_id,),
+        )
+        scan_id = cur.lastrowid
+
+    cfg = {
+        "storage": {
+            "backend": "elasticsearch",
+            "elasticsearch": {
+                "hosts": [es_container.get_url()],
+                "verify_certs": False,
+                "request_timeout": 30,
+            },
+        }
+    }
+    backend = ElasticsearchBackend(db, cfg)
+    return backend, source_id, scan_id
+
+
+def _refresh(backend: ElasticsearchBackend, scan_id: int, source_id: int) -> None:
+    """Tests ONLY: force refresh so subsequent reads see writes.
+    Production code does NOT do this; we keep the production paths
+    refresh-free per the operator runbook."""
+    index = f"scanned_files-{source_id}-{scan_id}"
+    try:
+        backend.client.indices.refresh(index=index)
+    except Exception:
+        pass
+
+
+# ---- Tests -----------------------------------------------------------------
+
+
+def test_insert_and_count(seeded):
+    backend, source_id, scan_id = seeded
+    rows = [
+        {
+            "source_id": source_id,
+            "file_path": r"\\share\dir\a.pdf",
+            "file_name": "a.pdf",
+            "extension": "pdf",
+            "file_size": 2_000_000,
+            "owner": "alice",
+            "last_modify_time": "2024-06-01T00:00:00",
+        },
+        {
+            "source_id": source_id,
+            "file_path": r"\\share\dir\b.pdf",
+            "file_name": "b.pdf",
+            "extension": "pdf",
+            "file_size": 500_000,
+            "owner": "bob",
+            "last_modify_time": "2024-06-02T00:00:00",
+        },
+        {
+            "source_id": source_id,
+            "file_path": r"\\share\other\c.txt",
+            "file_name": "c.txt",
+            "extension": "txt",
+            "file_size": 1024,
+            "owner": "alice",
+            "last_modify_time": "2024-06-03T00:00:00",
+        },
+    ]
+    inserted = backend.insert_scanned_files(scan_id, rows)
+    assert inserted == 3
+    _refresh(backend, scan_id, source_id)
+    assert backend.count_scanned_files(scan_id) == 3
+
+
+def test_query_files_extension_filter(seeded):
+    backend, source_id, scan_id = seeded
+    rows = [
+        {
+            "source_id": source_id,
+            "file_path": r"\\share\dir\a.pdf",
+            "file_name": "a.pdf",
+            "extension": "pdf",
+            "file_size": 2_000_000,
+            "owner": "alice",
+        },
+        {
+            "source_id": source_id,
+            "file_path": r"\\share\dir\b.pdf",
+            "file_name": "b.pdf",
+            "extension": "pdf",
+            "file_size": 500_000,
+            "owner": "bob",
+        },
+        {
+            "source_id": source_id,
+            "file_path": r"\\share\other\c.txt",
+            "file_name": "c.txt",
+            "extension": "txt",
+            "file_size": 1024,
+            "owner": "alice",
+        },
+    ]
+    backend.insert_scanned_files(scan_id, rows)
+    _refresh(backend, scan_id, source_id)
+
+    pdfs = backend.query_files(scan_id, {"extension": "pdf"})
+    assert len(pdfs) == 2
+    assert all(r["extension"] == "pdf" for r in pdfs)
+
+    # Whitelist enforcement matches SqliteBackend.
+    with pytest.raises(ValueError):
+        backend.query_files(scan_id, {"file_path; DROP": "x"})
+
+
+def test_aggregate_group_by_extension(seeded):
+    backend, source_id, scan_id = seeded
+    rows = [
+        {
+            "source_id": source_id,
+            "file_path": r"\\share\dir\a.pdf",
+            "file_name": "a.pdf",
+            "extension": "pdf",
+            "file_size": 2_000_000,
+            "owner": "alice",
+        },
+        {
+            "source_id": source_id,
+            "file_path": r"\\share\dir\b.pdf",
+            "file_name": "b.pdf",
+            "extension": "pdf",
+            "file_size": 500_000,
+            "owner": "bob",
+        },
+        {
+            "source_id": source_id,
+            "file_path": r"\\share\other\c.txt",
+            "file_name": "c.txt",
+            "extension": "txt",
+            "file_size": 1024,
+            "owner": "alice",
+        },
+    ]
+    backend.insert_scanned_files(scan_id, rows)
+    _refresh(backend, scan_id, source_id)
+
+    counts = backend.aggregate(scan_id, "extension", "count")
+    counts_by_ext = {r["extension"]: r["count"] for r in counts}
+    assert counts_by_ext == {"pdf": 2, "txt": 1}
+
+    sums = backend.aggregate(scan_id, "extension", "sum_size")
+    sums_by_ext = {r["extension"]: r["sum_size"] for r in sums}
+    assert sums_by_ext["pdf"] == 2_500_000
+    assert sums_by_ext["txt"] == 1024
+
+    with pytest.raises(ValueError):
+        backend.aggregate(scan_id, "file_path", "count")
+    with pytest.raises(ValueError):
+        backend.aggregate(scan_id, "extension", "avg_size")
+
+
+def test_search_text(seeded):
+    backend, source_id, scan_id = seeded
+    rows = [
+        {
+            "source_id": source_id,
+            "file_path": r"\\share\dir\quarterly_report.pdf",
+            "file_name": "quarterly_report.pdf",
+            "extension": "pdf",
+            "file_size": 1024,
+        },
+        {
+            "source_id": source_id,
+            "file_path": r"\\share\other\notes.txt",
+            "file_name": "notes.txt",
+            "extension": "txt",
+            "file_size": 1024,
+        },
+    ]
+    backend.insert_scanned_files(scan_id, rows)
+    _refresh(backend, scan_id, source_id)
+
+    hits = backend.search_text(scan_id, "quarterly")
+    paths = [h["file_path"] for h in hits]
+    assert any("quarterly_report" in p for p in paths)
+
+
+def test_iterate_scan(seeded):
+    backend, source_id, scan_id = seeded
+    rows = [
+        {
+            "source_id": source_id,
+            "file_path": f"\\\\share\\bulk\\f{i}.bin",
+            "file_name": f"f{i}.bin",
+            "extension": "bin",
+            "file_size": 100 + i,
+        }
+        for i in range(5)
+    ]
+    backend.insert_scanned_files(scan_id, rows)
+    _refresh(backend, scan_id, source_id)
+
+    batches = list(backend.iterate_scan(scan_id, batch_size=2))
+    flat = [r for b in batches for r in b]
+    assert len(flat) == 5
+
+
+def test_delete_scan(seeded):
+    backend, source_id, scan_id = seeded
+    rows = [
+        {
+            "source_id": source_id,
+            "file_path": r"\\share\d\a.pdf",
+            "file_name": "a.pdf",
+            "extension": "pdf",
+            "file_size": 1,
+        },
+    ]
+    backend.insert_scanned_files(scan_id, rows)
+    _refresh(backend, scan_id, source_id)
+    assert backend.count_scanned_files(scan_id) == 1
+    backend.delete_scan(scan_id)
+    _refresh(backend, scan_id, source_id)
+    assert backend.count_scanned_files(scan_id) == 0
+
+
+def test_health_check(seeded):
+    backend, _, _ = seeded
+    res = backend.health_check()
+    assert res["name"] == "elasticsearch"
+    assert isinstance(res["details"], dict)
+    # Container is up — ping should succeed.
+    assert res["available"] is True
+
+
+def test_health_check_never_raises(db):
+    """Pointed at a dead host, health_check still returns a dict."""
+    cfg = {
+        "storage": {
+            "backend": "elasticsearch",
+            "elasticsearch": {
+                "hosts": ["http://127.0.0.1:1"],  # closed port
+                "verify_certs": False,
+                "request_timeout": 1,
+            },
+        }
+    }
+    backend = ElasticsearchBackend(db, cfg)
+    res = backend.health_check()
+    assert res["name"] == "elasticsearch"
+    assert res["available"] is False
+    assert "details" in res

--- a/tests/test_elasticsearch_backend.py
+++ b/tests/test_elasticsearch_backend.py
@@ -13,7 +13,6 @@ should still get a green pytest run for the rest of the suite.
 from __future__ import annotations
 
 import os
-import time
 
 import pytest
 
@@ -63,6 +62,9 @@ def es_container():
         try:
             container.stop()
         except Exception:
+            # Best-effort teardown: a stop() failure here would mask the
+            # real test failure and the next pytest run picks up after
+            # the container's TTL anyway. Logging would also be noise.
             pass
 
 
@@ -75,6 +77,9 @@ def db(tmp_path):
     try:
         inst.close()
     except Exception:
+        # Best-effort teardown: tmp_path is removed by pytest regardless,
+        # so a close() failure here would only obscure the real test
+        # failure further up the stack.
         pass
 
 
@@ -115,6 +120,9 @@ def _refresh(backend: ElasticsearchBackend, scan_id: int, source_id: int) -> Non
     try:
         backend.client.indices.refresh(index=index)
     except Exception:
+        # Refresh may legitimately 404 when the test wrote zero rows
+        # (delete_scan / empty insert paths). Treating that as fatal
+        # would mask the real assertion below.
         pass
 
 

--- a/tests/test_storage_backend.py
+++ b/tests/test_storage_backend.py
@@ -117,10 +117,22 @@ def test_storage_manager_explicit_sqlite(db):
     assert isinstance(mgr.backend, SqliteBackend)
 
 
-def test_storage_manager_elasticsearch_raises_not_implemented(db):
-    """ES backend is reserved for Phase 2 — must raise NotImplementedError."""
-    with pytest.raises(NotImplementedError):
-        StorageManager(db, {"storage": {"backend": "elasticsearch"}})
+def test_storage_manager_elasticsearch_lazy_imports(db):
+    """Phase 2 (#114): ES backend is wired but the import is lazy.
+
+    If the ``elasticsearch`` client is not installed the constructor
+    raises ``ImportError`` with a pointer to ``requirements-elastic.txt``.
+    If it IS installed the constructor must succeed (network ping is
+    deferred to ``health_check`` so a missing cluster doesn't break
+    boot)."""
+    try:
+        import elasticsearch  # noqa: F401
+    except Exception:
+        with pytest.raises(ImportError):
+            StorageManager(db, {"storage": {"backend": "elasticsearch"}})
+        return
+    mgr = StorageManager(db, {"storage": {"backend": "elasticsearch"}})
+    assert mgr.name == "elasticsearch"
 
 
 def test_storage_manager_unknown_backend_raises(db):


### PR DESCRIPTION
## Summary

Phase 2 of issue #114: lands an `ElasticsearchBackend` implementing the same `StorageBackend` Protocol that Phase 1 (#121) defined for `SqliteBackend`. The ES backend is opt-in — SQLite remains the default and SQLite-only deployments do not need to install the `elasticsearch` client.

This PR is intentionally narrow: it ships the backend, registers it in the manager, and adds operator-facing config + docs. It does not touch the dashboard query layer (Phase 3), does not migrate existing SQLite data (Phase 4), and does not refresh ES indices in production paths (refresh is a per-shard cluster-load anti-pattern at scale; tests refresh explicitly via the client).

## Design

- **Same DSL across backends.** `_ALLOWED_FILTER_KEYS`, `_ALLOWED_GROUP_BY`, `_ALLOWED_METRICS` are imported from `sqlite_backend`. The ES backend rejects unknown keys with the same `ValueError` message style. One whitelist, two backends.
- **`scan_id`-only Protocol surface preserved.** ES indices are partitioned by `(source_id, scan_id)`, but the Protocol only takes `scan_id`. The backend resolves `source_id` through the SQLite `Database` catalog (`scan_runs` table), cached per scan.
- **Index naming centralised.** `es_mapping.index_name(source_id, scan_id)` is the single source of truth so producer and reader can never disagree on the format.
- **Lazy import everywhere.** `StorageManager` only imports `ElasticsearchBackend` when `storage.backend == "elasticsearch"`; the package `__init__` exposes a `get_elasticsearch_backend()` factory. Verified: `import src.storage.backends.manager` does not pull in `elasticsearch`.
- **`health_check` never raises** — wrapped in try/except, returns `{'available': False, 'details': {'error': ...}}` so the dashboard ops banner survives a dead cluster. Test `test_health_check_never_raises` exercises this against a closed port.
- **Bulk insert with retry + backoff.** `helpers.bulk` with `refresh="false"`, `raise_on_error=False`, count successes from the return tuple. Three attempts at 1s/2s/4s.

## Files touched

New:
- `src/storage/backends/elasticsearch_backend.py` — the implementation (~370 LoC).
- `src/storage/backends/es_mapping.py` — `INDEX_BODY` literal + `index_name` helper.
- `requirements-elastic.txt` — `elasticsearch>=8.0,<9.0`.
- `tests/test_elasticsearch_backend.py` — testcontainers-based integration tests; skips cleanly if Docker / testcontainers / the ES client are unavailable.

Modified:
- `src/storage/backends/manager.py` — `"elasticsearch"` branch wired (lazy import).
- `src/storage/backends/__init__.py` — exposes `StorageManager`, `SqliteBackend`, `get_elasticsearch_backend`.
- `tests/test_storage_backend.py` — Phase-1 test that asserted `NotImplementedError` rewritten to assert lazy import behaviour.
- `config.yaml` — commented-out `storage.elasticsearch` block.
- `docs/operator-runbook.md` — "Switching to Elasticsearch (optional)" subsection.

## Verification

- `python -m compileall src/storage/backends/{elasticsearch_backend,es_mapping,manager,__init__}.py` — clean.
- `python -m pytest tests/test_elasticsearch_backend.py -x` — 1 skipped (Docker not available on the runner; ES client not installed) — exits cleanly.
- `python -m pytest tests/test_storage_backend.py -x` — 14 passed.
- `python -m pytest tests/ --ignore=tests/test_elasticsearch_backend.py --ignore=tests/test_mft_progress.py -q` — **484 passed, 6 skipped**. (`tests/test_mft_progress.py` has 4 pre-existing failures on master — `NtfsMftBackend.__init__()` doesn't accept the `ops_registry` kwarg the test passes; unrelated to Phase 2.)
- Confirmed: with `storage.backend: "sqlite"` the manager builds the backend without importing the `elasticsearch` package.

## Deferred

- **Phase 3** — dashboard query layer rewrite. Replace raw SQL in `src/dashboard/api.py` with `app.state.storage.<method>(...)` calls.
- **Phase 4** — SQLite → Elasticsearch backfill / migration tool (uses `iterate_scan` + `insert_scanned_files`).
- **Phase 5** — extended docs + production cluster sizing notes.

Closes part of #114.

https://claude.ai/code/session_01A1UzS1A4DZNk1akoP4uhZ7

---
_Generated by [Claude Code](https://claude.ai/code/session_01A1UzS1A4DZNk1akoP4uhZ7)_