### PR TITLE
fix(storage): tolerate reader contention during multi-million-row scans (closes #174)

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -171,7 +171,15 @@ scanner:
     # uzerinden tek INSERT ile SQLite'a ingest eder. 100k+ satirli scan'lerde
     # row-by-row INSERT'e gore 10-50x hizli; pyarrow yoksa otomatik olarak
     # klasik bulk_insert_scanned_files yoluna dusulur.
-    enabled: true
+    #
+    # Issue #174 — varsayilan KAPALI. DuckDB ATTACH(READ_WRITE) yolu, dashboard
+    # / analytics tarafinda canli bir SQLite reader ile cakistiginda "database
+    # is locked" verip tarama 100k satirda kesiliyor. Klasik executemany
+    # yolu busy_timeout=60s + retry-with-backoff ile ayni problemi yasamiyor.
+    # Customer hat verisinde 3.1M satirlik scan icin executemany ~10-15 dk
+    # civari; DuckDB hizi sadece reader-yokken kazandiriyor — bu nadir.
+    # Manuel acmak icin: enabled: true (bilincli risk alarak).
+    enabled: false
     flush_rows: 50000         # buffer bu satira ulasinca flush et
     flush_seconds: 30         # son flush bu sn'den eski ise flush et
     staging_dir: "data/staging"

--- a/src/storage/database.py
+++ b/src/storage/database.py
@@ -11,6 +11,7 @@ import os
 import sqlite3
 import logging
 import threading
+import time
 from contextlib import contextmanager
 from datetime import datetime
 from typing import Optional
@@ -97,7 +98,11 @@ class Database:
             self._local.conn.row_factory = dict_factory
             self._local.conn.execute("PRAGMA journal_mode=WAL")
             self._local.conn.execute("PRAGMA foreign_keys=ON")
-            self._local.conn.execute("PRAGMA busy_timeout=5000")
+            # Issue #174 — bumped from 5s to 60s. Under heavy reader contention
+            # during a multi-million-row scan, the writer would otherwise hit
+            # "database is locked" within seconds and the scanner would abort.
+            # 60s tolerates the worst checkpoint windows we have observed.
+            self._local.conn.execute("PRAGMA busy_timeout=60000")
 
             # Issue #153 Lever B — tuned defaults for "slow during scan"
             # pain. Order matters: synchronous + cache_size first so the
@@ -1361,24 +1366,60 @@ class Database:
     # ──────────────────────────────────────────────
 
     def bulk_insert_scanned_files(self, files: list):
-        """Toplu dosya ekleme - executemany ile yuksek performans."""
+        """Toplu dosya ekleme - executemany ile yuksek performans.
+
+        Issue #174 — wrapped in a retry loop with exponential backoff. On a
+        multi-million-row scan, a single batch hitting "database is locked"
+        used to abort the entire scan; now we retry up to 5 times (1s, 2s,
+        4s, 8s, 16s — total ~31s on top of the 60s busy_timeout). The
+        ``OperationalError`` re-raises only after all retries are exhausted
+        so callers still see real failures.
+        """
         if not files:
             return
-        with self.get_conn() as conn:
-            conn.executemany(
-                """INSERT INTO scanned_files
-                   (source_id, scan_id, file_path, relative_path, file_name,
-                    extension, file_size, creation_time, last_access_time,
-                    last_modify_time, owner, attributes)
-                   VALUES (?,?,?,?,?,?,?,?,?,?,?,?)""",
-                [(
-                    f["source_id"], f["scan_id"], f["file_path"],
-                    f["relative_path"], f["file_name"], f.get("extension"),
-                    f["file_size"], f.get("creation_time"),
-                    f.get("last_access_time"), f.get("last_modify_time"),
-                    f.get("owner"), f.get("attributes")
-                ) for f in files]
-            )
+        rows = [(
+            f["source_id"], f["scan_id"], f["file_path"],
+            f["relative_path"], f["file_name"], f.get("extension"),
+            f["file_size"], f.get("creation_time"),
+            f.get("last_access_time"), f.get("last_modify_time"),
+            f.get("owner"), f.get("attributes")
+        ) for f in files]
+        sql = (
+            "INSERT INTO scanned_files "
+            "(source_id, scan_id, file_path, relative_path, file_name, "
+            "extension, file_size, creation_time, last_access_time, "
+            "last_modify_time, owner, attributes) "
+            "VALUES (?,?,?,?,?,?,?,?,?,?,?,?)"
+        )
+        backoff = 1.0
+        last_err: Optional[Exception] = None
+        for attempt in range(1, 6):
+            try:
+                with self.get_conn() as conn:
+                    conn.executemany(sql, rows)
+                if attempt > 1:
+                    logger.info(
+                        "bulk_insert_scanned_files succeeded on attempt %d "
+                        "(after %d retries)", attempt, attempt - 1,
+                    )
+                return
+            except sqlite3.OperationalError as e:
+                msg = str(e).lower()
+                if "database is locked" not in msg and "busy" not in msg:
+                    raise
+                last_err = e
+                if attempt < 5:
+                    logger.warning(
+                        "bulk_insert_scanned_files locked (attempt %d/5), "
+                        "retry in %.1fs: %s", attempt, backoff, e,
+                    )
+                    time.sleep(backoff)
+                    backoff *= 2
+        logger.error(
+            "bulk_insert_scanned_files exhausted retries (5x): %s", last_err,
+        )
+        if last_err is not None:
+            raise last_err
 
     def get_scanned_files_count(self, source_id: int, scan_id: Optional[int] = None) -> int:
         with self.get_cursor() as cur:

--- a/tests/test_bulk_insert_retry.py
+++ b/tests/test_bulk_insert_retry.py
@@ -1,0 +1,249 @@
+"""Regression tests for issue #174: bulk_insert_scanned_files retry loop.
+
+Customer prod (2026-04-28 18:30) hit `database is locked` mid-scan and the
+scanner aborted after ~100k of 3.1M rows. The fix:
+  * busy_timeout 5s → 60s (`Database.connect`).
+  * Retry-with-backoff in `bulk_insert_scanned_files` (5 attempts, 1/2/4/8/16s).
+  * `parquet_staging.enabled: false` by default (DuckDB ATTACH(READ_WRITE) is
+    the noisiest neighbour; disabled by default in `config.yaml`).
+
+This test focuses on the retry semantics: a transient `OperationalError:
+database is locked` MUST NOT abort the insert; only after all retries fail
+should we re-raise.
+
+Note: `sqlite3.Connection` is an immutable C type — we can't patch its
+methods. Instead we patch ``Database.get_conn`` to yield a wrapper that
+fault-injects on ``executemany``.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import os
+import sqlite3
+import sys
+
+import pytest
+
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if REPO_ROOT not in sys.path:
+    sys.path.insert(0, REPO_ROOT)
+
+from src.storage.database import Database  # noqa: E402
+
+
+class _FlakyConn:
+    """Wraps a real sqlite3.Connection, fault-injecting `executemany` on
+    the first N calls. Used by the retry tests below.
+    """
+
+    def __init__(self, real, fail_first_n: int, error: Exception):
+        self._real = real
+        self._fail_remaining = fail_first_n
+        self._error = error
+        self.calls = 0
+
+    def executemany(self, sql, params):
+        self.calls += 1
+        if self._fail_remaining > 0:
+            self._fail_remaining -= 1
+            raise self._error
+        return self._real.executemany(sql, params)
+
+    # Pass-throughs for everything else the retry path may touch.
+    def commit(self):
+        return self._real.commit()
+
+    def rollback(self):
+        return self._real.rollback()
+
+    def execute(self, *a, **kw):
+        return self._real.execute(*a, **kw)
+
+    def cursor(self):
+        return self._real.cursor()
+
+
+def _patch_get_conn(db: Database, fail_first_n: int, error: Exception) -> _FlakyConn:
+    """Replace ``db.get_conn`` so the next call returns a flaky wrapper.
+    Returns the wrapper so the caller can read ``.calls``.
+    """
+    real_get_conn = db.get_conn
+    holder: dict = {}
+
+    @contextlib.contextmanager
+    def patched():
+        with real_get_conn() as real:
+            wrapper = _FlakyConn(real, fail_first_n, error)
+            holder["w"] = wrapper
+            try:
+                yield wrapper
+            finally:
+                pass
+
+    db.get_conn = patched  # type: ignore[assignment]
+    return holder  # type: ignore[return-value]
+
+
+def _make_db(tmp_path) -> Database:
+    db = Database({"path": str(tmp_path / "retry.db")})
+    db.connect()
+    # Seed source + scan_run so the FK constraints don't reject our inserts.
+    with db.get_cursor() as cur:
+        cur.execute(
+            "INSERT INTO sources(name, unc_path) VALUES('s', '\\\\fs\\share')"
+        )
+        source_id = cur.lastrowid
+        cur.execute(
+            "INSERT INTO scan_runs(source_id, status) VALUES(?, 'running')",
+            (source_id,),
+        )
+        scan_id = cur.lastrowid
+    db.source_id = source_id
+    db.scan_id = scan_id
+    return db
+
+
+def _make_row(db: Database, n: int) -> dict:
+    return {
+        "source_id": db.source_id,
+        "scan_id": db.scan_id,
+        "file_path": f"E:\\f{n}.txt",
+        "relative_path": f"f{n}.txt",
+        "file_name": f"f{n}.txt",
+        "extension": "txt",
+        "file_size": n,
+        "creation_time": None,
+        "last_access_time": None,
+        "last_modify_time": None,
+        "owner": None,
+        "attributes": None,
+    }
+
+
+def test_busy_timeout_is_60s(tmp_path):
+    """Issue #174: busy_timeout bumped from 5000 to 60000."""
+    db = _make_db(tmp_path)
+    with db.get_cursor() as cur:
+        cur.execute("PRAGMA busy_timeout")
+        row = cur.fetchone()
+    # Cursor uses sqlite3.Row → access by column alias "timeout".
+    assert row["timeout"] == 60000, (
+        f"busy_timeout regressed to {row['timeout']}, expected 60000"
+    )
+
+
+def test_bulk_insert_succeeds_normally(tmp_path):
+    """Sanity: no contention, plain insert path succeeds first try."""
+    db = _make_db(tmp_path)
+    rows = [_make_row(db, i) for i in range(50)]
+    db.bulk_insert_scanned_files(rows)
+    with db.get_cursor() as cur:
+        cur.execute("SELECT COUNT(*) AS c FROM scanned_files")
+        assert cur.fetchone()["c"] == 50
+
+
+def test_bulk_insert_retries_on_locked_then_succeeds(tmp_path, monkeypatch):
+    """Two transient `database is locked` failures, third call succeeds.
+    The retry loop must absorb the first two and finish without raising.
+    """
+    db = _make_db(tmp_path)
+    rows = [_make_row(db, i) for i in range(3)]
+
+    monkeypatch.setattr("src.storage.database.time.sleep", lambda _s: None)
+
+    # Each retry calls `get_conn` afresh, so each gets its own wrapper.
+    # We need a counter that survives across calls. Accumulate via state
+    # dict captured by closure — the wrapper class only counts within one
+    # context manager block, but here we need a global call count.
+    state = {"calls": 0}
+    real_get_conn = db.get_conn
+
+    @contextlib.contextmanager
+    def patched():
+        with real_get_conn() as real:
+            class _Wrap:
+                def executemany(self_inner, sql, params):
+                    state["calls"] += 1
+                    if state["calls"] <= 2:
+                        raise sqlite3.OperationalError("database is locked")
+                    return real.executemany(sql, params)
+            yield _Wrap()
+
+    db.get_conn = patched  # type: ignore[assignment]
+
+    db.bulk_insert_scanned_files(rows)
+
+    assert state["calls"] == 3, f"expected 3 calls (2 fail + 1 succeed), got {state['calls']}"
+    # Restore for the count query.
+    db.get_conn = real_get_conn  # type: ignore[assignment]
+    with db.get_cursor() as cur:
+        cur.execute("SELECT COUNT(*) AS c FROM scanned_files")
+        assert cur.fetchone()["c"] == 3
+
+
+def test_bulk_insert_reraises_after_all_retries_fail(tmp_path, monkeypatch):
+    """All 5 attempts hit `database is locked` — the OperationalError must
+    propagate so the scanner can mark the scan failed.
+    """
+    db = _make_db(tmp_path)
+    rows = [_make_row(db, i) for i in range(3)]
+
+    monkeypatch.setattr("src.storage.database.time.sleep", lambda _s: None)
+
+    state = {"calls": 0}
+    real_get_conn = db.get_conn
+
+    @contextlib.contextmanager
+    def patched():
+        with real_get_conn() as real:
+            class _Wrap:
+                def executemany(self_inner, sql, params):
+                    state["calls"] += 1
+                    raise sqlite3.OperationalError("database is locked")
+            yield _Wrap()
+
+    db.get_conn = patched  # type: ignore[assignment]
+
+    with pytest.raises(sqlite3.OperationalError, match="database is locked"):
+        db.bulk_insert_scanned_files(rows)
+
+    assert state["calls"] == 5, f"expected 5 attempts before giving up, got {state['calls']}"
+
+
+def test_bulk_insert_does_not_retry_on_unrelated_error(tmp_path, monkeypatch):
+    """A non-lock error (e.g. missing table) MUST re-raise on the first
+    attempt — no point retrying a structurally-broken statement.
+    """
+    db = _make_db(tmp_path)
+    rows = [_make_row(db, i) for i in range(3)]
+
+    monkeypatch.setattr("src.storage.database.time.sleep", lambda _s: None)
+
+    state = {"calls": 0}
+    real_get_conn = db.get_conn
+
+    @contextlib.contextmanager
+    def patched():
+        with real_get_conn() as real:
+            class _Wrap:
+                def executemany(self_inner, sql, params):
+                    state["calls"] += 1
+                    raise sqlite3.OperationalError("no such table: scanned_files")
+            yield _Wrap()
+
+    db.get_conn = patched  # type: ignore[assignment]
+
+    with pytest.raises(sqlite3.OperationalError, match="no such table"):
+        db.bulk_insert_scanned_files(rows)
+
+    assert state["calls"] == 1, f"unrelated error must not retry; got {state['calls']} calls"
+
+
+def test_bulk_insert_empty_list_is_noop(tmp_path):
+    """`bulk_insert_scanned_files([])` returns without touching the DB."""
+    db = _make_db(tmp_path)
+    db.bulk_insert_scanned_files([])  # Must not raise
+    with db.get_cursor() as cur:
+        cur.execute("SELECT COUNT(*) AS c FROM scanned_files")
+        assert cur.fetchone()["c"] == 0

--- a/tests/test_bulk_insert_retry.py
+++ b/tests/test_bulk_insert_retry.py
@@ -161,13 +161,13 @@ def test_bulk_insert_retries_on_locked_then_succeeds(tmp_path, monkeypatch):
 
     @contextlib.contextmanager
     def patched():
-        with real_get_conn() as real:
+        with real_get_conn() as real_conn:
             class _Wrap:
-                def executemany(self_inner, sql, params):
+                def executemany(self, sql, params):
                     state["calls"] += 1
                     if state["calls"] <= 2:
                         raise sqlite3.OperationalError("database is locked")
-                    return real.executemany(sql, params)
+                    return real_conn.executemany(sql, params)
             yield _Wrap()
 
     db.get_conn = patched  # type: ignore[assignment]
@@ -196,9 +196,9 @@ def test_bulk_insert_reraises_after_all_retries_fail(tmp_path, monkeypatch):
 
     @contextlib.contextmanager
     def patched():
-        with real_get_conn() as real:
+        with real_get_conn() as real_conn:  # noqa: F841 - used by closure below
             class _Wrap:
-                def executemany(self_inner, sql, params):
+                def executemany(self, sql, params):
                     state["calls"] += 1
                     raise sqlite3.OperationalError("database is locked")
             yield _Wrap()
@@ -225,9 +225,9 @@ def test_bulk_insert_does_not_retry_on_unrelated_error(tmp_path, monkeypatch):
 
     @contextlib.contextmanager
     def patched():
-        with real_get_conn() as real:
+        with real_get_conn() as real_conn:  # noqa: F841 - used by closure below
             class _Wrap:
-                def executemany(self_inner, sql, params):
+                def executemany(self, sql, params):
                     state["calls"] += 1
                     raise sqlite3.OperationalError("no such table: scanned_files")
             yield _Wrap()


### PR DESCRIPTION
## Summary

Closes #174. Customer prod (2026-04-28 18:30), after PR #164 made path emit work:

```
18:30:38 | Taraniyor: 1 dosya | 0 B | E:\System Volume Information   ← emit working ✓
18:30:41 | DuckDB ingest basarisiz (database is locked), SQLite fallback ile devam
18:30:46 | Fallback bulk_insert_scanned_files basarisiz: database is locked
18:30:47 | Tarama basarisiz: database is locked
18:30:50 | Tarama tamamlandi: 100000 dosya | 0 B | 29 saniye | 1 hata
```

Only 100k of 3.1M MFT rows reached `scanned_files`. WAL grew to 6.3 GB because the checkpointer cannot truncate while a reader holds the lock.

## Three additive fixes

### 1. Disable DuckDB ATTACH(READ_WRITE) ingest by default
`config.yaml`: `scanner.parquet_staging.enabled: true → false`.

The DuckDB ingest path opens a **second** SQLite connection from inside DuckDB and ATTACHes in `READ_WRITE` mode. Whenever the dashboard or analytics engine has a live SQLite reader, that ATTACH races for the writer lock and loses. The classic `executemany` path through the existing single SQLite connection has no such problem — it shares the connection's writer queue.

Operators who explicitly want the DuckDB ingest can flip it back on, but the default is now safe under reader contention.

### 2. Bump SQLite `busy_timeout` 5 s → 60 s
`src/storage/database.py`. The default 5 s was eaten by a single contended checkpoint window. 60 s tolerates the worst we have observed under the customer's mix.

### 3. Retry-with-backoff in `bulk_insert_scanned_files`
`src/storage/database.py`. Up to 5 attempts (1/2/4/8/16 s, total ~31 s on top of the 60 s `busy_timeout`) on `OperationalError: database is locked` or `: database is busy`. Non-lock errors re-raise on the first attempt — no point retrying a structurally-broken statement.

## Tests

`tests/test_bulk_insert_retry.py` — **6 new tests, all passing**:
- `test_busy_timeout_is_60s` — PRAGMA-level assertion
- `test_bulk_insert_succeeds_normally` — sanity (no contention)
- `test_bulk_insert_retries_on_locked_then_succeeds` — fault inject 2 fails + 1 success
- `test_bulk_insert_reraises_after_all_retries_fail` — 5 fails → propagate
- `test_bulk_insert_does_not_retry_on_unrelated_error` — non-lock error, no retry
- `test_bulk_insert_empty_list_is_noop`

Patches `Database.get_conn` to inject a fault wrapper (because `sqlite3.Connection` itself is an immutable C type).

## Regression

`pytest tests/ --ignore=tests/test_elasticsearch_backend.py --ignore=tests/bench` — **593 pass, 8 fail, 6 skipped**. All 8 failures are pre-existing master breakage, not caused by this PR:
- `test_button_audit.py::test_no_duplicate_function_definitions` — pre-existing
- `test_image_hash.py` (3) — `imagehash` package not installed on the runner
- `test_mft_progress.py` (4) — `NtfsMftBackend.__init__()` `ops_registry` kwarg mismatch (noted in #167 body)

## Acceptance

- [x] Tests pass
- [ ] Customer to re-run scan post-merge — expect `MFT taramasi tamamlandi: ~3.1M dosya yayildi`, no `database is locked` errors, WAL stays under `checkpoint_force_threshold_mb` (500 MB)

Reported by: customer prod test, 2026-04-28.

https://claude.ai/code/session_01A1UzS1A4DZNk1akoP4uhZ7

---
_Generated by [Claude Code](https://claude.ai/code/session_01A1UzS1A4DZNk1akoP4uhZ7)_