### PR TITLE
sec(extensions): Phase 1 wrong-extension detection (Czkawka pattern) (#144)

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -151,6 +151,15 @@ scanner:
     - ".DS_Store"
   read_owner: true            # dosya sahiplik bilgisi topla (biraz yavaşlatır)
   incremental: true           # sadece değişen dosyaları tara
+  # Issue #144 Phase 1 — yanlis-uzanti tespiti (Czkawka kalibi).
+  # python-magic + libmagic gerektirir; default kapali (her dosya icin
+  # libmagic.from_file() cagrisi tarama suresini uzatir). Acildiginda
+  # tarama tamamlandiktan sonra ayri bir pas calisir (ana MFT/SMB
+  # walk'u bloklamaz). libmagic kurulu degilse modul tek bir WARNING
+  # log atip no-op'a duser; tarama normal sekilde devam eder.
+  # Kurulum:
+  #   pip install -r requirements-accel.txt
+  detect_wrong_extensions: false
   parquet_staging:
     # Tarama sirasinda satirlari Parquet dosyasina biriktirir, sonra DuckDB
     # uzerinden tek INSERT ile SQLite'a ingest eder. 100k+ satirli scan'lerde

--- a/requirements-accel.txt
+++ b/requirements-accel.txt
@@ -21,3 +21,26 @@
 # PyPI; on Windows install via vcpkg or use the stdlib fallback (which
 # is what `compliance.pii.engine: "auto"` selects automatically).
 hyperscan>=0.8.2
+
+# ──────────────────────────────────────────────────────────────────────
+# libmagic-based MIME detection (issue #144 Phase 1)
+#
+# Powers ExtensionChecker — surfaces "wrong extension" findings (e.g.
+# rapor.pdf whose magic bytes are application/zip, the canonical
+# ransomware/payload disguise). When this dep is missing the scanner
+# logs ONE WARNING and the feature degrades to a no-op; the rest of the
+# scan continues normally. Default OFF in config.yaml; flip
+# scanner.detect_wrong_extensions: true to enable.
+#
+# Platform notes:
+#   * Linux: install python-magic + ensure system libmagic1 is present
+#       sudo apt install libmagic1   # Debian / Ubuntu
+#       sudo dnf install file-libs   # RHEL / Fedora
+#   * Windows: prefer python-magic-bin which bundles a libmagic.dll;
+#       installing python-magic alone fails because the DLL is missing.
+#   * macOS: brew install libmagic, then python-magic.
+#
+# We pin both. pip will pick the right one (python-magic-bin only ships
+# Windows wheels; on Linux/macOS pip falls through to python-magic).
+python-magic>=0.4.27; sys_platform != "win32"
+python-magic-bin>=0.4.14; sys_platform == "win32"

--- a/src/analyzer/extension_check.py
+++ b/src/analyzer/extension_check.py
@@ -1,0 +1,407 @@
+"""Yanlis-uzanti tespiti (issue #144 Phase 1 — Czkawka pattern).
+
+Customer dedup tools surface "wrong extension" findings (e.g., a file
+named ``rapor.pdf`` whose magic bytes actually decode as ``application/zip``).
+This is a common ransomware / payload disguise pattern that pure
+byte-hash dedup never catches.
+
+The module ships an ``ExtensionChecker`` that:
+
+* Lazy-imports ``python-magic`` (libmagic). When the lib is missing it
+  gracefully no-ops with a single WARNING — operators can install it
+  via ``pip install -r requirements-accel.txt``.
+* Maps the declared extension to the set of MIME types we expect
+  (e.g. ``pdf`` -> ``{'application/pdf'}``). Unknown extensions are
+  skipped (we cannot say anything useful).
+* Categorises mismatches into ``low | medium | high | critical``.
+  Executable-as-document (a ``.pdf`` whose magic is ``application/x-dosexec``)
+  is the canonical critical pattern.
+
+Phase 2 (perceptual hashes) and Phase 3 (broken file detection) are
+deferred — see issue #144 for the deferred work.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass
+from typing import Iterable, List, Optional
+
+logger = logging.getLogger("file_activity.analyzer.extension_check")
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Result model
+# ──────────────────────────────────────────────────────────────────────
+
+
+@dataclass
+class ExtensionAnomaly:
+    """One mismatch row. Mirrors ``extension_anomalies`` columns."""
+
+    file_path: str
+    declared_ext: Optional[str]      # 'pdf' (already lowercased, no leading dot)
+    detected_mime: Optional[str]     # 'application/zip'
+    detected_ext: Optional[str]      # 'zip' (best-guess from MIME)
+    severity: str                    # 'low'|'medium'|'high'|'critical'
+
+    def as_row(self) -> tuple:
+        return (
+            self.file_path,
+            self.declared_ext,
+            self.detected_mime,
+            self.detected_ext,
+            self.severity,
+        )
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Severity rules
+# ──────────────────────────────────────────────────────────────────────
+
+
+# Top ~30 common types. Each declared extension maps to the set of MIME
+# strings we'll accept. Several Office formats are ZIP archives under the
+# hood, so we list both the canonical Office MIME and ``application/zip``
+# as "expected" to avoid false positives on lenient libmagic builds.
+EXPECTED_MIMES: dict[str, set[str]] = {
+    # Documents
+    "pdf": {"application/pdf"},
+    "doc": {"application/msword", "application/x-ole-storage",
+            "application/CDFV2"},
+    "docx": {
+        "application/vnd.openxmlformats-officedocument."
+        "wordprocessingml.document",
+        "application/zip",
+    },
+    "xls": {"application/vnd.ms-excel", "application/x-ole-storage",
+            "application/CDFV2"},
+    "xlsx": {
+        "application/vnd.openxmlformats-officedocument."
+        "spreadsheetml.sheet",
+        "application/zip",
+    },
+    "ppt": {"application/vnd.ms-powerpoint", "application/x-ole-storage",
+            "application/CDFV2"},
+    "pptx": {
+        "application/vnd.openxmlformats-officedocument."
+        "presentationml.presentation",
+        "application/zip",
+    },
+    "rtf": {"application/rtf", "text/rtf"},
+    "odt": {"application/vnd.oasis.opendocument.text", "application/zip"},
+    "ods": {"application/vnd.oasis.opendocument.spreadsheet",
+            "application/zip"},
+
+    # Plain text / markup
+    "txt": {"text/plain"},
+    "csv": {"text/csv", "text/plain"},
+    "log": {"text/plain"},
+    "md": {"text/plain", "text/markdown"},
+    "json": {"application/json", "text/plain"},
+    "xml": {"application/xml", "text/xml", "text/plain"},
+    "html": {"text/html"},
+    "htm": {"text/html"},
+    "yaml": {"text/plain", "application/yaml"},
+    "yml": {"text/plain", "application/yaml"},
+
+    # Images
+    "jpg": {"image/jpeg"},
+    "jpeg": {"image/jpeg"},
+    "png": {"image/png"},
+    "gif": {"image/gif"},
+    "bmp": {"image/bmp", "image/x-ms-bmp"},
+    "tif": {"image/tiff"},
+    "tiff": {"image/tiff"},
+    "webp": {"image/webp"},
+    "svg": {"image/svg+xml", "text/xml", "text/plain"},
+
+    # Audio / video
+    "mp3": {"audio/mpeg"},
+    "wav": {"audio/x-wav", "audio/wav"},
+    "mp4": {"video/mp4"},
+    "avi": {"video/x-msvideo"},
+    "mov": {"video/quicktime"},
+    "mkv": {"video/x-matroska"},
+
+    # Archives
+    "zip": {"application/zip"},
+    "rar": {"application/x-rar", "application/vnd.rar"},
+    "7z": {"application/x-7z-compressed"},
+    "tar": {"application/x-tar"},
+    "gz": {"application/gzip", "application/x-gzip"},
+
+    # Executable / script (declared extension matches binary -> NOT an
+    # anomaly. We DO list these because a ``.exe`` whose magic is
+    # ``application/pdf`` is a different kind of disguise.)
+    "exe": {"application/x-dosexec", "application/x-msdownload",
+            "application/vnd.microsoft.portable-executable"},
+    "dll": {"application/x-dosexec", "application/x-msdownload",
+            "application/vnd.microsoft.portable-executable"},
+    "msi": {"application/x-msi", "application/x-ole-storage"},
+}
+
+# MIME -> a "best guess" canonical extension shown in the report column.
+_MIME_TO_EXT: dict[str, str] = {
+    "application/pdf": "pdf",
+    "application/zip": "zip",
+    "application/x-rar": "rar",
+    "application/vnd.rar": "rar",
+    "application/x-7z-compressed": "7z",
+    "application/x-tar": "tar",
+    "application/gzip": "gz",
+    "application/x-gzip": "gz",
+    "application/x-dosexec": "exe",
+    "application/x-msdownload": "exe",
+    "application/vnd.microsoft.portable-executable": "exe",
+    "application/x-ole-storage": "doc",
+    "application/CDFV2": "doc",
+    "application/msword": "doc",
+    "application/vnd.ms-excel": "xls",
+    "application/vnd.ms-powerpoint": "ppt",
+    "application/json": "json",
+    "application/xml": "xml",
+    "application/rtf": "rtf",
+    "image/jpeg": "jpg",
+    "image/png": "png",
+    "image/gif": "gif",
+    "image/bmp": "bmp",
+    "image/tiff": "tif",
+    "image/webp": "webp",
+    "image/svg+xml": "svg",
+    "audio/mpeg": "mp3",
+    "audio/wav": "wav",
+    "audio/x-wav": "wav",
+    "video/mp4": "mp4",
+    "video/x-msvideo": "avi",
+    "video/quicktime": "mov",
+    "video/x-matroska": "mkv",
+    "text/plain": "txt",
+    "text/csv": "csv",
+    "text/html": "html",
+    "text/xml": "xml",
+    "text/markdown": "md",
+}
+
+# Extensions that are normally executable / scriptable. A *document*
+# extension (pdf, docx, jpg, …) whose magic resolves to one of the
+# entries in ``_EXECUTABLE_MIMES`` is the canonical "ransomware payload
+# disguised as a document" pattern -> CRITICAL severity.
+_EXECUTABLE_MIMES: set[str] = {
+    "application/x-dosexec",
+    "application/x-msdownload",
+    "application/vnd.microsoft.portable-executable",
+    "application/x-msi",
+    "application/x-sharedlib",
+    "application/x-mach-binary",
+    "application/x-elf",
+    "application/x-executable",
+}
+
+# Extensions where we're confident the file SHOULD be a benign document
+# format. Used together with ``_EXECUTABLE_MIMES`` for the critical rule.
+_DOCUMENT_LIKE_EXTS: set[str] = {
+    "pdf", "doc", "docx", "xls", "xlsx", "ppt", "pptx", "rtf", "odt",
+    "ods", "txt", "csv", "log", "md", "json", "xml", "html", "htm",
+    "yaml", "yml",
+    "jpg", "jpeg", "png", "gif", "bmp", "tif", "tiff", "webp", "svg",
+    "mp3", "wav", "mp4", "avi", "mov", "mkv",
+    "zip", "rar", "7z", "tar", "gz",
+}
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Checker
+# ──────────────────────────────────────────────────────────────────────
+
+
+class ExtensionChecker:
+    """Detects extension/MIME mismatches via libmagic.
+
+    Lazy import — if ``python-magic`` (or its ``libmagic`` C dependency)
+    is unavailable the checker logs ONE WARNING on first use and then
+    returns ``None`` for every probe. This keeps the scanner working on
+    minimal Linux/Windows installs where libmagic isn't shipped.
+    """
+
+    # Class-level guard so we only emit the import warning once even
+    # when the scanner instantiates many checkers.
+    _import_warned = False
+
+    def __init__(self):
+        self._magic = None
+        self._magic_unavailable = False
+        self._init_magic()
+
+    # ── lazy import ──────────────────────────────────────────────────
+
+    def _init_magic(self) -> None:
+        """Try to construct a ``magic.Magic(mime=True)`` instance.
+
+        Failure modes:
+          * ``ImportError``  — python-magic not installed.
+          * ``OSError`` / ``magic.MagicException`` — libmagic.so missing.
+
+        On either failure we set ``_magic_unavailable=True`` and never
+        retry (avoid log spam).
+        """
+        try:
+            import magic  # type: ignore[import-not-found]
+        except ImportError:
+            self._magic_unavailable = True
+            if not ExtensionChecker._import_warned:
+                logger.warning(
+                    "python-magic not installed; extension-check disabled. "
+                    "Install via 'pip install -r requirements-accel.txt'."
+                )
+                ExtensionChecker._import_warned = True
+            return
+
+        try:
+            # ``mime=True`` returns 'application/zip' instead of the
+            # human-readable description.
+            self._magic = magic.Magic(mime=True)
+        except Exception as e:  # libmagic missing or broken
+            self._magic_unavailable = True
+            if not ExtensionChecker._import_warned:
+                logger.warning(
+                    "libmagic unavailable (%s); extension-check disabled. "
+                    "On Windows install 'python-magic-bin'; on Linux ensure "
+                    "the 'libmagic1' system package is present.", e,
+                )
+                ExtensionChecker._import_warned = True
+
+    # ── public API ───────────────────────────────────────────────────
+
+    @property
+    def available(self) -> bool:
+        return self._magic is not None and not self._magic_unavailable
+
+    def check_file(self, path: str) -> Optional[ExtensionAnomaly]:
+        """Probe one file. Returns the anomaly or None.
+
+        Returns None when:
+          * libmagic is unavailable
+          * the file has no extension or an unknown one (no ground truth)
+          * the detected MIME matches one of the expected MIMEs
+          * the file can't be opened (PermissionError / OSError) — we log
+            at debug and move on; this isn't an anomaly.
+        """
+        if not self.available:
+            return None
+
+        try:
+            file_name = os.path.basename(path)
+            ext = os.path.splitext(file_name)[1].lower().lstrip(".")
+        except Exception:
+            return None
+
+        if not ext:
+            return None
+        expected = EXPECTED_MIMES.get(ext)
+        if expected is None:
+            # Unknown extension — we cannot say whether the magic matches.
+            return None
+
+        try:
+            detected_mime = self._magic.from_file(path)
+        except (PermissionError, FileNotFoundError) as e:
+            logger.debug("extension-check skip %s: %s", path, e)
+            return None
+        except Exception as e:  # libmagic occasionally raises on weird files
+            logger.debug("extension-check magic.from_file failed %s: %s",
+                         path, e)
+            return None
+
+        if not detected_mime:
+            return None
+
+        # Normalise: libmagic sometimes returns 'application/zip; charset=binary'
+        detected_mime = detected_mime.split(";", 1)[0].strip().lower()
+
+        if detected_mime in expected:
+            return None  # all good
+
+        severity = self._severity_for(ext, detected_mime)
+        detected_ext = _MIME_TO_EXT.get(detected_mime)
+
+        return ExtensionAnomaly(
+            file_path=path,
+            declared_ext=ext,
+            detected_mime=detected_mime,
+            detected_ext=detected_ext,
+            severity=severity,
+        )
+
+    def check_files(self, paths: Iterable[str]) -> List[ExtensionAnomaly]:
+        """Convenience wrapper — call ``check_file`` over an iterable.
+
+        Used by the scanner's optional post-walk pass. Returns only the
+        anomaly hits (None entries dropped).
+        """
+        out: List[ExtensionAnomaly] = []
+        if not self.available:
+            return out
+        for p in paths:
+            try:
+                hit = self.check_file(p)
+            except Exception as e:  # never let one bad file break the pass
+                logger.debug("extension-check unexpected error %s: %s", p, e)
+                continue
+            if hit is not None:
+                out.append(hit)
+        return out
+
+    # ── severity rules ───────────────────────────────────────────────
+
+    @staticmethod
+    def _severity_for(declared_ext: str, detected_mime: str) -> str:
+        """Map (declared ext, detected MIME) -> severity bucket.
+
+        Critical: a document/image/text extension whose actual content
+        is an executable. This is the ransomware-payload pattern the
+        customer asked for.
+
+        High: declared as a top-tier business document (pdf/docx/xlsx)
+        but actually any *non*-archive container we don't recognise as
+        plausibly that format.
+
+        Medium: any other concrete mismatch with a known content type
+        (e.g. a ``.png`` whose magic is ``image/jpeg``).
+
+        Low: text-vs-text confusions (``.json`` detected as ``text/plain``
+        — usually still readable, just not strictly typed).
+        """
+        ext = (declared_ext or "").lower()
+        mime = (detected_mime or "").lower()
+
+        # Critical: payload disguised as a document/image/text.
+        if mime in _EXECUTABLE_MIMES and ext in _DOCUMENT_LIKE_EXTS:
+            return "critical"
+
+        # High: top-tier business document with a clearly different format.
+        # We exclude the ZIP-like Office case here — that's already in the
+        # expected set so this branch only fires when the MIME is something
+        # else entirely.
+        TOP_DOCS = {"pdf", "docx", "xlsx", "pptx", "doc", "xls", "ppt"}
+        if ext in TOP_DOCS:
+            # If libmagic reports an archive that ISN'T in the expected
+            # set for this ext, treat as high (e.g. a ``.pdf`` that's a
+            # ``.rar`` archive — common bundled payload).
+            if mime in {"application/x-rar", "application/vnd.rar",
+                        "application/x-7z-compressed",
+                        "application/x-tar", "application/gzip",
+                        "application/x-gzip"}:
+                return "high"
+            # Generic doc-vs-other-content.
+            return "high"
+
+        # Low: very loose text-family confusion (we still want to surface
+        # but it isn't actionable security content).
+        TEXTY = {"text/plain", "text/csv", "text/html", "text/markdown"}
+        if mime in TEXTY and ext in {"json", "xml", "yaml", "yml", "html",
+                                       "htm", "md", "csv", "txt", "log"}:
+            return "low"
+
+        return "medium"

--- a/src/dashboard/api.py
+++ b/src/dashboard/api.py
@@ -4366,11 +4366,12 @@ def create_app(db, config, analytics=None, ad_lookup=None, email_notifier=None,
 
     @app.get("/api/security/feature-flags")
     async def security_feature_flags():
-        """Read-only view of the three security feature flags so the
-        dashboard can render a "kapali" banner when a page is disabled
-        in config.yaml. Cheap; no DB access.
+        """Read-only view of the security feature flags so the dashboard
+        can render a "kapali" banner when a page is disabled in
+        config.yaml. Cheap; no DB access.
         """
         sec = (config or {}).get("security", {}) or {}
+        scanner_cfg = (config or {}).get("scanner", {}) or {}
         ransom = sec.get("ransomware", {}) or {}
         orphan = sec.get("orphan_sid", {}) or {}
         return {
@@ -4386,6 +4387,12 @@ def create_app(db, config, analytics=None, ad_lookup=None, email_notifier=None,
             # ACL analyzer has no enabled flag in config.yaml today; it
             # is always available (read-side is DB-only).
             "acl": {"enabled": True},
+            # Issue #144 Phase 1 — wrong-extension detection.
+            "extension_anomalies": {
+                "enabled": bool(
+                    scanner_cfg.get("detect_wrong_extensions", False)
+                ),
+            },
         }
 
     @app.get("/api/security/orphan-sids/{source_id}/export.xlsx")
@@ -4530,6 +4537,116 @@ def create_app(db, config, analytics=None, ad_lookup=None, email_notifier=None,
                      "Inherited"],
             filename=filename,
             sheet_title="Trustee Paths",
+        )
+
+    # ─────────────────────────────────────────────────────────────────
+    # Extension-anomaly findings (#144 Phase 1 — Czkawka pattern)
+    # ─────────────────────────────────────────────────────────────────
+
+    @app.get("/api/security/extension-anomalies")
+    async def list_extension_anomalies(
+        scan_id: Optional[int] = None,
+        source_id: Optional[int] = None,
+        severity: Optional[str] = None,
+        limit: int = Query(500, ge=1, le=10000),
+        offset: int = Query(0, ge=0),
+    ):
+        """Paginated list of extension/MIME mismatches.
+
+        Filters:
+          * ``scan_id`` — explicit scan to query
+          * ``source_id`` — convenience: resolves to that source's
+            latest completed scan and queries that scan_id.
+          * ``severity`` — one of ``low|medium|high|critical``
+        """
+        if severity is not None and severity not in {
+            "low", "medium", "high", "critical"
+        }:
+            raise HTTPException(400, "severity must be low|medium|high|critical")
+
+        # Resolve source_id -> latest scan if given
+        resolved_scan_id = scan_id
+        if resolved_scan_id is None and source_id is not None:
+            resolved_scan_id = db.get_latest_scan_id(
+                source_id, include_running=False,
+            )
+
+        rows = db.list_extension_anomalies(
+            scan_id=resolved_scan_id,
+            severity=severity,
+            limit=limit,
+            offset=offset,
+        )
+        total = db.count_extension_anomalies(
+            scan_id=resolved_scan_id, severity=severity,
+        )
+        # By-severity breakdown for the dashboard summary cards.
+        by_sev = {"critical": 0, "high": 0, "medium": 0, "low": 0}
+        try:
+            with db.get_cursor() as cur:
+                where = "WHERE scan_id = ?" if resolved_scan_id is not None else ""
+                params = (resolved_scan_id,) if resolved_scan_id is not None else ()
+                cur.execute(
+                    f"SELECT severity, COUNT(*) AS c "
+                    f"FROM extension_anomalies {where} "
+                    f"GROUP BY severity",
+                    params,
+                )
+                for r in cur.fetchall():
+                    sev = (r["severity"] or "").lower()
+                    if sev in by_sev:
+                        by_sev[sev] = int(r["c"])
+        except Exception:
+            pass
+
+        return {
+            "scan_id": resolved_scan_id,
+            "source_id": source_id,
+            "severity_filter": severity,
+            "total": int(total),
+            "by_severity": by_sev,
+            "items": rows,
+            "limit": int(limit),
+            "offset": int(offset),
+        }
+
+    @app.get(
+        "/api/security/extension-anomalies/{source_id}/export.xlsx"
+    )
+    async def extension_anomalies_export_xlsx(
+        source_id: int,
+        severity: Optional[str] = None,
+    ):
+        """XLSX export of extension-anomaly rows for ``source_id``'s
+        latest completed scan. Mirrors the orphan-SID / ACL exports.
+        """
+        scan_id = db.get_latest_scan_id(source_id, include_running=False)
+        if not scan_id:
+            raise HTTPException(404, f"No scan_runs found for source {source_id}")
+        rows_db = db.list_extension_anomalies(
+            scan_id=scan_id, severity=severity, limit=1_000_000,
+        )
+        rows = []
+        for r in rows_db:
+            rows.append([
+                r.get("file_path", ""),
+                r.get("declared_ext", "") or "",
+                r.get("detected_mime", "") or "",
+                r.get("detected_ext", "") or "",
+                r.get("severity", "") or "",
+                r.get("detected_at", "") or "",
+            ])
+        filename = (
+            f"extension_anomalies_source{source_id}_scan{scan_id}.xlsx"
+        )
+        return _xlsx_response(
+            rows,
+            headers=[
+                "File Path", "Declared Ext", "Detected MIME",
+                "Detected Ext", "Severity", "Detected At",
+            ],
+            filename=filename,
+            sheet_title="Extension Anomalies",
         )
 
     # ─────────────────────────────────────────────────────────────────

--- a/src/dashboard/static/index.html
+++ b/src/dashboard/static/index.html
@@ -601,6 +601,7 @@ body.sidebar-open { overflow: hidden; }
         <div class="nav-item" onclick="showPage('orphan-sids')" title="Yetim SID'ler"><span class="icon">👤</span> <span>Yetim SID'ler</span></div>
         <div class="nav-item" onclick="showPage('ransomware')" title="Ransomware Uyarilari"><span class="icon">🛡️</span> <span>Ransomware Uyarilari</span></div>
         <div class="nav-item" onclick="showPage('acl')" title="ACL Analizi"><span class="icon">🔐</span> <span>ACL Analizi</span></div>
+        <div class="nav-item" onclick="showPage('extension-anomalies')" title="Yanlis Uzantili Dosyalar"><span class="icon">⚠️</span> <span>Yanlis Uzantili Dosyalar</span></div>
     </div>
     <div class="nav-section" data-group="Islemler">
         <div class="nav-label">Islemler <span class="chev">&#9660;</span></div>
@@ -1422,6 +1423,39 @@ body.sidebar-open { overflow: hidden; }
     <div class="panel" style="margin-top:20px">
         <h3 class="panel-title">Uyari Akisi</h3>
         <div id="ransomware-container"></div>
+    </div>
+</div>
+
+<!-- ============ GUVENLIK > YANLIS UZANTILI DOSYALAR (issue #144 Phase 1) ============ -->
+<div class="page" id="page-extension-anomalies">
+    <div class="page-header">
+        <div>
+            <h2>Yanlis Uzantili Dosyalar</h2>
+            <div class="desc">Guvenlik &rsaquo; Uzanti ile MIME uyumsuzlugu (Czkawka kalibi) — fidye/payload tespiti</div>
+        </div>
+        <div class="actions">
+            <select id="ext-anomaly-source" onchange="loadExtensionAnomalies()" style="width:200px">
+                <option value="">Kaynak secin...</option>
+            </select>
+            <select id="ext-anomaly-severity" onchange="loadExtensionAnomalies()" style="width:160px">
+                <option value="">Tum ciddiyetler</option>
+                <option value="critical">Kritik</option>
+                <option value="high">Yuksek</option>
+                <option value="medium">Orta</option>
+                <option value="low">Dusuk</option>
+            </select>
+            <button class="btn btn-outline" id="ext-anomaly-xlsx-btn" onclick="exportExtensionAnomaliesXlsx(event)" style="display:none">Excel Export</button>
+        </div>
+    </div>
+    <div id="ext-anomaly-banner" style="display:none;margin-bottom:16px;padding:12px 16px;background:rgba(245,158,11,0.1);border:1px solid var(--warning);border-radius:var(--radius);color:var(--warning);font-size:13px"></div>
+    <div class="cards" id="ext-anomaly-summary"></div>
+    <div class="panel" style="margin-top:20px">
+        <h3 class="panel-title">Anomali Listesi</h3>
+        <div id="ext-anomaly-toolbar" style="margin-bottom:12px;display:flex;gap:8px;align-items:center;font-size:12px;color:var(--text-secondary)">
+            <span id="ext-anomaly-selcount">0 secili</span>
+            <button class="btn btn-sm btn-outline" onclick="extAnomalyOpenSelected()" title="Secili dosyalarin klasorunu ac (max 5)">Hedefe Git</button>
+        </div>
+        <div id="ext-anomaly-container"></div>
     </div>
 </div>
 
@@ -2495,7 +2529,7 @@ function showPage(name) {
     // Find and activate nav item
     document.querySelectorAll('.nav-item').forEach(n => { if (n.getAttribute('onclick')?.includes(name)) n.classList.add('active'); });
     // Auto-load data
-    const loaders = { overview: loadOverview, sources: loadSources, frequency: loadFrequency, types: loadTypes, sizes: loadSizes, users: loadUsers, anomalies: loadAnomalies, archive: loadArchive, 'archive-history': loadArchiveHistory, duplicates: loadDuplicates, growth: loadGrowth, naming: loadNaming, policies: loadPolicies, schedules: loadSchedules, treemap: loadTreemap, insights: loadInsights, sqlquery: sqlqInit, 'legal-holds': loadLegalHolds, 'orphan-sids': loadOrphanSids, ransomware: loadRansomwareAlerts, acl: loadAclAnalyzer, pii: loadPii, retention: loadRetention, syslog: loadSyslog, mcp: loadMcp, backups: loadBackups, operations: loadOperations, approvals: loadApprovalsAll, chargeback: loadChargeback, quarantine: loadQuarantine, forecast: loadForecast };
+    const loaders = { overview: loadOverview, sources: loadSources, frequency: loadFrequency, types: loadTypes, sizes: loadSizes, users: loadUsers, anomalies: loadAnomalies, archive: loadArchive, 'archive-history': loadArchiveHistory, duplicates: loadDuplicates, growth: loadGrowth, naming: loadNaming, policies: loadPolicies, schedules: loadSchedules, treemap: loadTreemap, insights: loadInsights, sqlquery: sqlqInit, 'legal-holds': loadLegalHolds, 'orphan-sids': loadOrphanSids, ransomware: loadRansomwareAlerts, acl: loadAclAnalyzer, 'extension-anomalies': loadExtensionAnomalies, pii: loadPii, retention: loadRetention, syslog: loadSyslog, mcp: loadMcp, backups: loadBackups, operations: loadOperations, approvals: loadApprovalsAll, chargeback: loadChargeback, quarantine: loadQuarantine, forecast: loadForecast };
     // Issue #79: route through loadWithProgress so slow pages get a top
     // progress bar, ETA from p50 history, and a retry path on failure.
     if (loaders[name]) loadWithProgress(name, loaders[name]).catch(() => { /* widget surfaces error */ });
@@ -2523,10 +2557,10 @@ async function loadSources() {
 }
 
 function populateAllSourceSelects() {
-    ['overview-source','freq-source','types-source','sizes-source','treemap-source','insights-source','ah-source','dup-source','growth-source','naming-source','orphan-sids-source','acl-source','pii-source','cb-source','fc-source'].forEach(id => populateSourceSelect(id));
+    ['overview-source','freq-source','types-source','sizes-source','treemap-source','insights-source','ah-source','dup-source','growth-source','naming-source','orphan-sids-source','acl-source','ext-anomaly-source','pii-source','cb-source','fc-source'].forEach(id => populateSourceSelect(id));
     // Auto-select first source if only one
     if (sources.length === 1) {
-        ['overview-source','freq-source','types-source','sizes-source','treemap-source','insights-source','ah-source','dup-source','growth-source','naming-source','orphan-sids-source','acl-source','pii-source','cb-source','fc-source'].forEach(id => {
+        ['overview-source','freq-source','types-source','sizes-source','treemap-source','insights-source','ah-source','dup-source','growth-source','naming-source','orphan-sids-source','acl-source','ext-anomaly-source','pii-source','cb-source','fc-source'].forEach(id => {
             const sel = document.getElementById(id);
             if (sel && !sel.value) sel.value = sources[0].id;
         });
@@ -7361,6 +7395,145 @@ async function exportAclXlsx(ev) {
         } else {
             await fetchAndDownload(`${API}/security/acl/sprawl/export.xlsx`, signal, 'acl_sprawl.xlsx');
         }
+    });
+}
+
+// ─── EXTENSION ANOMALIES (issue #144 Phase 1) ─────────
+// Wrong-extension detection (Czkawka pattern). Lists files whose
+// declared extension doesn't match the libmagic-detected MIME type.
+// Highlights "executable disguised as document" as critical.
+
+let _extAnomalySelection = new Set();   // selected file_paths
+let _extAnomalyRows = [];               // last fetched rows
+
+async function loadExtensionAnomalies() {
+    const flags = await getSecurityFlags();
+    const banner = document.getElementById('ext-anomaly-banner');
+    if (!flags.extension_anomalies || !flags.extension_anomalies.enabled) {
+        banner.style.display = 'block';
+        banner.textContent = 'Bu ozellik kapali — config.yaml > scanner.detect_wrong_extensions: true ile aciliyor (libmagic gerektirir).';
+    } else {
+        banner.style.display = 'none';
+    }
+
+    const sourceId = document.getElementById('ext-anomaly-source')?.value;
+    const severity = document.getElementById('ext-anomaly-severity')?.value || '';
+    const summary = document.getElementById('ext-anomaly-summary');
+    const xlsxBtn = document.getElementById('ext-anomaly-xlsx-btn');
+    if (!sourceId) {
+        summary.innerHTML = '';
+        renderEntityList('ext-anomaly-container', [], [], { emptyHtml: 'Lutfen bir kaynak secin' });
+        if (xlsxBtn) xlsxBtn.style.display = 'none';
+        return;
+    }
+    if (xlsxBtn) xlsxBtn.style.display = '';
+
+    try {
+        const qs = new URLSearchParams({ source_id: sourceId, limit: '500' });
+        if (severity) qs.set('severity', severity);
+        const data = await api(`/security/extension-anomalies?${qs.toString()}`);
+        const bs = data.by_severity || {};
+        summary.innerHTML = `
+            <div class="card danger"><div class="card-label">Kritik</div><div class="card-value">${formatNum(bs.critical || 0)}</div></div>
+            <div class="card warning"><div class="card-label">Yuksek</div><div class="card-value">${formatNum(bs.high || 0)}</div></div>
+            <div class="card accent"><div class="card-label">Orta</div><div class="card-value">${formatNum(bs.medium || 0)}</div></div>
+            <div class="card success"><div class="card-label">Dusuk</div><div class="card-value">${formatNum(bs.low || 0)}</div></div>
+        `;
+        const items = data.items || [];
+        _extAnomalyRows = items;
+        _extAnomalySelection = new Set();
+        _extAnomalyUpdateSelCount();
+
+        const sevColors = { critical: 'var(--danger)', high: 'var(--danger)', medium: 'var(--warning)', low: 'var(--info)' };
+        renderEntityList('ext-anomaly-container', items, [
+            {
+                field: 'id',
+                label: '<input type="checkbox" onclick="extAnomalyToggleAll(this)">',
+                render: (item) => `<input type="checkbox" class="ext-anomaly-row-chk" data-path="${escapeHtml(item.file_path)}" onchange="extAnomalyToggleRow(this)">`,
+            },
+            {
+                field: 'file_path', label: 'Dosya Yolu',
+                render: (i, v) => `<span style="font-family:Consolas,monospace;font-size:11px">${escapeHtml(v || '')}</span>`,
+            },
+            { field: 'declared_ext', label: 'Beyan Edilen' },
+            {
+                field: 'detected_mime', label: 'Tespit Edilen MIME',
+                render: (i, v) => `<span style="font-family:Consolas,monospace;font-size:11px;color:var(--text-muted)">${escapeHtml(v || '')}</span>`,
+            },
+            {
+                field: 'severity', label: 'Ciddiyet',
+                render: (i, v) => {
+                    const c = sevColors[(v || '').toLowerCase()] || 'var(--text-muted)';
+                    return `<span style="display:inline-block;padding:2px 8px;border-radius:10px;font-size:10px;font-weight:700;background:${c}22;color:${c}">${escapeHtml((v || '').toUpperCase())}</span>`;
+                },
+            },
+            {
+                field: 'detected_at', label: 'Tespit',
+                render: (i, v) => `<span style="font-family:Consolas,monospace;font-size:11px">${escapeHtml(v || '')}</span>`,
+            },
+        ], { emptyHtml: '<span style="color:var(--success)">Anomali bulunamadi — tum uzantilar MIME ile uyumlu</span>' });
+    } catch (e) {
+        notify('Uzanti anomalileri alinamadi: ' + (e.message || e), 'error');
+    }
+}
+
+function extAnomalyToggleRow(chk) {
+    const p = chk.getAttribute('data-path');
+    if (!p) return;
+    if (chk.checked) _extAnomalySelection.add(p);
+    else _extAnomalySelection.delete(p);
+    _extAnomalyUpdateSelCount();
+}
+
+function extAnomalyToggleAll(headerChk) {
+    const boxes = document.querySelectorAll('.ext-anomaly-row-chk');
+    _extAnomalySelection = new Set();
+    boxes.forEach(c => {
+        c.checked = headerChk.checked;
+        if (headerChk.checked) {
+            const p = c.getAttribute('data-path');
+            if (p) _extAnomalySelection.add(p);
+        }
+    });
+    _extAnomalyUpdateSelCount();
+}
+
+function _extAnomalyUpdateSelCount() {
+    const el = document.getElementById('ext-anomaly-selcount');
+    if (el) el.textContent = _extAnomalySelection.size + ' secili';
+}
+
+function extAnomalyOpenSelected() {
+    const sel = Array.from(_extAnomalySelection);
+    if (!sel.length) { notify('Once en az bir dosya secin', 'warning'); return; }
+    if (sel.length > 5) {
+        notify('Hedefe Git en fazla 5 dosya icin acilabilir', 'warning');
+        return;
+    }
+    // Open the parent folder in the browser via /api/open-folder if it
+    // exists; otherwise just copy to clipboard with a notify hint.
+    sel.forEach(p => {
+        // Best-effort: try a generic explorer open endpoint
+        api('/system/open-folder', { method: 'POST', body: JSON.stringify({ path: p }), silent: true })
+            .catch(() => {
+                // Fallback — just log; the path is in the table for manual copy
+                console.log('[ext-anomaly] hedef:', p);
+            });
+    });
+    notify(`${sel.length} dosyanin klasoru acilmaya calisildi`, 'info');
+}
+
+async function exportExtensionAnomaliesXlsx(ev) {
+    const sourceId = document.getElementById('ext-anomaly-source')?.value;
+    if (!sourceId) { notify('Once kaynak secin', 'warning'); return; }
+    const severity = document.getElementById('ext-anomaly-severity')?.value || '';
+    await withButtonLoading(ev.target, async (signal) => {
+        const qs = severity ? `?severity=${encodeURIComponent(severity)}` : '';
+        await fetchAndDownload(
+            `${API}/security/extension-anomalies/${sourceId}/export.xlsx${qs}`,
+            signal,
+            `extension_anomalies_${sourceId}.xlsx`,
+        );
     });
 }
 

--- a/src/scanner/file_scanner.py
+++ b/src/scanner/file_scanner.py
@@ -972,6 +972,19 @@ class FileScanner:
             except Exception as e:
                 logger.warning("AI insights hesaplanamadi (scan_id=%d): %s", scan_id, e)
 
+            # Issue #144 Phase 1 — opt-in wrong-extension detection.
+            # Default OFF (perf cost: libmagic.from_file() per scanned
+            # file). When enabled, run as a separate post-scan phase so
+            # the main MFT/SMB walk never blocks on libmagic.
+            if self.config.get("detect_wrong_extensions", False):
+                try:
+                    self._run_extension_check(scan_id)
+                except Exception as e:
+                    logger.warning(
+                        "Extension-check pasi basarisiz (scan_id=%d): %s",
+                        scan_id, e,
+                    )
+
         # Son ilerleme durumunu guncelle
         # Issue #135 — phase artik ``completed`` (veya cancelled/failed). Bu
         # alan /api/scan/progress yanitinda kullanilir; in-memory progress
@@ -1029,6 +1042,98 @@ class FileScanner:
             progress["status"] = "completed"
 
         return result
+
+    def _run_extension_check(self, scan_id: int) -> dict:
+        """Issue #144 Phase 1 — wrong-extension detection (Czkawka pattern).
+
+        Iterates the freshly-inserted scanned_files for ``scan_id``,
+        runs ``ExtensionChecker.check_file()`` on each path and bulk-
+        inserts the mismatches into ``extension_anomalies``. Skips
+        cleanly when libmagic isn't installed.
+
+        Returns a small summary dict ({checked, anomalies, by_severity}).
+        """
+        from src.analyzer.extension_check import ExtensionChecker
+
+        checker = ExtensionChecker()
+        if not checker.available:
+            logger.info(
+                "Extension-check atlandi (libmagic yok). pip install -r "
+                "requirements-accel.txt"
+            )
+            return {"checked": 0, "anomalies": 0, "skipped_no_libmagic": True}
+
+        progress = _scan_progress.get(scan_id) or {}
+        progress["phase"] = "extension_check"
+
+        t0 = time.time()
+        # Stream paths so we don't materialise the full file set in
+        # memory on big shares.
+        paths_iter = self.db.iter_scanned_paths(scan_id) \
+            if hasattr(self.db, "iter_scanned_paths") \
+            else self._iter_scan_paths(scan_id)
+
+        anomalies = []
+        checked = 0
+        for path in paths_iter:
+            checked += 1
+            hit = checker.check_file(path)
+            if hit is not None:
+                anomalies.append(hit)
+            # Flush in chunks of 500 so a multi-million file scan doesn't
+            # hold all anomalies in memory.
+            if len(anomalies) >= 500:
+                self.db.insert_extension_anomalies(scan_id, anomalies)
+                anomalies = []
+
+        if anomalies:
+            self.db.insert_extension_anomalies(scan_id, anomalies)
+
+        elapsed = time.time() - t0
+        # Aggregate by severity for the log line / summary.
+        by_sev: dict[str, int] = {}
+        try:
+            counts = self.db.list_extension_anomalies(
+                scan_id=scan_id, limit=10_000_000,
+            )
+            for r in counts:
+                sev = r["severity"] or "?"
+                by_sev[sev] = by_sev.get(sev, 0) + 1
+        except Exception:
+            pass
+
+        total = sum(by_sev.values())
+        logger.info(
+            "Extension-check (scan_id=%d): %d dosya kontrol edildi, "
+            "%d anomali (kritik=%d, yuksek=%d, orta=%d, dusuk=%d) %.1f sn",
+            scan_id, checked, total,
+            by_sev.get("critical", 0),
+            by_sev.get("high", 0),
+            by_sev.get("medium", 0),
+            by_sev.get("low", 0),
+            elapsed,
+        )
+        return {
+            "scan_id": scan_id,
+            "checked": checked,
+            "anomalies": total,
+            "by_severity": by_sev,
+            "elapsed_seconds": round(elapsed, 2),
+        }
+
+    def _iter_scan_paths(self, scan_id: int):
+        """Fallback iterator — stream file_path values for ``scan_id``.
+
+        Used by ``_run_extension_check`` if Database doesn't expose a
+        dedicated streaming helper.
+        """
+        with self.db.get_cursor() as cur:
+            cur.execute(
+                "SELECT file_path FROM scanned_files WHERE scan_id = ?",
+                (scan_id,),
+            )
+            for row in cur.fetchall():
+                yield row["file_path"]
 
     def _generate_auto_report(self, source_id: int, source_name: str) -> dict:
         """Tarama sonrasi otomatik rapor uret ve kaydet."""

--- a/src/storage/database.py
+++ b/src/storage/database.py
@@ -911,6 +911,33 @@ class Database:
         cur.execute("CREATE INDEX IF NOT EXISTS idx_pii_path ON pii_findings(file_path)")
         cur.execute("CREATE INDEX IF NOT EXISTS idx_pii_scan ON pii_findings(scan_id)")
 
+        # Extension/MIME mismatch findings (issue #144 Phase 1). Populated
+        # by ExtensionChecker after a scan when scanner.detect_wrong_extensions
+        # is enabled. Mirrors the Czkawka "wrong extension" finding pattern;
+        # the canonical critical case is a document extension (pdf, docx,
+        # jpg, ...) whose libmagic-detected MIME is an executable container.
+        cur.execute("""
+            CREATE TABLE IF NOT EXISTS extension_anomalies (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                scan_id INTEGER REFERENCES scan_runs(id) ON DELETE CASCADE,
+                file_id INTEGER,
+                file_path TEXT NOT NULL,
+                declared_ext TEXT,
+                detected_mime TEXT,
+                detected_ext TEXT,
+                severity TEXT,
+                detected_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+            )
+        """)
+        cur.execute(
+            "CREATE INDEX IF NOT EXISTS idx_ext_anomaly_scan "
+            "ON extension_anomalies(scan_id)"
+        )
+        cur.execute(
+            "CREATE INDEX IF NOT EXISTS idx_ext_anomaly_severity "
+            "ON extension_anomalies(severity)"
+        )
+
         # GDPR retention policies (issue #58). Operator-defined rules of
         # the form "files matching <fnmatch> older than <N> days ->
         # archive|delete". Applied in dry-run by default; non-dry-run
@@ -3365,6 +3392,95 @@ class Database:
                 logger.warning("Summary backfill hatasi scan %s: %s", sid, e)
         logger.info("Backfill tamamlandi: %d scan", len(pending))
         return len(pending)
+
+    # ──────────────────────────────────────────────
+    # Extension/MIME mismatch findings (issue #144 Phase 1)
+    # ──────────────────────────────────────────────
+
+    def insert_extension_anomalies(
+        self,
+        scan_id: int,
+        anomalies,
+    ) -> int:
+        """Bulk-insert ``ExtensionAnomaly``-shaped rows for ``scan_id``.
+
+        ``anomalies`` is an iterable of objects exposing ``as_row()`` (the
+        ``ExtensionAnomaly`` dataclass) OR plain ``(file_path, declared_ext,
+        detected_mime, detected_ext, severity)`` tuples. Returns the count
+        of rows inserted.
+        """
+        rows = []
+        for a in anomalies or []:
+            if hasattr(a, "as_row"):
+                t = a.as_row()
+            else:
+                t = tuple(a)
+            # (file_path, declared_ext, detected_mime, detected_ext, severity)
+            rows.append((scan_id, *t))
+        if not rows:
+            return 0
+        with self.get_cursor() as cur:
+            cur.executemany(
+                """INSERT INTO extension_anomalies
+                   (scan_id, file_path, declared_ext, detected_mime,
+                    detected_ext, severity)
+                   VALUES (?, ?, ?, ?, ?, ?)""",
+                rows,
+            )
+        return len(rows)
+
+    def list_extension_anomalies(
+        self,
+        scan_id: Optional[int] = None,
+        severity: Optional[str] = None,
+        limit: int = 500,
+        offset: int = 0,
+    ) -> list:
+        """Return paginated extension-anomaly rows. Used by the dashboard
+        ``/api/security/extension-anomalies`` endpoint.
+        """
+        clauses = []
+        params: list = []
+        if scan_id is not None:
+            clauses.append("scan_id = ?")
+            params.append(int(scan_id))
+        if severity:
+            clauses.append("severity = ?")
+            params.append(severity)
+        where = ("WHERE " + " AND ".join(clauses)) if clauses else ""
+        sql = (
+            "SELECT id, scan_id, file_id, file_path, declared_ext, "
+            "detected_mime, detected_ext, severity, detected_at "
+            f"FROM extension_anomalies {where} "
+            "ORDER BY CASE severity "
+            "  WHEN 'critical' THEN 0 WHEN 'high' THEN 1 "
+            "  WHEN 'medium' THEN 2 WHEN 'low' THEN 3 ELSE 4 END, "
+            "detected_at DESC LIMIT ? OFFSET ?"
+        )
+        params.extend([int(limit), int(offset)])
+        with self.get_cursor() as cur:
+            cur.execute(sql, tuple(params))
+            return cur.fetchall()
+
+    def count_extension_anomalies(
+        self,
+        scan_id: Optional[int] = None,
+        severity: Optional[str] = None,
+    ) -> int:
+        clauses = []
+        params: list = []
+        if scan_id is not None:
+            clauses.append("scan_id = ?")
+            params.append(int(scan_id))
+        if severity:
+            clauses.append("severity = ?")
+            params.append(severity)
+        where = ("WHERE " + " AND ".join(clauses)) if clauses else ""
+        sql = f"SELECT COUNT(*) AS c FROM extension_anomalies {where}"
+        with self.get_cursor() as cur:
+            cur.execute(sql, tuple(params))
+            row = cur.fetchone()
+            return int(row["c"] if row else 0)
 
     def cleanup_old_scans(self, keep_last_n: int = 5) -> dict:
         """Eski tarama verilerini temizle. Her kaynak icin son N taramayi koru.

--- a/tests/test_extension_check.py
+++ b/tests/test_extension_check.py
@@ -1,0 +1,358 @@
+"""Tests for issue #144 Phase 1 — wrong-extension detection.
+
+Linux-runnable. Uses an in-process libmagic stub so tests don't depend
+on the system ``libmagic`` package being installed; one test verifies
+the graceful no-op path when ``python-magic`` is unavailable.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if REPO_ROOT not in sys.path:
+    sys.path.insert(0, REPO_ROOT)
+
+from src.analyzer.extension_check import (  # noqa: E402
+    ExtensionAnomaly, ExtensionChecker,
+)
+from src.dashboard.api import create_app  # noqa: E402
+from src.storage.database import Database  # noqa: E402
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Test doubles
+# ──────────────────────────────────────────────────────────────────────
+
+
+class _FakeMagic:
+    """Stand-in for ``magic.Magic(mime=True)`` returning preset answers."""
+
+    def __init__(self, mime_for: dict[str, str]):
+        self.mime_for = mime_for
+
+    def from_file(self, path: str) -> str:
+        # Allow lookups by basename or full path
+        if path in self.mime_for:
+            return self.mime_for[path]
+        base = os.path.basename(path)
+        return self.mime_for.get(base, "application/octet-stream")
+
+
+def _checker_with(mime_for: dict[str, str]) -> ExtensionChecker:
+    """Build an ExtensionChecker pre-wired with a fake magic backend."""
+    c = ExtensionChecker()
+    c._magic = _FakeMagic(mime_for)
+    c._magic_unavailable = False
+    return c
+
+
+# ──────────────────────────────────────────────────────────────────────
+# ExtensionChecker — happy path / mismatches
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_pdf_with_pdf_magic_no_anomaly(tmp_path):
+    """A real PDF (declared .pdf, magic application/pdf) -> no anomaly."""
+    p = tmp_path / "real.pdf"
+    p.write_bytes(b"%PDF-1.4\n...")
+    c = _checker_with({str(p): "application/pdf"})
+    assert c.check_file(str(p)) is None
+
+
+def test_pdf_with_zip_magic_high_severity(tmp_path):
+    """A zip masquerading as .pdf -> high severity (top-tier doc)."""
+    p = tmp_path / "rapor.pdf"
+    p.write_bytes(b"PK\x03\x04...")
+    c = _checker_with({str(p): "application/zip"})
+    hit = c.check_file(str(p))
+    assert isinstance(hit, ExtensionAnomaly)
+    assert hit.declared_ext == "pdf"
+    assert hit.detected_mime == "application/zip"
+    assert hit.detected_ext == "zip"
+    assert hit.severity == "high"
+
+
+def test_image_with_executable_magic_critical(tmp_path):
+    """A Windows PE disguised as .png -> critical severity."""
+    p = tmp_path / "logo.png"
+    p.write_bytes(b"MZ\x90\x00")
+    c = _checker_with({str(p): "application/x-dosexec"})
+    hit = c.check_file(str(p))
+    assert hit is not None
+    assert hit.severity == "critical"
+    assert hit.detected_ext == "exe"
+
+
+def test_pdf_with_executable_magic_critical(tmp_path):
+    """The canonical ransomware-payload pattern -> critical."""
+    p = tmp_path / "invoice.pdf"
+    p.write_bytes(b"MZ\x90\x00")
+    c = _checker_with({str(p): "application/x-msdownload"})
+    hit = c.check_file(str(p))
+    assert hit is not None
+    assert hit.severity == "critical"
+
+
+def test_unknown_extension_returns_none(tmp_path):
+    """Extensions we don't have a baseline for are skipped."""
+    p = tmp_path / "weird.xyz"
+    p.write_bytes(b"data")
+    c = _checker_with({str(p): "application/zip"})
+    assert c.check_file(str(p)) is None
+
+
+def test_no_extension_returns_none(tmp_path):
+    p = tmp_path / "Makefile"
+    p.write_bytes(b"all:\n\techo hi")
+    c = _checker_with({str(p): "text/plain"})
+    assert c.check_file(str(p)) is None
+
+
+def test_docx_zip_mime_no_anomaly(tmp_path):
+    """docx files report as application/zip in some libmagic builds — must
+    NOT raise a finding."""
+    p = tmp_path / "report.docx"
+    p.write_bytes(b"PK\x03\x04...")
+    c = _checker_with({str(p): "application/zip"})
+    assert c.check_file(str(p)) is None
+
+
+def test_libmagic_missing_returns_none(tmp_path):
+    """If python-magic isn't installed, check_file returns None for
+    everything (no exception, no log spam beyond the one-time warning).
+    """
+    p = tmp_path / "rapor.pdf"
+    p.write_bytes(b"PK\x03\x04...")
+
+    # Force the lazy import path to fail.
+    real_import = __import__
+
+    def _fake_import(name, *args, **kwargs):
+        if name == "magic":
+            raise ImportError("simulated python-magic missing")
+        return real_import(name, *args, **kwargs)
+
+    with patch("builtins.__import__", side_effect=_fake_import):
+        c = ExtensionChecker()
+
+    assert c.available is False
+    assert c.check_file(str(p)) is None
+    # check_files also returns []
+    assert c.check_files([str(p)]) == []
+
+
+def test_check_files_filters_none_hits(tmp_path):
+    p1 = tmp_path / "ok.pdf"
+    p1.write_bytes(b"%PDF-1.4")
+    p2 = tmp_path / "evil.pdf"
+    p2.write_bytes(b"MZ")
+    c = _checker_with({
+        str(p1): "application/pdf",
+        str(p2): "application/x-dosexec",
+    })
+    out = c.check_files([str(p1), str(p2)])
+    assert len(out) == 1
+    assert out[0].file_path == str(p2)
+    assert out[0].severity == "critical"
+
+
+def test_text_family_low_severity(tmp_path):
+    """A .json detected as text/plain — low severity, not actionable."""
+    p = tmp_path / "data.json"
+    p.write_text("not actually json")
+    c = _checker_with({str(p): "text/plain"})
+    hit = c.check_file(str(p))
+    # text/plain is in expected for json, so no anomaly at all.
+    assert hit is None
+
+
+def test_jpg_with_zip_magic_medium_severity(tmp_path):
+    """A jpg whose magic is application/zip — medium (image, not top-tier doc)."""
+    p = tmp_path / "img.jpg"
+    p.write_bytes(b"PK\x03\x04")
+    c = _checker_with({str(p): "application/zip"})
+    hit = c.check_file(str(p))
+    assert hit is not None
+    assert hit.severity == "medium"
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Database integration — idempotent schema + insert helpers
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_extension_anomalies_table_exists(tmp_path):
+    db = Database({"path": str(tmp_path / "ext.db")})
+    db.connect()
+    with db.get_cursor() as cur:
+        cur.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' "
+            "AND name='extension_anomalies'"
+        )
+        assert cur.fetchone() is not None
+
+
+def test_insert_and_list_extension_anomalies(tmp_path):
+    db = Database({"path": str(tmp_path / "ext.db")})
+    db.connect()
+    with db.get_cursor() as cur:
+        cur.execute("INSERT INTO sources (name, unc_path) VALUES ('s', '/x')")
+        source_id = cur.lastrowid
+        cur.execute(
+            "INSERT INTO scan_runs (source_id, status) VALUES (?, 'completed')",
+            (source_id,),
+        )
+        scan_id = cur.lastrowid
+
+    anomalies = [
+        ExtensionAnomaly(
+            file_path="/share/a.pdf", declared_ext="pdf",
+            detected_mime="application/zip", detected_ext="zip",
+            severity="high",
+        ),
+        ExtensionAnomaly(
+            file_path="/share/b.png", declared_ext="png",
+            detected_mime="application/x-dosexec", detected_ext="exe",
+            severity="critical",
+        ),
+    ]
+    n = db.insert_extension_anomalies(scan_id, anomalies)
+    assert n == 2
+
+    rows = db.list_extension_anomalies(scan_id=scan_id, limit=10)
+    assert len(rows) == 2
+    # Critical ordered first by severity sort
+    assert rows[0]["severity"] == "critical"
+    assert rows[1]["severity"] == "high"
+
+    # Severity filter
+    only_crit = db.list_extension_anomalies(
+        scan_id=scan_id, severity="critical",
+    )
+    assert len(only_crit) == 1
+    assert only_crit[0]["file_path"] == "/share/b.png"
+
+    assert db.count_extension_anomalies(scan_id=scan_id) == 2
+    assert db.count_extension_anomalies(scan_id=scan_id, severity="high") == 1
+
+
+# ──────────────────────────────────────────────────────────────────────
+# API smoke tests
+# ──────────────────────────────────────────────────────────────────────
+
+
+_BASE_CONFIG = {
+    "dashboard": {"auth": {"enabled": False}},
+    "scanner": {"detect_wrong_extensions": True},
+    "security": {
+        "ransomware": {"enabled": False},
+        "orphan_sid": {"enabled": False},
+    },
+    "analytics": {},
+}
+
+
+class _StubAnalytics:
+    available = False
+
+    def close(self):
+        pass
+
+
+@pytest.fixture
+def api_client(tmp_path):
+    db = Database({"path": str(tmp_path / "api.db")})
+    db.connect()
+    with db.get_cursor() as cur:
+        cur.execute("INSERT INTO sources (name, unc_path) VALUES ('s1', '/x')")
+        source_id = cur.lastrowid
+        cur.execute(
+            "INSERT INTO scan_runs (source_id, status) VALUES (?, 'completed')",
+            (source_id,),
+        )
+        scan_id = cur.lastrowid
+
+    db.insert_extension_anomalies(scan_id, [
+        ExtensionAnomaly("/share/a.pdf", "pdf", "application/zip", "zip", "high"),
+        ExtensionAnomaly("/share/b.png", "png", "application/x-dosexec", "exe", "critical"),
+        ExtensionAnomaly("/share/c.docx", "docx", "application/x-msdownload", "exe", "critical"),
+    ])
+
+    app = create_app(
+        db,
+        _BASE_CONFIG,
+        analytics=_StubAnalytics(),
+    )
+    return TestClient(app), source_id, scan_id
+
+
+def test_api_list_extension_anomalies(api_client):
+    client, source_id, scan_id = api_client
+    r = client.get(
+        f"/api/security/extension-anomalies?scan_id={scan_id}"
+    )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["total"] == 3
+    assert body["by_severity"]["critical"] == 2
+    assert body["by_severity"]["high"] == 1
+    # Critical rows ordered first
+    assert body["items"][0]["severity"] == "critical"
+
+
+def test_api_list_extension_anomalies_filter(api_client):
+    client, _src, scan_id = api_client
+    r = client.get(
+        f"/api/security/extension-anomalies?scan_id={scan_id}&severity=high"
+    )
+    assert r.status_code == 200
+    items = r.json()["items"]
+    assert len(items) == 1
+    assert items[0]["severity"] == "high"
+
+
+def test_api_list_extension_anomalies_bad_severity(api_client):
+    client, _src, scan_id = api_client
+    r = client.get(
+        f"/api/security/extension-anomalies?scan_id={scan_id}&severity=bogus"
+    )
+    assert r.status_code == 400
+
+
+def test_api_export_xlsx(api_client):
+    client, source_id, _scan = api_client
+    r = client.get(
+        f"/api/security/extension-anomalies/{source_id}/export.xlsx"
+    )
+    assert r.status_code == 200
+    assert r.headers["content-type"].startswith(
+        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+    )
+    # XLSX is a ZIP under the hood
+    assert r.content[:2] == b"PK"
+
+
+def test_api_feature_flags_includes_extension_anomalies(api_client):
+    client, _src, _scan = api_client
+    r = client.get("/api/security/feature-flags")
+    assert r.status_code == 200
+    body = r.json()
+    assert "extension_anomalies" in body
+    assert body["extension_anomalies"]["enabled"] is True
+
+
+def test_api_source_id_resolves_to_latest_scan(api_client):
+    client, source_id, _scan = api_client
+    r = client.get(
+        f"/api/security/extension-anomalies?source_id={source_id}"
+    )
+    assert r.status_code == 200
+    body = r.json()
+    # Should have resolved to the latest scan and returned all 3 rows.
+    assert body["total"] == 3


### PR DESCRIPTION
## Summary

Phase 1 of issue #144: detect files whose magic-byte MIME type doesn't match their extension (the "Czkawka pattern"). Common case: `.pdf` files that are actually `.exe` payloads. Off by default — gated by `scanner.detect_wrong_extensions`.

## Files

**New:**
- `src/analyzer/extension_check.py` — `ExtensionChecker` with lazy `magic` import, ~30 EXPECTED_MIMES entries, severity rules (critical/high/medium/low).
- `tests/test_extension_check.py` — 19 tests (unit + DB + API smoke).

**Modified:**
- `src/storage/database.py` — `extension_anomalies` table + idempotent indexes (`idx_ext_anomaly_scan`, `idx_ext_anomaly_severity`); helpers `insert_extension_anomalies`, `list_extension_anomalies`, `count_extension_anomalies`.
- `src/scanner/file_scanner.py` — opt-in post-scan `_run_extension_check()` (streams paths, flushes 500-row chunks, by-severity summary log). Runs AFTER `compute_scan_summary` + `ai_insights` so libmagic latency never blocks MFT/SMB enumeration.
- `src/dashboard/api.py` — `GET /api/security/extension-anomalies` (filters scan_id/source_id/severity, paginated, by_severity breakdown), `GET /api/security/extension-anomalies/{source_id}/export.xlsx`, `extension_anomalies` flag in `/api/security/feature-flags`.
- `src/dashboard/static/index.html` — sidebar entry under "Güvenlik", new `#page-extension-anomalies` page, severity dropdown filter, XLSX export button, "Hedefe Git" bulk action capped at 5.
- `config.yaml` — `scanner.detect_wrong_extensions: false`.
- `requirements-accel.txt` — `python-magic` (non-Windows) + `python-magic-bin` (Windows) with platform install notes.

## Severity rules

- **critical** — doc-like ext + executable MIME (the customer's payload pattern; e.g. `.pdf` reporting as `application/x-dosexec`)
- **high** — top-tier doc (pdf/docx/xlsx) ↔ any other type
- **medium** — concrete mismatch otherwise
- **low** — text-family confusion

## Judgement calls

- **`python-magic-bin>=0.4.14` for Windows** — bundles `libmagic.dll`; the plain `python-magic` package fails at runtime on Windows. Linux/macOS use `python-magic>=0.4.27` + system `libmagic1`. Selection via `sys_platform` markers so a single `pip install -r requirements-accel.txt` does the right thing.
- **MIME normalization** — strip `; charset=binary` suffix some libmagic builds add, lowercase before set-membership check.
- **docx/xlsx false-positive guard** — `application/zip` is in EXPECTED_MIMES for Office formats (many libmagic builds report Office as plain ZIP, would otherwise fire constant false anomalies).
- **Graceful libmagic-missing path** — emits one WARNING, `available=False`, `check_file()` returns `None`. Feature opts out cleanly.

## Test plan

- [x] `pytest tests/test_extension_check.py` — **19/19 passing** (~5s).
- [x] Synthetic disguised PDF (`MZ` header, `.pdf` ext, mime `application/x-dosexec`) → `severity=critical, detected_ext=exe`.
- [x] Real PDF (`%PDF-1.4`, mime `application/pdf`) → `None`.
- [x] libmagic missing path → graceful (one warning, no crash).
- [x] Existing security/dashboard tests still green (13/13 + 9/9).

Closes #144 (Phase 1).

https://claude.ai/code/session_01A1UzS1A4DZNk1akoP4uhZ7

---
_Generated by [Claude Code](https://claude.ai/code/session_01A1UzS1A4DZNk1akoP4uhZ7)_