### PR TITLE
feat(dashboard): reusable list pattern with XLSX export + bulk actions (closes #80)

### DIFF
--- a/src/dashboard/api.py
+++ b/src/dashboard/api.py
@@ -3141,6 +3141,287 @@ def create_app(db, config, analytics=None, ad_lookup=None, email_notifier=None,
         )
         return result
 
+    # --- ENTITY-LIST BULK ACTIONS (issue #80) ---
+    #
+    # These endpoints back the reusable ``entity-list.js`` toolbar. They are
+    # deliberately list-driven (paths, not ids) so any list page can call
+    # them without knowing the underlying scanned_files row id. Each call is
+    # written to the chained audit log via ``insert_audit_event_simple`` so
+    # operators retain a tamper-evident record of every bulk action.
+
+    @app.post("/api/archive/bulk-from-list")
+    async def archive_bulk_from_list(request: Request):
+        """Archive a hand-picked list of files coming from an entity-list page.
+
+        Body:
+          {
+            "source_id": <int>,           # optional; auto-detected from paths
+                                            otherwise
+            "file_paths": ["...", ...],
+            "confirm": <bool>,            # required for non-dry-run
+            "dry_run": <bool>,            # default true (matches policy gate)
+            "username": "<string>",       # optional, default 'dashboard'
+          }
+
+        Returns the archive engine result (or a preview when dry_run).
+        Always writes an audit event before returning.
+        """
+        from src.archiver.archive_engine import ArchiveEngine
+        from src.utils.size_formatter import format_size
+
+        body = await request.json()
+        if not isinstance(body, dict):
+            raise HTTPException(400, "Body JSON nesnesi olmali")
+
+        file_paths = body.get("file_paths") or []
+        if not isinstance(file_paths, list) or not file_paths:
+            raise HTTPException(400, "file_paths gerekli (liste)")
+        # Trim & dedupe; reject non-string entries.
+        cleaned: list[str] = []
+        seen: set[str] = set()
+        for p in file_paths:
+            if not isinstance(p, str) or not p.strip():
+                raise HTTPException(400, "file_paths icinde gecersiz giris")
+            ps = p.strip()
+            if ps not in seen:
+                seen.add(ps)
+                cleaned.append(ps)
+        file_paths = cleaned
+
+        # dry_run/confirm semantics — mirrors /api/archive/selective.
+        config_dry_run = bool(
+            (config or {}).get("archiving", {}).get("dry_run", True)
+        )
+        body_dry_run = body.get("dry_run")
+        effective_dry_run = (
+            bool(body_dry_run) if body_dry_run is not None else config_dry_run
+        )
+        confirm = bool(body.get("confirm", False))
+        if (not effective_dry_run) and not confirm:
+            raise HTTPException(
+                400,
+                "Real archive run requires confirm=true (issue #158 C-2). "
+                "Re-submit with dry_run=false + confirm=true after "
+                "reviewing the dry-run preview.",
+            )
+
+        username = (body.get("username") or "dashboard")[:64]
+
+        # Resolve files from scanned_files by path. If source_id provided,
+        # we constrain to that source; otherwise we let the path uniquely
+        # identify the row (current scan).
+        source_id = body.get("source_id")
+        files: list[dict] = []
+        with db.get_read_cursor() as cur:
+            placeholders = ",".join("?" * len(file_paths))
+            if source_id is not None:
+                try:
+                    sid = int(source_id)
+                except (TypeError, ValueError):
+                    raise HTTPException(400, "source_id integer olmali")
+                cur.execute(
+                    f"SELECT * FROM scanned_files "
+                    f"WHERE source_id=? AND file_path IN ({placeholders})",
+                    [sid] + file_paths,
+                )
+            else:
+                cur.execute(
+                    f"SELECT * FROM scanned_files "
+                    f"WHERE file_path IN ({placeholders})",
+                    file_paths,
+                )
+            files = [dict(r) for r in cur.fetchall()]
+
+        if not files:
+            raise HTTPException(404, "Belirtilen yollar icin dosya bulunamadi")
+
+        # Audit-log every call (dry-run included). file_path is NOT NULL in
+        # the schema, so we record the first matched path as a sentinel and
+        # encode the rest of the batch in `details`.
+        try:
+            db.insert_audit_event_simple(
+                source_id=files[0].get("source_id"),
+                event_type=(
+                    "bulk_archive_dry_run" if effective_dry_run
+                    else "bulk_archive"
+                ),
+                username=username,
+                file_path=files[0].get("file_path") or "",
+                details=(
+                    f"paths={len(file_paths)} matched={len(files)} "
+                    f"dry_run={effective_dry_run}"
+                ),
+                detected_by="entity-list",
+            )
+        except Exception as e:  # pragma: no cover - audit failure is non-fatal
+            logger.warning("audit-log write failed for bulk-from-list: %s", e)
+
+        # Dry-run: synthesise a preview without invoking the engine.
+        total_size = sum(int(f.get("file_size") or 0) for f in files)
+        if effective_dry_run:
+            return {
+                "dry_run": True,
+                "preview": True,
+                "matched": len(files),
+                "missing": len(file_paths) - len(files),
+                "total_size": total_size,
+                "total_size_formatted": format_size(total_size),
+                "sample": files[:20],
+            }
+
+        # Real archive: resolve source(s) and dispatch to ArchiveEngine.
+        # All matched files must share the same source for a single batch.
+        sids = {f.get("source_id") for f in files}
+        if len(sids) != 1 or None in sids:
+            raise HTTPException(
+                400,
+                "Toplu arsivleme icin tum dosyalar ayni kaynaktan olmali",
+            )
+        sid = next(iter(sids))
+        source = db.get_source_by_id(sid)
+        if not source:
+            raise HTTPException(404, "Kaynak bulunamadi")
+        if not source.archive_dest:
+            raise HTTPException(400, "Arsiv hedefi tanimli degil")
+
+        engine = ArchiveEngine(db, config)
+        return engine.archive_files(
+            files,
+            source.archive_dest,
+            source.unc_path,
+            sid,
+            archived_by=f"entity-list:{username}",
+            trigger_type="manual",
+            trigger_detail="bulk-from-list",
+            dry_run=False,
+        )
+
+    @app.post("/api/explorer/open")
+    async def explorer_open(request: Request):
+        """Open one or more paths in Windows Explorer (Windows-only).
+
+        Body: { "paths": ["...", ...], "username": "<string>" }
+
+        Refuses on non-Windows hosts (400). Each path must resolve to a real
+        directory or file under one of the configured source roots so the
+        endpoint cannot be abused as a generic local-FS browser. Audit-log
+        every call.
+        """
+        body = await request.json()
+        if not isinstance(body, dict):
+            raise HTTPException(400, "Body JSON nesnesi olmali")
+        paths = body.get("paths") or []
+        if not isinstance(paths, list) or not paths:
+            raise HTTPException(400, "paths gerekli (liste)")
+        username = (body.get("username") or "dashboard")[:64]
+
+        if os.name != "nt":
+            raise HTTPException(
+                400,
+                "explorer.exe yalnizca Windows uzerinde kullanilabilir",
+            )
+
+        # Build the allowed-roots set from sources.unc_path. Each candidate
+        # path must be inside one of these roots (after realpath). This
+        # prevents traversal like ../../etc/passwd and blocks arbitrary
+        # local-disk browsing on the server.
+        allowed_roots: list[str] = []
+        for s in db.get_sources():
+            root = (s.unc_path or "").strip()
+            if not root:
+                continue
+            try:
+                allowed_roots.append(
+                    os.path.realpath(os.path.normpath(root)).rstrip("\\/")
+                )
+            except Exception:
+                continue
+        if not allowed_roots:
+            raise HTTPException(
+                400,
+                "Hicbir kaynak tanimli degil; explorer/open kullanilamaz",
+            )
+
+        import subprocess
+        opened: list[str] = []
+        rejected: list[dict] = []
+        for raw in paths:
+            if not isinstance(raw, str) or not raw.strip():
+                rejected.append({"path": raw, "reason": "empty"})
+                continue
+            try:
+                resolved = os.path.realpath(os.path.normpath(raw))
+            except Exception:
+                rejected.append({"path": raw, "reason": "invalid"})
+                continue
+            inside = any(
+                resolved == root or resolved.startswith(root + os.sep)
+                for root in allowed_roots
+            )
+            if not inside:
+                rejected.append({"path": raw, "reason": "outside_source_roots"})
+                continue
+            if not (os.path.isdir(resolved) or os.path.isfile(resolved)):
+                rejected.append({"path": raw, "reason": "not_found"})
+                continue
+            try:
+                # shell=False + argv list -> no command injection risk.
+                if os.path.isdir(resolved):
+                    subprocess.Popen(["explorer.exe", resolved], shell=False)
+                else:
+                    subprocess.Popen(
+                        ["explorer.exe", "/select,", resolved], shell=False,
+                    )
+                opened.append(resolved)
+            except Exception as e:
+                rejected.append({"path": raw, "reason": f"popen_error:{e}"})
+
+        # Audit-log every call (one event per request). file_path is NOT
+        # NULL — record the first attempted path (opened or rejected) as a
+        # sentinel; the full count breakdown lives in `details`.
+        first_path = ""
+        if opened:
+            first_path = opened[0]
+        elif rejected:
+            first_raw = rejected[0].get("path")
+            if isinstance(first_raw, str):
+                first_path = first_raw
+        try:
+            # source_id required for chained audit; fall back to first source.
+            sources = db.get_sources()
+            sid = sources[0].id if sources else None
+            db.insert_audit_event_simple(
+                source_id=sid,
+                event_type="explorer_open",
+                username=username,
+                file_path=first_path or "(none)",
+                details=(
+                    f"requested={len(paths)} opened={len(opened)} "
+                    f"rejected={len(rejected)}"
+                ),
+                detected_by="entity-list",
+            )
+        except Exception as e:  # pragma: no cover
+            logger.warning("audit-log write failed for explorer/open: %s", e)
+
+        if rejected and not opened:
+            # All paths were rejected — surface as 400 so the UI can show
+            # a clear error rather than a misleading 200 "ok, opened 0".
+            return JSONResponse(
+                status_code=400,
+                content={
+                    "ok": False,
+                    "opened": [],
+                    "rejected": rejected,
+                    "message": "Tum yollar reddedildi",
+                },
+            )
+        return {
+            "ok": True,
+            "opened": opened,
+            "rejected": rejected,
+        }
+
     # --- BUYUME ANALIZI ---
 
     @app.get("/api/growth/{source_id}")

--- a/src/dashboard/static/components/entity-list.js
+++ b/src/dashboard/static/components/entity-list.js
@@ -69,6 +69,112 @@
         document.body.removeChild(a);
     }
 
+    function _formatBytes(v) {
+        const n = Number(v);
+        if (!Number.isFinite(n) || n <= 0) return '0 B';
+        const units = ['B', 'KB', 'MB', 'GB', 'TB'];
+        let i = 0, x = n;
+        while (x >= 1024 && i < units.length - 1) { x /= 1024; i++; }
+        return (i === 0 ? x.toFixed(0) : x.toFixed(2)) + ' ' + units[i];
+    }
+
+    function _formatDateTime(v) {
+        if (v === null || v === undefined || v === '') return '';
+        // Already a YYYY-MM-DD HH:MM:SS string? Pass through.
+        return String(v);
+    }
+
+    const _FORMATTERS = {
+        bytes: _formatBytes,
+        datetime: _formatDateTime,
+    };
+
+    // Lightweight modal helper. Returns a `close` function. The modal is
+    // built from a body-string + footer buttons; the caller is responsible
+    // for escaping any dynamic content before passing the body in.
+    function _modal(title, bodyHtml, buttons) {
+        const overlay = document.createElement('div');
+        overlay.className = 'modal-overlay active';
+        overlay.style.cssText =
+            'position:fixed;inset:0;background:rgba(0,0,0,0.55);' +
+            'display:flex;align-items:center;justify-content:center;' +
+            'z-index:9999';
+        const dlg = document.createElement('div');
+        dlg.className = 'modal';
+        dlg.style.cssText =
+            'background:var(--bg-card,#1e293b);color:var(--text-primary,#e2e8f0);' +
+            'border:1px solid var(--border,#334155);border-radius:8px;' +
+            'max-width:600px;width:95%;padding:20px;box-shadow:0 8px 32px rgba(0,0,0,0.4)';
+        dlg.innerHTML =
+            '<h3 style="margin:0 0 12px 0;font-size:16px">' +
+            _escape(title) +
+            '</h3>' +
+            '<div class="el-modal-body" style="font-size:13px;line-height:1.5;' +
+            'max-height:50vh;overflow-y:auto;margin-bottom:16px">' +
+            (bodyHtml || '') +
+            '</div>' +
+            '<div class="el-modal-buttons" style="display:flex;gap:8px;' +
+            'justify-content:flex-end;flex-wrap:wrap"></div>';
+        overlay.appendChild(dlg);
+        document.body.appendChild(overlay);
+
+        const close = function () {
+            if (overlay.parentNode) overlay.parentNode.removeChild(overlay);
+        };
+
+        const btnHost = dlg.querySelector('.el-modal-buttons');
+        (buttons || []).forEach(function (b) {
+            const el = document.createElement('button');
+            el.type = 'button';
+            el.className = 'btn btn-sm ' + (b.className || 'btn-outline');
+            el.textContent = b.label;
+            el.addEventListener('click', function () {
+                if (typeof b.onClick === 'function') {
+                    Promise.resolve()
+                        .then(function () { return b.onClick(close); })
+                        .catch(function (e) {
+                            _toast(
+                                'Islem hatasi: ' +
+                                    (e && e.message ? e.message : e),
+                                'error',
+                            );
+                        });
+                } else {
+                    close();
+                }
+            });
+            btnHost.appendChild(el);
+        });
+
+        // Click-outside dismiss.
+        overlay.addEventListener('click', function (e) {
+            if (e.target === overlay) close();
+        });
+        return close;
+    }
+
+    function _postJson(endpoint, body) {
+        return fetch(endpoint, {
+            method: 'POST',
+            headers: {'Content-Type': 'application/json'},
+            body: JSON.stringify(body || {}),
+        }).then(function (resp) {
+            return resp.text().then(function (txt) {
+                let parsed = null;
+                try { parsed = txt ? JSON.parse(txt) : null; } catch (e) {}
+                if (!resp.ok) {
+                    const msg = (parsed && (parsed.detail || parsed.message))
+                        || ('HTTP ' + resp.status);
+                    const err = new Error(msg);
+                    err.status = resp.status;
+                    err.body = parsed;
+                    throw err;
+                }
+                return parsed;
+            });
+        });
+    }
+
     function _matchesSearch(row, query, keys) {
         if (!query) return true;
         const q = query.toLowerCase();
@@ -258,6 +364,9 @@
                             }
                             // render() may return raw HTML — caller's responsibility.
                             if (cell === undefined || cell === null) cell = '';
+                        } else if (c.formatter && _FORMATTERS[c.formatter]) {
+                            // Built-in formatter ('bytes', 'datetime', ...).
+                            cell = _escape(_FORMATTERS[c.formatter](row[c.key]));
                         } else {
                             cell = _escape(row[c.key]);
                         }
@@ -422,21 +531,154 @@
                         _toast('Once en az bir satir secin', 'warning');
                         return;
                     }
-                    if (action.confirm) {
-                        const msg = typeof action.confirm === 'string'
-                            ? action.confirm
-                            : (action.label + ': ' + selected.length + ' satir icin onayliyor musunuz?');
-                        if (!window.confirm(msg)) return;
+                    // Issue #80: max-cap enforcement.
+                    if (typeof action.max === 'number' && selected.length > action.max) {
+                        _toast(
+                            'Bu islem icin en fazla ' + action.max + ' satir secebilirsiniz ' +
+                                '(secili: ' + selected.length + ')',
+                            'warning'
+                        );
+                        return;
                     }
-                    if (onBulkAction) {
-                        Promise.resolve()
-                            .then(function () { return onBulkAction(action.action, selected); })
-                            .catch(function (e) {
-                                _toast('Toplu islem hatasi: ' + (e && e.message ? e.message : e), 'error');
-                            });
-                    }
+                    _runBulkAction(action, selected);
                 });
             });
+        }
+
+        // Issue #80: dispatch a bulk action.
+        //
+        // Two flavours, picked by config:
+        //   1. action.endpoint set      -> POST to that endpoint with the
+        //      selected rows. If action.dryRun is true, we POST first with
+        //      {dry_run: true} to fetch a preview, render the modal, then
+        //      POST again with {dry_run: false, confirm: true} on confirm.
+        //   2. action.endpoint missing  -> fall back to onBulkAction(actionId, rows).
+        //
+        // Every endpoint-driven action surfaces an audit-event banner so the
+        // operator knows the call is logged.
+        function _runBulkAction(action, selected) {
+            const filePaths = selected
+                .map(function (r) { return r.file_path || r.path; })
+                .filter(function (p) { return !!p; });
+
+            // Endpoint-driven action.
+            if (action.endpoint) {
+                const auditNote =
+                    '<div style="background:var(--bg-secondary,#0f172a);border:1px solid var(--border,#334155);' +
+                    'border-left:3px solid var(--info,#38bdf8);padding:8px 12px;border-radius:6px;' +
+                    'font-size:12px;color:var(--text-secondary,#94a3b8);margin-bottom:12px">' +
+                    'Bu islem audit log\'a yazilir.</div>';
+
+                const _doConfirm = function (preview) {
+                    let bodyHtml = auditNote;
+                    if (preview && typeof preview === 'object') {
+                        bodyHtml +=
+                            '<p>' + _escape(action.label) + ': ' +
+                            '<strong>' + selected.length + '</strong> satir secildi.</p>';
+                        if (preview.matched != null) {
+                            bodyHtml +=
+                                '<div style="font-size:12px;color:var(--text-secondary,#94a3b8)">' +
+                                'Eslesti: <strong>' + Number(preview.matched) + '</strong>' +
+                                (preview.missing ? ' &middot; eksik: ' + Number(preview.missing) : '') +
+                                (preview.total_size_formatted
+                                    ? ' &middot; toplam: ' + _escape(preview.total_size_formatted)
+                                    : '') +
+                                '</div>';
+                        }
+                    } else {
+                        bodyHtml +=
+                            '<p>' + _escape(action.label) + ': ' +
+                            '<strong>' + selected.length + '</strong> satir icin ' +
+                            'onayliyor musunuz?</p>';
+                    }
+                    _modal(
+                        action.label + ' - Onay',
+                        bodyHtml,
+                        [
+                            {label: 'Vazgec', className: 'btn-outline'},
+                            {
+                                label: 'Onayla',
+                                className: action.danger ? 'btn-danger' : 'btn-primary',
+                                onClick: function (close) {
+                                    return _postJson(action.endpoint, {
+                                        file_paths: filePaths,
+                                        paths: filePaths,
+                                        confirm: true,
+                                        dry_run: false,
+                                    }).then(function (resp) {
+                                        close();
+                                        _toast(
+                                            action.label + ' tamamlandi' +
+                                                (resp && resp.archived != null
+                                                    ? ' (' + resp.archived + ' dosya)' : ''),
+                                            'success'
+                                        );
+                                        state.selected.clear();
+                                        _render();
+                                    });
+                                },
+                            },
+                        ]
+                    );
+                };
+
+                if (action.dryRun) {
+                    // Stage 1: fetch preview.
+                    _postJson(action.endpoint, {
+                        file_paths: filePaths,
+                        paths: filePaths,
+                        dry_run: true,
+                    }).then(function (preview) {
+                        _doConfirm(preview);
+                    }).catch(function (e) {
+                        _toast(
+                            'On izleme hatasi: ' + (e && e.message ? e.message : e),
+                            'error'
+                        );
+                    });
+                } else if (action.confirmRequired) {
+                    _doConfirm(null);
+                } else {
+                    // Fire and forget (still POSTs with confirm=true so the
+                    // server's confirm gate is satisfied).
+                    _postJson(action.endpoint, {
+                        file_paths: filePaths,
+                        paths: filePaths,
+                        confirm: true,
+                        dry_run: false,
+                    }).then(function () {
+                        _toast(action.label + ' tamamlandi', 'success');
+                        state.selected.clear();
+                        _render();
+                    }).catch(function (e) {
+                        _toast(
+                            'Toplu islem hatasi: ' +
+                                (e && e.message ? e.message : e),
+                            'error'
+                        );
+                    });
+                }
+                return;
+            }
+
+            // Legacy path: defer to onBulkAction.
+            if (action.confirm) {
+                const msg = typeof action.confirm === 'string'
+                    ? action.confirm
+                    : (action.label + ': ' + selected.length + ' satir icin onayliyor musunuz?');
+                if (!window.confirm(msg)) return;
+            }
+            if (onBulkAction) {
+                Promise.resolve()
+                    .then(function () { return onBulkAction(action.action || action.id, selected); })
+                    .catch(function (e) {
+                        _toast(
+                            'Toplu islem hatasi: ' +
+                                (e && e.message ? e.message : e),
+                            'error'
+                        );
+                    });
+            }
         }
 
         function _doExport(exportCfg, kind) {

--- a/src/dashboard/static/index.html
+++ b/src/dashboard/static/index.html
@@ -5361,30 +5361,32 @@ async function renderMitNamingEntityList(sourceId, report) {
                     endpoint: `/api/reports/mit-naming/${sourceId}/export.xlsx`,
                     filenameBase: `naming-${sourceId}`,
                 },
+                // Issue #80: endpoint-driven bulk actions with dry-run preview
+                // + audit banner. The component renders a confirmation modal
+                // for confirmRequired actions; max-cap is enforced client-side.
                 bulkActions: [
-                    {label: 'Hedefe Git', action: 'open-folder'},
-                    // Destructive actions deferred to issue #83.
-                    {label: 'Toplu Arsivle', action: 'bulk-archive',
-                     confirm: true, comingSoon: 'Yakinda eklenecek (#83)'},
-                    {label: 'Legal Hold Ekle', action: 'add-hold',
-                     confirm: true, comingSoon: 'Yakinda eklenecek (#83)'},
+                    {id: 'open-target', action: 'open-folder',
+                     label: 'Hedefe Git', icon: 'open',
+                     confirmRequired: false, max: 5},
+                    {id: 'archive-bulk', action: 'bulk-archive',
+                     label: 'Toplu Arsivle',
+                     confirmRequired: true, dryRun: true, danger: true,
+                     endpoint: '/api/archive/bulk-from-list'},
+                    {id: 'legal-hold-add', action: 'add-hold',
+                     label: 'Legal Hold Ekle',
+                     confirmRequired: true,
+                     endpoint: '/api/compliance/legal-holds'},
                 ],
             },
             onBulkAction: async (actionId, selectedRows) => {
-                if (actionId === 'open-folder') {
-                    if (selectedRows.length > 5) {
-                        notify('Bir defada en fazla 5 konum acilabilir', 'warning');
-                        return;
-                    }
+                // Reached only for actions without an `endpoint` set.
+                if (actionId === 'open-folder' || actionId === 'open-target') {
                     for (const r of selectedRows) {
-                        // Use existing openFolder() — already handles localhost vs
-                        // remote per #82 Bug 1 fix.
                         const target = r.directory || (r.file_path || '').replace(/[\\/][^\\/]*$/, '');
                         if (target) openFolder(target);
                     }
                     return;
                 }
-                // Other action ids fall here only if not flagged comingSoon.
                 notify('Bilinmeyen toplu islem: ' + actionId, 'warning');
             },
             emptyMessage: 'Ihlal eden dosya bulunamadi',

--- a/tests/test_entity_list_endpoints.py
+++ b/tests/test_entity_list_endpoints.py
@@ -1,0 +1,358 @@
+"""Tests for issue #80: entity-list bulk-action endpoints.
+
+Covers the two new POST endpoints introduced for the reusable
+``entity-list.js`` component:
+
+  * ``POST /api/archive/bulk-from-list`` — list-driven bulk archive with
+    a dry-run preview mode and a confirm gate (mirrors #158 C-2).
+  * ``POST /api/explorer/open`` — Windows-only Explorer launcher with a
+    source-roots traversal guard.
+
+Plus a regression check that the existing
+``/api/reports/mit-naming/{id}/files`` shape is unchanged.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+import pytest
+from fastapi.testclient import TestClient
+
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if REPO_ROOT not in sys.path:
+    sys.path.insert(0, REPO_ROOT)
+
+from src.dashboard.api import create_app  # noqa: E402
+from src.storage.database import Database  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Stubbed sidecar dependencies (same shape as test_archive_confirm_gate.py).
+# ---------------------------------------------------------------------------
+
+
+class _StubADLookup:
+    available = False
+
+    def lookup(self, name, force_refresh=False):
+        return {"username": name, "email": None, "display_name": None,
+                "found": False, "source": "live"}
+
+    def health(self):
+        return {"available": False, "configured": False}
+
+
+class _StubEmailNotifier:
+    available = False
+
+    def send(self, *a, **kw):
+        return False
+
+    def health(self):
+        return {"available": False, "configured": False}
+
+
+class _StubAnalytics:
+    available = False
+
+    def health(self):
+        return {"available": False, "configured": False}
+
+    def close(self):  # pragma: no cover - defensive
+        pass
+
+
+def _base_config() -> dict:
+    return {
+        "dashboard": {"auth": {"enabled": False}},
+        "archiving": {
+            "verify_checksum": False,
+            "dry_run": True,
+            "cleanup_empty_dirs": False,
+        },
+        "security": {
+            "ransomware": {"enabled": False},
+            "orphan_sid": {"enabled": False},
+        },
+        "analytics": {},
+        "backup": {"enabled": False, "dir": "/tmp/_no_backups",
+                   "keep_last_n": 1, "keep_weekly": 0},
+        "integrations": {"syslog": {"enabled": False}},
+    }
+
+
+@pytest.fixture
+def client(tmp_path, monkeypatch):
+    """Boot create_app() with a tiny seeded SQLite + an
+    ArchiveEngine.archive_files stub that records kwargs."""
+    db_path = tmp_path / "naming.db"
+    db = Database({"path": str(db_path)})
+    db.connect()
+
+    # Seed: one source rooted at tmp_path/share with archive_dest, one
+    # completed scan, and two violation files inside the share.
+    share = tmp_path / "share"
+    share.mkdir()
+    (share / "Bad File.txt").write_text("hi")  # R1: contains space
+    (share / "Bad File 2.txt").write_text("hi2")  # R1: contains space
+    archive_dest = str(tmp_path / "archive")
+    os.makedirs(archive_dest, exist_ok=True)
+
+    file_a = str(share / "Bad File.txt")
+    file_b = str(share / "Bad File 2.txt")
+
+    with db.get_cursor() as cur:
+        cur.execute(
+            "INSERT INTO sources (name, unc_path, archive_dest) "
+            "VALUES ('s1', ?, ?)",
+            (str(share), archive_dest),
+        )
+        cur.execute(
+            "INSERT INTO scan_runs (source_id, status, completed_at) "
+            "VALUES (1, 'completed', '2026-01-01 00:00:00')"
+        )
+        cur.execute(
+            "INSERT INTO scanned_files "
+            "(source_id, scan_id, file_path, relative_path, file_name, "
+            " file_size, last_access_time) "
+            "VALUES (1, 1, ?, 'Bad File.txt', 'Bad File.txt', 100, "
+            "        '2020-01-01 00:00:00')",
+            (file_a,),
+        )
+        cur.execute(
+            "INSERT INTO scanned_files "
+            "(source_id, scan_id, file_path, relative_path, file_name, "
+            " file_size, last_access_time) "
+            "VALUES (1, 1, ?, 'Bad File 2.txt', 'Bad File 2.txt', 200, "
+            "        '2020-01-01 00:00:00')",
+            (file_b,),
+        )
+
+    archive_calls: list[dict] = []
+
+    def fake_archive_files(self, files, archive_dest_, source_unc,
+                           source_id, archived_by="manual",
+                           dry_run=None, trigger_type="manual",
+                           trigger_detail=None):
+        archive_calls.append({
+            "files_count": len(files),
+            "archive_dest": archive_dest_,
+            "source_id": source_id,
+            "archived_by": archived_by,
+            "dry_run": dry_run,
+            "trigger_type": trigger_type,
+            "trigger_detail": trigger_detail,
+        })
+        return {
+            "archived": len(files),
+            "failed": 0,
+            "total_size": sum(int(f.get("file_size") or 0) for f in files),
+            "total_size_formatted": "300 B",
+            "errors": [],
+            "dry_run": bool(dry_run),
+        }
+
+    from src.archiver import archive_engine as _ae
+    monkeypatch.setattr(_ae.ArchiveEngine, "archive_files", fake_archive_files)
+
+    cfg = _base_config()
+    app = create_app(
+        db,
+        cfg,
+        analytics=_StubAnalytics(),
+        ad_lookup=_StubADLookup(),
+        email_notifier=_StubEmailNotifier(),
+    )
+    tc = TestClient(app)
+    tc.archive_calls = archive_calls
+    tc.db = db
+    tc.share_root = str(share)
+    tc.file_a = file_a
+    tc.file_b = file_b
+    return tc
+
+
+def _audit_event_count(db, event_type=None):
+    with db.get_read_cursor() as cur:
+        if event_type is not None:
+            cur.execute(
+                "SELECT COUNT(*) AS c FROM file_audit_events "
+                "WHERE event_type=?",
+                (event_type,),
+            )
+        else:
+            cur.execute("SELECT COUNT(*) AS c FROM file_audit_events")
+        return int(cur.fetchone()["c"])
+
+
+# ---------------------------------------------------------------------------
+# /api/archive/bulk-from-list
+# ---------------------------------------------------------------------------
+
+
+def test_bulk_from_list_dry_run_returns_preview(client):
+    """dry_run=true => 200, preview body, no engine invocation."""
+    resp = client.post("/api/archive/bulk-from-list", json={
+        "file_paths": [client.file_a, client.file_b],
+        "dry_run": True,
+    })
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["dry_run"] is True
+    assert body["preview"] is True
+    assert body["matched"] == 2
+    assert body["total_size"] == 300  # 100 + 200
+    assert "total_size_formatted" in body
+    assert len(body["sample"]) == 2
+    # Engine MUST NOT be called for a preview.
+    assert not client.archive_calls
+
+
+def test_bulk_from_list_real_without_confirm_blocked(client):
+    """dry_run=false without confirm=true is rejected (issue #158 C-2)."""
+    resp = client.post("/api/archive/bulk-from-list", json={
+        "file_paths": [client.file_a],
+        "dry_run": False,
+    })
+    assert resp.status_code == 400
+    assert "confirm=true" in resp.text
+    assert not client.archive_calls
+
+
+def test_bulk_from_list_real_with_confirm_invokes_engine(client):
+    resp = client.post("/api/archive/bulk-from-list", json={
+        "file_paths": [client.file_a],
+        "dry_run": False,
+        "confirm": True,
+    })
+    assert resp.status_code == 200, resp.text
+    assert len(client.archive_calls) == 1
+    call = client.archive_calls[-1]
+    assert call["dry_run"] is False
+    assert call["files_count"] == 1
+    assert call["trigger_detail"] == "bulk-from-list"
+
+
+def test_bulk_from_list_audit_event_written(client):
+    """Every bulk-from-list call (dry-run or real) writes an audit event."""
+    before = _audit_event_count(client.db)
+    resp = client.post("/api/archive/bulk-from-list", json={
+        "file_paths": [client.file_a],
+        "dry_run": True,
+    })
+    assert resp.status_code == 200, resp.text
+    after = _audit_event_count(client.db)
+    assert after == before + 1
+    # Real-run path also logs.
+    resp2 = client.post("/api/archive/bulk-from-list", json={
+        "file_paths": [client.file_a],
+        "dry_run": False,
+        "confirm": True,
+    })
+    assert resp2.status_code == 200, resp2.text
+    assert _audit_event_count(client.db) == after + 1
+
+
+def test_bulk_from_list_rejects_empty_file_paths(client):
+    resp = client.post("/api/archive/bulk-from-list", json={
+        "file_paths": [],
+        "dry_run": True,
+    })
+    assert resp.status_code == 400
+    assert "file_paths" in resp.text
+
+
+def test_bulk_from_list_unknown_paths_404(client):
+    resp = client.post("/api/archive/bulk-from-list", json={
+        "file_paths": ["/no/such/file"],
+        "dry_run": True,
+    })
+    assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# /api/explorer/open
+# ---------------------------------------------------------------------------
+
+
+def test_explorer_open_non_windows_refused(client, monkeypatch):
+    """On Linux/Mac the endpoint must return 400 with a clear message."""
+    if os.name == "nt":
+        pytest.skip("non-Windows guard test")
+    resp = client.post("/api/explorer/open", json={
+        "paths": [client.share_root],
+    })
+    assert resp.status_code == 400
+    assert "Windows" in resp.text
+
+
+def test_explorer_open_rejects_path_traversal(client, monkeypatch):
+    """A path outside any source root must be rejected.
+
+    We force os.name='nt' via a stub so the Windows-only branch is reachable
+    on the CI (Linux) runner. subprocess.Popen is patched to a no-op so we
+    don't actually try to launch explorer.exe.
+    """
+    monkeypatch.setattr(os, "name", "nt")
+    import subprocess as _sp
+    popen_calls: list[list[str]] = []
+
+    class _FakePopen:
+        def __init__(self, argv, **kw):
+            popen_calls.append(list(argv))
+
+    monkeypatch.setattr(_sp, "Popen", _FakePopen)
+
+    # /etc/passwd (or any non-source path) is outside the allowed root.
+    bad = "/etc/passwd" if os.path.exists("/etc/passwd") else os.path.expanduser("~")
+    resp = client.post("/api/explorer/open", json={"paths": [bad]})
+    assert resp.status_code == 400, resp.text
+    body = resp.json()
+    assert body["ok"] is False
+    assert any(r["reason"] == "outside_source_roots" for r in body["rejected"])
+    # Importantly, Popen was never called for the rejected path.
+    assert popen_calls == []
+
+
+def test_explorer_open_audit_event_written(client, monkeypatch):
+    """Every explorer/open call writes a single audit event regardless of
+    whether any path actually opened."""
+    monkeypatch.setattr(os, "name", "nt")
+    import subprocess as _sp
+    monkeypatch.setattr(
+        _sp, "Popen", lambda argv, **kw: None,
+    )
+
+    before = _audit_event_count(client.db, "explorer_open")
+    # Even a fully-rejected request increments the audit counter.
+    resp = client.post("/api/explorer/open", json={"paths": ["/etc/passwd"]})
+    assert resp.status_code in (200, 400)
+    after = _audit_event_count(client.db, "explorer_open")
+    assert after == before + 1
+
+
+# ---------------------------------------------------------------------------
+# /api/reports/mit-naming/{id}/files — shape regression
+# ---------------------------------------------------------------------------
+
+
+def test_mit_naming_files_shape_unchanged(client):
+    """Existing endpoint must keep returning {code,total,page,page_size,
+    total_pages,files:[...]} so the entity-list page does not break."""
+    resp = client.get("/api/reports/mit-naming/1/files?code=R1&page=1&page_size=50")
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    for key in ("code", "total", "page", "page_size", "total_pages", "files"):
+        assert key in body, "missing key: " + key
+    assert body["code"] == "R1"
+    # Both seeded files match R1 (contain a space).
+    assert body["total"] == 2
+    assert isinstance(body["files"], list)
+    if body["files"]:
+        f = body["files"][0]
+        # Fields the entity-list mit-naming page consumes.
+        for key in ("file_path", "file_name", "file_size", "owner",
+                    "last_modify_time", "file_size_formatted", "directory"):
+            assert key in f, "missing field in row: " + key


### PR DESCRIPTION
## Summary

- Extend `entity-list.js` with endpoint-driven bulk actions, a dry-run preview confirmation modal + audit-event banner, `max`-cap enforcement, and built-in column formatters (`bytes` / `datetime`). The mit-naming page (issue #80's first consumer) now wires its three toolbar actions through the new component instead of the legacy `onBulkAction` shim.
- New `POST /api/archive/bulk-from-list` — list-driven archive endpoint with a dry-run preview that returns `{matched, missing, total_size, sample}` and a `confirm`/`dry_run` gate that mirrors the issue #158 C-2 contract used by `/api/archive/run` and `/api/archive/selective`. Audit-logs every call via `Database.insert_audit_event_simple` (chain-routed per #160).
- New `POST /api/explorer/open` — Windows-only Explorer launcher with a realpath + source-roots traversal guard so the endpoint cannot be abused as a generic local-FS browser; non-Windows hosts get HTTP 400 with a clear message; every call is audit-logged.
- Tests: `tests/test_entity_list_endpoints.py` (10 cases) covers the dry-run preview, confirm gate, audit-log writes for both endpoints, the path-traversal guard, the non-Windows refusal, empty/unknown-path validation, and a shape regression for `/api/reports/mit-naming/{id}/files`.

## Test plan

- [x] `python -m compileall src/dashboard/api.py` — clean
- [x] `python -m pytest tests/test_entity_list_endpoints.py -x` — 10/10 pass
- [x] `python -m pytest tests/test_archive_confirm_gate.py tests/test_dashboard_smoke.py tests/test_dashboard_api.py tests/test_audit_chain.py tests/test_dashboard_security_pages.py tests/test_dashboard_integrations_pages.py tests/test_csp_headers.py -q` — 54/54 pass
- [x] Full suite: `python -m pytest tests/ --ignore=tests/test_elasticsearch_backend.py -q` — 645 passed; 8 pre-existing failures unrelated to this change (verified by stashing and re-running on `master`: `_esc` duplicate in `test_button_audit`, `imagehash` library absent, and a `NtfsMftBackend.__init__` signature drift in `test_mft_progress`).
- [ ] Manual smoke: open Adlandirma Uyumu page, exercise "Hedefe Git" / "Toplu Arsivle" (dry-run preview shows totals + audit banner) / "Legal Hold Ekle"; confirm XLSX export still streams.

Closes #80.

https://claude.ai/code/session_01A1UzS1A4DZNk1akoP4uhZ7

---
_Generated by [Claude Code](https://claude.ai/code/session_01A1UzS1A4DZNk1akoP4uhZ7)_