### PR TITLE
perf(dashboard): migrate read endpoints to read-only connection pool (#181 Track A)

### DIFF
--- a/src/dashboard/api.py
+++ b/src/dashboard/api.py
@@ -821,6 +821,9 @@ def create_app(db, config, analytics=None, ad_lookup=None, email_notifier=None,
         summaries = {}
         for s in sources:
             try:
+                # Writer pool required: cursor block fixes up scan_runs
+                # totals via UPDATE when total_files=0 fallback hits
+                # (issue #181 Track A — keep on get_cursor, not get_read_cursor).
                 with db.get_cursor() as cur:
                     # 1) Son tamamlanmis tarama (completed once priority)
                     cur.execute("""
@@ -2046,7 +2049,7 @@ def create_app(db, config, analytics=None, ad_lookup=None, email_notifier=None,
             raise HTTPException(404, "Tarama bulunamadi")
 
         analyzer = MITNamingAnalyzer()
-        with db.get_cursor() as cur:
+        with db.get_read_cursor() as cur:
             cur.execute("""
                 SELECT file_path, file_name FROM scanned_files
                 WHERE scan_id=?
@@ -2088,7 +2091,7 @@ def create_app(db, config, analytics=None, ad_lookup=None, email_notifier=None,
 
         # Dosyalari tara ve ihlal edenleri topla
         matching = []
-        with db.get_cursor() as cur:
+        with db.get_read_cursor() as cur:
             cur.execute("""
                 SELECT id, file_path, file_name, file_size, owner, last_modify_time
                 FROM scanned_files WHERE scan_id=?
@@ -2137,7 +2140,7 @@ def create_app(db, config, analytics=None, ad_lookup=None, email_notifier=None,
 
         # Tum dosyalari tara
         violations = {code: [] for code in checks}
-        with db.get_cursor() as cur:
+        with db.get_read_cursor() as cur:
             cur.execute("""
                 SELECT file_path, file_name, file_size, owner, last_modify_time
                 FROM scanned_files WHERE source_id=? AND scan_id=?
@@ -2260,7 +2263,7 @@ def create_app(db, config, analytics=None, ad_lookup=None, email_notifier=None,
         # this lazily — peak memory stays in the MB range even for the 5M-row
         # internal probe (issue #122).
         def _violation_rows():
-            with db.get_cursor() as cur:
+            with db.get_read_cursor() as cur:
                 cur.execute(
                     """SELECT id, file_path, file_name, owner,
                               last_modify_time, file_size
@@ -2466,7 +2469,7 @@ def create_app(db, config, analytics=None, ad_lookup=None, email_notifier=None,
         placeholders = ','.join(['?'] * len(risky_exts))
         stale_date = (datetime.now() - timedelta(days=365)).strftime('%Y-%m-%d')
 
-        with db.get_cursor() as cur:
+        with db.get_read_cursor() as cur:
             # TEK SORGU: 5 metrigi bir seferde hesapla (6 ayri sorgu yerine)
             cur.execute(f"""
                 SELECT
@@ -2543,7 +2546,7 @@ def create_app(db, config, analytics=None, ad_lookup=None, email_notifier=None,
     @app.get("/api/trend/{source_id}")
     async def scan_trend(source_id: int):
         """Storage growth trend from scan history."""
-        with db.get_cursor() as cur:
+        with db.get_read_cursor() as cur:
             cur.execute("""
                 SELECT id, started_at, completed_at, total_files, total_size, status
                 FROM scan_runs WHERE source_id = ? ORDER BY started_at DESC LIMIT 20
@@ -2790,7 +2793,7 @@ def create_app(db, config, analytics=None, ad_lookup=None, email_notifier=None,
         sql += "ORDER BY moved_at DESC LIMIT ?"
         params.append(int(limit))
         rows: list = []
-        with db.get_cursor() as cur:
+        with db.get_read_cursor() as cur:
             cur.execute(sql, params)
             for r in cur.fetchall():
                 d = dict(r)
@@ -2967,7 +2970,7 @@ def create_app(db, config, analytics=None, ad_lookup=None, email_notifier=None,
 
         # Secili dosyalari veritabanindan al
         files = []
-        with db.get_cursor() as cur:
+        with db.get_read_cursor() as cur:
             placeholders = ','.join('?' * len(file_ids))
             cur.execute(f"""
                 SELECT * FROM scanned_files WHERE id IN ({placeholders}) AND source_id=?
@@ -3034,7 +3037,7 @@ def create_app(db, config, analytics=None, ad_lookup=None, email_notifier=None,
         from src.utils.size_formatter import format_size
 
         # Build query based on insight_type
-        with db.get_cursor() as cur:
+        with db.get_read_cursor() as cur:
             if insight_type == "stale_1year":
                 cur.execute("""
                     SELECT * FROM scanned_files WHERE source_id=? AND scan_id=?
@@ -3487,7 +3490,7 @@ def create_app(db, config, analytics=None, ad_lookup=None, email_notifier=None,
             conditions.append("status = ?")
             params.append(status)
         where = (" WHERE " + " AND ".join(conditions)) if conditions else ""
-        with db.get_cursor() as cur:
+        with db.get_read_cursor() as cur:
             cur.execute(f"SELECT COUNT(*) AS cnt FROM notification_log{where}", params)
             total = cur.fetchone()["cnt"]
             cur.execute(
@@ -3854,7 +3857,7 @@ def create_app(db, config, analytics=None, ad_lookup=None, email_notifier=None,
                     cell.alignment = Alignment(horizontal='center')
 
                 row = 2
-                with db.get_cursor() as cur:
+                with db.get_read_cursor() as cur:
                     cur.execute("SELECT COUNT(*) as cnt FROM scanned_files WHERE source_id=? AND scan_id=?", (source_id, scan_id))
                     total = cur.fetchone()["cnt"]
                     cur.execute("SELECT file_path, file_name, file_size, owner, last_modify_time FROM scanned_files WHERE source_id=? AND scan_id=?", (source_id, scan_id))
@@ -3897,7 +3900,7 @@ def create_app(db, config, analytics=None, ad_lookup=None, email_notifier=None,
                     cell.fill = header_fill
 
                 row = 2
-                with db.get_cursor() as cur:
+                with db.get_read_cursor() as cur:
                     cur.execute("""
                         SELECT file_name, file_size, file_path, owner, last_modify_time
                         FROM scanned_files WHERE source_id=? AND scan_id=? AND file_size > 1048576
@@ -3929,7 +3932,7 @@ def create_app(db, config, analytics=None, ad_lookup=None, email_notifier=None,
                     cell.fill = header_fill
 
                 row = 2
-                with db.get_cursor() as cur:
+                with db.get_read_cursor() as cur:
                     cur.execute("SELECT COUNT(*) as cnt FROM scanned_files WHERE source_id=? AND scan_id=?", (source_id, scan_id))
                     total = cur.fetchone()["cnt"]
                     cur.execute("SELECT * FROM scanned_files WHERE source_id=? AND scan_id=? ORDER BY file_path", (source_id, scan_id))
@@ -3981,7 +3984,7 @@ def create_app(db, config, analytics=None, ad_lookup=None, email_notifier=None,
     async def start_export(report_type: str = Query(...), source_id: int = Query(...)):
         """Arka planda XLS export baslat. Tarama devam ederken bile calisir."""
         # Son tamamlanmis taramayi kullan (aktif tarama kilitlemesin)
-        with db.get_cursor() as cur:
+        with db.get_read_cursor() as cur:
             cur.execute("""
                 SELECT id FROM scan_runs WHERE source_id=? AND status='completed'
                 ORDER BY started_at DESC LIMIT 1
@@ -4219,7 +4222,7 @@ def create_app(db, config, analytics=None, ad_lookup=None, email_notifier=None,
         if not analyzer.is_supported():
             raise HTTPException(501, "ACL snapshot requires Windows + pywin32")
         src = _get_source(db, source_id)
-        with db.get_cursor() as cur:
+        with db.get_read_cursor() as cur:
             cur.execute(
                 """SELECT id FROM scan_runs WHERE source_id=?
                    ORDER BY CASE WHEN status='completed' THEN 0 ELSE 1 END,
@@ -4339,7 +4342,7 @@ def create_app(db, config, analytics=None, ad_lookup=None, email_notifier=None,
 
             placeholders = ",".join(["?"] * len(orphan_sids))
             params: list = [source_id, scan_id, *orphan_sids]
-            with db.get_cursor() as cur:
+            with db.get_read_cursor() as cur:
                 cur.execute(
                     f"""SELECT file_path, owner, file_size, last_modify_time
                         FROM scanned_files
@@ -4468,7 +4471,7 @@ def create_app(db, config, analytics=None, ad_lookup=None, email_notifier=None,
         from src.analyzer.image_hash import find_duplicate_groups
 
         if scan_id is None:
-            with db.get_cursor() as cur:
+            with db.get_read_cursor() as cur:
                 cur.execute(
                     "SELECT id FROM scan_runs WHERE status = 'completed' "
                     "ORDER BY completed_at DESC LIMIT 1"
@@ -4525,7 +4528,7 @@ def create_app(db, config, analytics=None, ad_lookup=None, email_notifier=None,
         from src.analyzer.image_hash import find_duplicate_groups
 
         if scan_id is None:
-            with db.get_cursor() as cur:
+            with db.get_read_cursor() as cur:
                 cur.execute(
                     "SELECT id FROM scan_runs WHERE status = 'completed' "
                     "ORDER BY completed_at DESC LIMIT 1"
@@ -4744,7 +4747,7 @@ def create_app(db, config, analytics=None, ad_lookup=None, email_notifier=None,
         # By-severity breakdown for the dashboard summary cards.
         by_sev = {"critical": 0, "high": 0, "medium": 0, "low": 0}
         try:
-            with db.get_cursor() as cur:
+            with db.get_read_cursor() as cur:
                 where = "WHERE scan_id = ?" if resolved_scan_id is not None else ""
                 params = (resolved_scan_id,) if resolved_scan_id is not None else ()
                 cur.execute(
@@ -5201,7 +5204,7 @@ def create_app(db, config, analytics=None, ad_lookup=None, email_notifier=None,
             )
             params.append(int(source_id))
         where = ("WHERE " + " AND ".join(clauses)) if clauses else ""
-        with db.get_cursor() as cur:
+        with db.get_read_cursor() as cur:
             cur.execute(
                 f"SELECT COUNT(*) AS cnt FROM pii_findings p {where}",
                 params,
@@ -5312,7 +5315,7 @@ def create_app(db, config, analytics=None, ad_lookup=None, email_notifier=None,
         # Stream rows directly out of the cursor — keeps memory flat even
         # when the findings table grows past 1M rows on big PII scans.
         def _finding_rows():
-            with db.get_cursor() as cur:
+            with db.get_read_cursor() as cur:
                 cur.execute(
                     f"""SELECT p.id, p.scan_id, p.file_path, p.pattern_name,
                                p.hit_count, p.sample_snippet, p.detected_at
@@ -6074,7 +6077,7 @@ def create_app(db, config, analytics=None, ad_lookup=None, email_notifier=None,
         Excludes still-running scans because their total_size is interim.
         Sorted ascending so forecast_growth() can use the first row as t0.
         """
-        with db.get_cursor() as cur:
+        with db.get_read_cursor() as cur:
             cur.execute(
                 """
                 SELECT started_at, total_size, total_files
@@ -6138,7 +6141,7 @@ def create_app(db, config, analytics=None, ad_lookup=None, email_notifier=None,
 
         # Verify the source exists so callers get a real 404 (not an empty
         # forecast with samples_used=0).
-        with db.get_cursor() as cur:
+        with db.get_read_cursor() as cur:
             cur.execute("SELECT 1 FROM sources WHERE id = ?", (source_id,))
             if not cur.fetchone():
                 raise HTTPException(404, "source bulunamadi")
@@ -6192,7 +6195,7 @@ def create_app(db, config, analytics=None, ad_lookup=None, email_notifier=None,
         if not fc_cfg["enabled"]:
             raise HTTPException(404, "forecast.enabled=false")
 
-        with db.get_cursor() as cur:
+        with db.get_read_cursor() as cur:
             cur.execute(
                 "SELECT id, name FROM sources WHERE id = ?", (source_id,)
             )

--- a/tests/test_dashboard_readonly_pool.py
+++ b/tests/test_dashboard_readonly_pool.py
@@ -1,0 +1,415 @@
+"""Tests for the read-only connection pool migration (issue #181 Track A).
+
+The dashboard's read endpoints used to share the writer's thread-local
+connection pool. While the scanner held the writer lock, those reads
+piled up behind it and the dashboard would freeze for tens of seconds
+mid-scan.
+
+Track A swaps each read-only call site over to ``Database.get_read_cursor``,
+which opens a *separate* ``mode=ro`` URI connection per call — readers
+no longer contend with the writer.
+
+These tests pin the contract so future refactors can't silently:
+
+* Re-route a read endpoint back through the writer pool.
+* Allow ``get_read_cursor`` to accept DML.
+* Leak file descriptors on the per-call connection lifecycle.
+* Block the writer-checkpointer with a stale read snapshot.
+
+Test list (≥8):
+
+1. ``get_read_cursor`` raises ``OperationalError`` on INSERT.
+2. ``get_read_cursor`` succeeds on SELECT.
+3. Mid-scan: writer holds a 5s transaction, reader still <1s.
+4. Mid-bulk-insert: 10k-row writer, reader still <1s.
+5. WAL: read cursor doesn't block ``PRAGMA wal_checkpoint(TRUNCATE)``.
+6. Per-call cleanup: 100 read cursors, no FD leak (Linux only).
+7. ``dict_factory`` rows look identical to the writer-pool cursor.
+8. Endpoint smoke test: ``GET /api/sources`` returns 200 while a
+   ``scan_runs`` row sits in 'running' state (mimics live scan).
+"""
+
+from __future__ import annotations
+
+import os
+import sqlite3
+import sys
+import threading
+import time
+
+import pytest
+
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if REPO_ROOT not in sys.path:
+    sys.path.insert(0, REPO_ROOT)
+
+from src.storage.database import Database  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def db(tmp_path):
+    """Fresh on-disk SQLite Database with one source row seeded."""
+    db_path = tmp_path / "ro_pool.db"
+    database = Database({"path": str(db_path)})
+    database.connect()
+    with database.get_cursor() as cur:
+        cur.execute(
+            "INSERT INTO sources(name, unc_path) VALUES(?, ?)",
+            ("share1", "\\\\fs\\share1"),
+        )
+    yield database
+    try:
+        database.close()
+    except Exception:
+        pass
+
+
+# ---------------------------------------------------------------------------
+# Stubs for the endpoint smoke test
+# ---------------------------------------------------------------------------
+
+
+class _StubAnalytics:
+    available = False
+
+    def health(self):
+        return {"available": False, "configured": False}
+
+    def close(self):  # pragma: no cover - defensive
+        pass
+
+
+class _StubADLookup:
+    available = False
+
+    def lookup(self, name, force_refresh=False):
+        return {"username": name, "email": None, "display_name": None,
+                "found": False, "source": "live"}
+
+    def health(self):
+        return {"available": False, "configured": False}
+
+
+class _StubEmailNotifier:
+    available = False
+
+    def send(self, *a, **kw):
+        return False
+
+    def health(self):
+        return {"available": False, "configured": False}
+
+
+def _make_config():
+    return {
+        "dashboard": {"auth": {"enabled": False}},
+        "archiving": {"enabled": False, "dry_run": True},
+        "audit": {"chain_enabled": False},
+        "database": {},
+        "analytics": {},
+        "security": {
+            "ransomware": {
+                "enabled": False,
+                "rename_velocity_threshold": 50,
+                "rename_velocity_window": 60,
+                "deletion_velocity_threshold": 100,
+                "deletion_velocity_window": 60,
+                "risky_new_extensions": [],
+                "canary_file_names": [],
+                "auto_kill_session": False,
+                "notification_email": "",
+            },
+            "orphan_sid": {"enabled": False, "cache_ttl_minutes": 60},
+        },
+        "backup": {"enabled": False, "dir": "/tmp/_no_backups",
+                   "keep_last_n": 1, "keep_weekly": 0},
+        "integrations": {"syslog": {"enabled": False}},
+    }
+
+
+# ---------------------------------------------------------------------------
+# 1) Read-only enforcement
+# ---------------------------------------------------------------------------
+
+
+def test_get_read_cursor_rejects_insert(db):
+    """Any DML on a read cursor must raise ``OperationalError``.
+
+    SQLite's ``mode=ro`` URI parameter is the enforcement layer; we want
+    a hard failure, not a silent no-op, so the caller never thinks a
+    write succeeded.
+    """
+    with db.get_read_cursor() as cur:
+        with pytest.raises(sqlite3.OperationalError):
+            cur.execute(
+                "INSERT INTO sources(name, unc_path) VALUES(?, ?)",
+                ("rogue", "\\\\evil\\share"),
+            )
+
+
+def test_get_read_cursor_allows_select(db):
+    """SELECT succeeds and returns the seeded source row."""
+    with db.get_read_cursor() as cur:
+        cur.execute("SELECT id, name FROM sources WHERE name=?", ("share1",))
+        row = cur.fetchone()
+    assert row is not None
+    assert row["name"] == "share1"
+
+
+# ---------------------------------------------------------------------------
+# 2) No contention with the writer lock
+# ---------------------------------------------------------------------------
+
+
+def test_read_cursor_not_blocked_by_writer_transaction(db):
+    """A 5s writer transaction must not block a parallel read.
+
+    Simulates the scanner pattern: BEGIN IMMEDIATE on the writer
+    connection, hold for 5 seconds, then commit. Meanwhile a separate
+    thread runs a SELECT through ``get_read_cursor`` — that SELECT must
+    return in well under a second.
+    """
+    writer_done = threading.Event()
+    writer_started = threading.Event()
+
+    def _hold_writer():
+        # Use the thread-local writer pool the same way the scanner does.
+        conn = db._get_conn()
+        try:
+            conn.execute("BEGIN IMMEDIATE")
+            conn.execute(
+                "INSERT INTO sources(name, unc_path) VALUES(?, ?)",
+                ("writer_held", "\\\\fs\\hold"),
+            )
+            writer_started.set()
+            time.sleep(5.0)
+            conn.rollback()
+        finally:
+            writer_done.set()
+
+    t = threading.Thread(target=_hold_writer, daemon=True)
+    t.start()
+    assert writer_started.wait(timeout=2.0), "writer thread didn't start"
+
+    # Reader should NOT wait for the writer to finish.
+    t0 = time.perf_counter()
+    with db.get_read_cursor() as cur:
+        cur.execute("SELECT COUNT(*) AS cnt FROM sources")
+        row = cur.fetchone()
+    elapsed = time.perf_counter() - t0
+
+    assert row is not None
+    assert elapsed < 1.0, (
+        f"reader was blocked by writer ({elapsed:.2f}s); "
+        "the read-only pool should bypass the writer lock"
+    )
+
+    t.join(timeout=10.0)
+    assert writer_done.is_set()
+
+
+def test_read_cursor_not_blocked_by_bulk_insert(db):
+    """While a 10k-row bulk_insert_scanned_files is running, a separate
+    ``get_read_cursor`` SELECT must still return promptly.
+
+    Repeats the pattern of the previous test but with a realistic write
+    payload — proves the no-contention guarantee under the same kind of
+    load the scanner generates in production.
+    """
+    # Need a scan_runs row first; foreign-key linkage makes the bulk
+    # insert realistic.
+    with db.get_cursor() as cur:
+        cur.execute(
+            "INSERT INTO scan_runs(source_id, status) VALUES(?, 'running')",
+            (1,),
+        )
+        scan_id = cur.lastrowid
+
+    payload = [
+        {
+            "source_id": 1,
+            "scan_id": scan_id,
+            "file_path": f"/test/file_{i}.bin",
+            "relative_path": f"file_{i}.bin",
+            "file_name": f"file_{i}.bin",
+            "extension": "bin",
+            "file_size": 1024 + i,
+            "creation_time": "2026-01-01 00:00:00",
+            "last_access_time": "2026-01-01 00:00:00",
+            "last_modify_time": "2026-01-01 00:00:00",
+            "owner": "tester",
+            "attributes": "",
+        }
+        for i in range(10_000)
+    ]
+
+    insert_done = threading.Event()
+
+    def _bulk_insert():
+        try:
+            db.bulk_insert_scanned_files(payload)
+        finally:
+            insert_done.set()
+
+    t = threading.Thread(target=_bulk_insert, daemon=True)
+    t.start()
+    # Give the writer a brief head start so it's mid-flight when we read.
+    time.sleep(0.05)
+
+    t0 = time.perf_counter()
+    with db.get_read_cursor() as cur:
+        cur.execute("SELECT id FROM sources LIMIT 1")
+        row = cur.fetchone()
+    elapsed = time.perf_counter() - t0
+
+    assert row is not None
+    assert elapsed < 1.0, (
+        f"reader blocked by bulk insert ({elapsed:.2f}s)"
+    )
+
+    t.join(timeout=30.0)
+    assert insert_done.is_set()
+
+
+# ---------------------------------------------------------------------------
+# 3) WAL behaviour
+# ---------------------------------------------------------------------------
+
+
+def test_wal_checkpoint_truncate_after_read(db):
+    """After a read cursor closes, ``PRAGMA wal_checkpoint(TRUNCATE)``
+    must succeed (returns ``(0, ...)``, not ``(1, ...)``).
+
+    A ``(1, ...)`` return means the checkpointer hit a busy reader and
+    couldn't reset the WAL — which would mean ``get_read_cursor`` is
+    leaking a long-lived connection. The contract is that the connection
+    is closed in the ``finally`` branch of the context manager.
+    """
+    # Hold a read cursor briefly, then close it, then checkpoint.
+    with db.get_read_cursor() as cur:
+        cur.execute("SELECT 1")
+        cur.fetchone()
+        time.sleep(2.0)
+    # cursor + connection are now closed.
+
+    conn = db._get_conn()
+    cur = conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+    res = cur.fetchone()
+    # SQLite returns (busy, log_pages, checkpointed_pages). Busy=0 means
+    # no reader/writer was holding the WAL hostage.
+    if isinstance(res, dict):
+        busy = list(res.values())[0]
+    else:
+        busy = res[0]
+    assert busy == 0, f"WAL checkpoint blocked (busy={busy}); read cursor leaked"
+
+
+# ---------------------------------------------------------------------------
+# 4) Per-call cleanup — no FD leak
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(
+    sys.platform.startswith("win"),
+    reason="num_fds() is POSIX-only; Windows uses num_handles() with very different semantics",
+)
+def test_no_fd_leak_across_100_calls(db):
+    """Open 100 read cursors back-to-back and assert the process FD count
+    is stable. Catches the regression where ``get_read_cursor`` forgets
+    to close its connection.
+    """
+    psutil = pytest.importorskip("psutil")
+    proc = psutil.Process()
+
+    # Warmup — first call may open shared cache / other transient FDs.
+    for _ in range(5):
+        with db.get_read_cursor() as cur:
+            cur.execute("SELECT 1")
+            cur.fetchone()
+
+    before = proc.num_fds()
+    for _ in range(100):
+        with db.get_read_cursor() as cur:
+            cur.execute("SELECT id FROM sources")
+            cur.fetchall()
+    after = proc.num_fds()
+
+    # Allow tiny slack for unrelated FDs (logging, etc) — anything above
+    # ~10 means the per-call connection isn't being closed.
+    assert after - before <= 10, (
+        f"FD leak: before={before} after={after} delta={after - before}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 5) Row shape parity with the writer-pool cursor
+# ---------------------------------------------------------------------------
+
+
+def test_dict_factory_parity_with_writer_cursor(db):
+    """Rows from ``get_read_cursor`` must look identical to rows from
+    ``get_cursor`` — same dict shape, same column-name lookup. Otherwise
+    every migrated endpoint silently breaks its frontend contract.
+    """
+    with db.get_cursor() as cur:
+        cur.execute("SELECT id, name, unc_path FROM sources WHERE name=?", ("share1",))
+        writer_row = cur.fetchone()
+
+    with db.get_read_cursor() as cur:
+        cur.execute("SELECT id, name, unc_path FROM sources WHERE name=?", ("share1",))
+        reader_row = cur.fetchone()
+
+    assert isinstance(writer_row, dict), (
+        "writer cursor must yield dicts (dict_factory contract)"
+    )
+    assert isinstance(reader_row, dict), (
+        "read cursor must yield dicts too"
+    )
+    assert reader_row["name"] == writer_row["name"]
+    assert reader_row["unc_path"] == writer_row["unc_path"]
+    assert reader_row["id"] == writer_row["id"]
+    # Same key set, no surprise extras.
+    assert set(reader_row.keys()) == set(writer_row.keys())
+
+
+# ---------------------------------------------------------------------------
+# 6) Endpoint smoke — GET /api/sources during a "scan in progress"
+# ---------------------------------------------------------------------------
+
+
+def test_endpoint_get_sources_succeeds_during_running_scan(db):
+    """``GET /api/sources`` must 200 even with a 'running' scan_runs row
+    — the migrated read-only path doesn't acquire the writer lock so a
+    live scan can't block it.
+    """
+    fastapi_testclient = pytest.importorskip("fastapi.testclient")
+    TestClient = fastapi_testclient.TestClient
+
+    # Fake "scan in progress" so the read path has to skip past
+    # uncommitted writer state.
+    with db.get_cursor() as cur:
+        cur.execute(
+            "INSERT INTO scan_runs(source_id, status) VALUES(?, 'running')",
+            (1,),
+        )
+
+    from src.dashboard.api import create_app
+    app = create_app(
+        db=db,
+        config=_make_config(),
+        analytics=_StubAnalytics(),
+        ad_lookup=_StubADLookup(),
+        email_notifier=_StubEmailNotifier(),
+    )
+    client = TestClient(app)
+
+    resp = client.get("/api/sources")
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert isinstance(body, list)
+    assert any(item.get("name") == "share1" for item in body), body


### PR DESCRIPTION
## Summary

Track A of issue #181 — migrates 24 read-only dashboard cursor sites in `src/dashboard/api.py` from `Database.get_cursor` (thread-local writer pool) to `Database.get_read_cursor` (per-call `mode=ro` URI connection).

Why: the writer pool serializes against the scanner's WAL writer lock, which caused dashboard reads to stall for tens of seconds during a live scan. `get_read_cursor` opens a separate read-only handle that gets its own WAL snapshot and never contends with the writer.

Scope: pure connection-source swap. No SQL changes. No schema changes. No behaviour changes for endpoints that legitimately write.

## Migration audit

| Line | Endpoint | Verdict | Reason |
| ---- | -------- | ------- | ------ |
| 766  | (already migrated) | migrated | issue #132 baseline |
| 824  | `GET /api/dashboard/init` | kept | UPDATE scan_runs cache fix inside with-block |
| 2049 | `GET /api/reports/mit-naming/{id}` | migrated | SELECT-only |
| 2091 | `GET /api/reports/mit-naming/{id}/files` | migrated | SELECT-only |
| 2140 | `GET /api/reports/mit-naming/{id}/export` | migrated | SELECT-only |
| 2263 | `GET /api/reports/mit-naming/{id}/export.xlsx` | migrated | SELECT stream |
| 2469 | `GET /api/risk-score/{id}` | migrated | SELECT-only |
| 2546 | `GET /api/trend/{id}` | migrated | SELECT-only |
| 2793 | `GET /api/quarantine` | migrated | SELECT-only |
| 2970 | `POST /api/archive/selective` | migrated | cursor block SELECT-only (writes via engine) |
| 3037 | `POST /api/archive/by-insight` | migrated | cursor block SELECT-only (writes via engine) |
| 3490 | `GET /api/notifications/log` | migrated | SELECT-only |
| 3857 | `_export_worker` (mit_naming branch) | migrated | SELECT-only |
| 3900 | `_export_worker` (duplicates branch) | migrated | SELECT-only |
| 3932 | `_export_worker` (full branch) | migrated | SELECT-only |
| 3984 | `POST /api/export/start` | migrated | cursor block SELECT-only |
| 4074 | `POST /api/security/ransomware/alerts/{id}/acknowledge` | kept | UPDATE ransomware_alerts |
| 4222 | `POST /api/security/acl/scan/{id}` | migrated | cursor block SELECT-only |
| 4342 | `GET /api/security/orphan-sids/{id}/export.csv` | migrated | SELECT stream |
| 4471 | `GET /api/security/image-duplicates` | migrated | SELECT-only |
| 4528 | `GET /api/security/image-duplicates/export.xlsx` | migrated | SELECT-only |
| 4627 | `POST /api/security/ransomware/alerts/acknowledge-all` | kept | UPDATE ransomware_alerts |
| 4747 | `GET /api/security/extension-anomalies` | migrated | SELECT-only |
| 5204 | `GET /api/compliance/pii/findings` | migrated | SELECT-only |
| 5315 | `GET /api/compliance/pii/findings/export.xlsx` | migrated | SELECT stream |
| 6077 | `_scan_history_for` (helper for forecast) | migrated | SELECT-only |
| 6141 | `GET /api/forecast/{id}` | migrated | SELECT-only |
| 6195 | `GET /api/forecast/{id}/export.xlsx` | migrated | SELECT-only |

Post-migration counts in `src/dashboard/api.py`:

* `db.get_cursor`      → 3  (writers, all 3 do UPDATE)
* `db.get_read_cursor` → 25 (24 newly-migrated + 1 baseline)

The single kept GET endpoint (`/api/dashboard/init`) writes a cache fix-up UPDATE inside the same with-block; an inline comment now documents that for future migrators. The two kept POST endpoints (ransomware acknowledge / acknowledge-all) need no comment per the spec.

## New tests — `tests/test_dashboard_readonly_pool.py`

8 tests pinning the read-only-pool contract:

1. `get_read_cursor` raises `OperationalError` on `INSERT INTO sources`.
2. `get_read_cursor` succeeds on `SELECT FROM sources`.
3. Reader < 1s while a writer thread holds a 5-second `BEGIN IMMEDIATE`.
4. Reader < 1s during a 10k-row `bulk_insert_scanned_files`.
5. `PRAGMA wal_checkpoint(TRUNCATE)` returns `busy=0` after a read cursor closes.
6. 100 sequential read cursors don't leak FDs (Linux only via `psutil`; skips elsewhere).
7. Read-cursor rows have the same dict shape as writer-cursor rows.
8. `GET /api/sources` returns 200 with a 'running' `scan_runs` row in flight.

## Test plan

- [x] `python -m pytest tests/test_dashboard_readonly_pool.py -v` — 7 passed, 1 skipped (FD-leak skip is correct: `psutil` not installed in the test container)
- [x] `python -m pytest tests/ --ignore=tests/test_elasticsearch_backend.py -q` — 614 passed, 7 skipped, 8 known pre-existing failures (`test_button_audit`, `test_image_hash` x3, `test_mft_progress` x4 — all unrelated to this change)
- [x] `grep -nE "db\.get_cursor\b" src/dashboard/api.py | wc -l` → 3 (writers only)
- [x] `grep -nE "db\.get_read_cursor\b" src/dashboard/api.py | wc -l` → 25 (read-only)
- [x] Sum = 28 = 27 original `get_cursor` + 1 baseline `get_read_cursor` ✓

## Out of scope

- Track B1 (partial summary v2) — separate subagent.
- Track B2 (frontend page integration) — separate Copilot agent.
- Changing `Database.get_cursor` itself — writer pool untouched.

Closes part of #181 (Track A).

https://claude.ai/code/session_01A1UzS1A4DZNk1akoP4uhZ7

---
_Generated by [Claude Code](https://claude.ai/code/session_01A1UzS1A4DZNk1akoP4uhZ7)_