### PR TITLE
ci: Docker-based reproducible test infrastructure (#91 Phase 1+3)

### DIFF
--- a/tests/test_docker_smoke.py
+++ b/tests/test_docker_smoke.py
@@ -1,0 +1,99 @@
+"""Sanity tests for the Docker test image (issue #91, Phase 1+3).
+
+These tests don't exercise application code — they're a tripwire that
+fails loud if the test runner image (``docker/Dockerfile.test``) drifts
+out from under us. Concrete failures they catch:
+
+* Required runtime dep missing from ``requirements.txt`` *and* the image
+  (e.g. ``duckdb`` or ``pyarrow`` accidentally dropped during a refactor).
+* Optional accel dep silently uninstallable on the slim base — surfaces
+  as a *skip* in CI output, not a hard failure, so we still merge but
+  the operator sees the regression in the PR check log.
+* Python interpreter accidentally bumped off 3.11 — the rest of the
+  toolchain (PyInstaller spec, deploy scripts) still pins 3.11, so a
+  silent bump would split prod and CI environments.
+
+Runs unchanged on the host-runner pytest path too. The file is named
+``test_docker_smoke.py`` because the *image* is what's under test, not
+because it must run inside Docker — host runs are equally valid and
+catch dep drift on developer workstations.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+
+import pytest
+
+
+# ----------------------------------------------------------------------
+# Required runtime deps — listed in requirements.txt, must always import.
+# A failure here means the image (or the host venv) is missing a package
+# the application core actually needs at runtime, so we hard-fail.
+# ----------------------------------------------------------------------
+REQUIRED_PACKAGES = [
+    "sqlite3",   # stdlib — sanity check that the python build isn't broken
+    "duckdb",    # analytics engine
+    "pyarrow",   # parquet staging for fast bulk ingest
+    "yaml",      # config loader (PyYAML)
+    "click",     # CLI entrypoint
+    "fastapi",   # dashboard
+    "uvicorn",   # ASGI server
+]
+
+
+# ----------------------------------------------------------------------
+# Optional packages — gated by feature flags / pytest.importorskip in the
+# real test suite. We only verify they're *importable* if installed; if
+# they're absent (e.g. hyperscan on a glibc that PyPI doesn't ship a
+# wheel for) we record a skip so the CI log shows the gap without
+# turning the build red.
+# ----------------------------------------------------------------------
+OPTIONAL_PACKAGES = [
+    "watchdog",      # event-driven scanner (issue #14)
+    "magic",         # python-magic — wrong-extension detection (issue #144)
+    "imagehash",     # perceptual image hashing (issue #144 phase 2)
+    "hyperscan",     # PII regex engine (issue #64) — Linux x86_64 only
+    "ldap3",         # AD lookup
+    "openpyxl",      # xlsx reports
+    "reportlab",     # pdf reports
+    "apscheduler",   # scheduling
+]
+
+
+@pytest.mark.parametrize("name", REQUIRED_PACKAGES)
+def test_required_package_importable(name: str) -> None:
+    """Required runtime deps must import cleanly."""
+    importlib.import_module(name)
+
+
+@pytest.mark.parametrize("name", OPTIONAL_PACKAGES)
+def test_optional_package_importable_or_skipped(name: str) -> None:
+    """Optional deps either import or get skipped — never error."""
+    try:
+        importlib.import_module(name)
+    except ImportError as exc:
+        pytest.skip(f"optional dep {name!r} not installed: {exc}")
+
+
+def test_python_version_is_3_11() -> None:
+    """Stay on 3.11 to match the production deploy + PyInstaller spec.
+
+    Bumping the Python minor version requires a coordinated update to
+    ``deploy/setup-source.ps1`` (which auto-installs Python on Windows)
+    and ``file_activity.spec`` (which bakes the interpreter into the EXE
+    release). Splitting CI off from those would mean prod ships against
+    one runtime and the test suite validates against another — which is
+    exactly the failure mode this image is supposed to *prevent*.
+    """
+    assert sys.version_info[:2] == (3, 11), (
+        f"expected Python 3.11.x in the test image, got "
+        f"{sys.version_info.major}.{sys.version_info.minor}"
+    )
+
+
+def test_pytest_importable() -> None:
+    """The runner itself must be importable — guards against a broken
+    requirements-dev.txt install layer in the Dockerfile."""
+    import pytest as _pytest  # noqa: F401  -- import is the assertion


### PR DESCRIPTION
## What was failing on master CI

Every PR in recent history (verified across PRs #163, #164, #167, #168, #169, #176, #178, #179, #182, #183, #184, #186) hit the same two CI failures, even though master itself was green:

- **Python syntax check** flaked on `pip install` / `actions/setup-python` cache layer.
- **Pytest (Linux, Docker)** Docker build failed during dependency install.

The pattern was always the same: PR runs hit infra flake before pytest could even collect tests. Nothing to do with the code under review.

## How #91 fixes it

Phase 1 (image + compose + wrapper) and Phase 3 (CI integration) collapse the failure surface area by baking the test environment into a `python:3.11-slim`-based image where dependency resolution is a build-time concern, not a per-CI-run concern. Buildx routes layers through `type=gha` so warm runs skip pip entirely; cold runs build once and cache for everything downstream.

Phase 1 (commit 07152f6) and Phase 3 (commit 89779f5) already shipped to master before this PR opened. What was still missing from the issue spec was item #7 — a sanity test that exercises the image itself.

## Summary

This PR adds **`tests/test_docker_smoke.py`**:

- `REQUIRED_PACKAGES` — `sqlite3`, `duckdb`, `pyarrow`, `yaml`, `click`, `fastapi`, `uvicorn`. Must import. If `requirements.txt` ever drops one of these in a refactor, this catches it before the dashboard 500s.
- `OPTIONAL_PACKAGES` — `watchdog`, `magic`, `imagehash`, `hyperscan`, `ldap3`, `openpyxl`, `reportlab`, `apscheduler`. Must either import or skip cleanly — Hyperscan in particular doesn't have a manylinux wheel for every glibc, and the skip surfaces the gap in CI output without turning the build red.
- `test_python_version_is_3_11` — pins the interpreter against `file_activity.spec` (PyInstaller) and `deploy/setup-source.ps1` (Windows auto-install) so prod and CI can't silently drift onto different minor versions.
- `test_pytest_importable` — guards the `requirements-dev.txt` layer in the Dockerfile.

Runs unchanged on the host pytest path too: `python -m pytest tests/test_docker_smoke.py` is 15 passed / 2 skipped on a stock workstation, which is the expected behaviour.

## Existing infra (already on master)

Confirmed in place — left untouched:

| Path | Purpose |
| ---- | ------- |
| `docker/Dockerfile.test` | `python:3.11-slim` + `libhyperscan-dev` + `libpcre3-dev` + `build-essential`. `pywin32` filtered out before install. Optional accel/MCP layers are best-effort. |
| `docker/docker-compose.test.yml` | `pytest` service, bind-mounts repo, image tag `fa-test:latest`. |
| `scripts/run-tests.sh` | POSIX-bash wrapper, `--no-build` / `--shell` flags, propagates pytest exit code. |
| `.dockerignore` | Mirrors `.gitignore` + dev caches; keeps build context small. |
| `.github/workflows/ci.yml` | `tests` job builds with `docker/build-push-action@v5`, `cache-from: type=gha`, `cache-to: type=gha,mode=max`, `load: true`. Currently `continue-on-error: true` — flip to false after 3 consecutive green master runs. |
| `README.md` § "Local Testing with Docker" | Quick-start docs. |
| `docker/README.md` | Full reference. |

## Test plan

- [x] `python -m pytest tests/test_docker_smoke.py -v` on the host: 15 passed, 2 skipped (`magic`, `imagehash` not installed locally), 0 failed.
- [ ] CI build green: image builds against `python:3.11-slim`, smoke test runs inside the container as part of `tests/`.
- [ ] CI cache hit on the second push: Buildx reports cache hit on the dep layers, build completes in <30s warm.
- [ ] Optional skips visible in CI output (hyperscan / python-magic / imagehash) — these are expected on the slim image and documented.

Closes #91 Phase 1+3.

https://claude.ai/code/session_01A1UzS1A4DZNk1akoP4uhZ7

---
_Generated by [Claude Code](https://claude.ai/code/session_01A1UzS1A4DZNk1akoP4uhZ7)_