### PR TITLE
fix(dashboard): restore lost loadOverview() declaration — sidebar nav broken

### DIFF
--- a/src/dashboard/static/index.html
+++ b/src/dashboard/static/index.html
@@ -3473,6 +3473,15 @@ function _psv2StopPoll() {
 }
 
 
+// ═══════════════════════════════════════════════════
+// OVERVIEW (Genel Bakis)
+// ═══════════════════════════════════════════════════
+// Issue (post-#192): a previous merge accidentally removed this
+// function's declaration line, leaving the body floating at the top
+// level. Result: SyntaxError on `await loadSources()`, the entire
+// inline script fails to parse, every sidebar menu stops working
+// (customer report 2026-04-28: "menüler arası gezinti yok").
+async function loadOverview() {
     if (!sources.length) await loadSources();
     const sid = document.getElementById('overview-source').value;
 


### PR DESCRIPTION
## CRITICAL HOTFIX

Customer prod (2026-04-28 19:47): "dashboard menüler arası gezinti yok". Sidebar items highlight on click but the page never changes; all KPIs show `--` / `-`.

## Root cause

The body of `async function loadOverview()` was orphaned at the top level — the declaration line went missing in some recent merge. The first statement was:

```js
if (!sources.length) await loadSources();
```

Which raises at parse time:

```
SyntaxError: await is only valid in async functions and the top level bodies of modules
```

The entire inline `<script>` block failed to parse → every onclick handler the sidebar wired up was undefined → **no menu navigation, no data load, no charts**.

## Diagnosis

Extracted the inline script block, ran `node --check`:

```
$ node --check /tmp/script.js
/tmp/script.js:1362
    if (!sources.length) await loadSources();
                         ^^^^^
SyntaxError: await is only valid in async functions...
```

After fix: `node --check` exits 0.

## Fix

Restored the `async function loadOverview() {` declaration before the orphaned body. Also added a comment block citing the customer report so this can't happen silently again.

## Test plan

- [x] `node --check` on extracted script — clean
- [x] Function structure intact (3476 → 3615 body, opening `{` at 3486 / closing `}` at 3624)
- [ ] Customer to pull `update.cmd` and confirm sidebar navigation works

## Customer impact

This fix is a prerequisite for any further dashboard work. Customer should pull as soon as it's merged — current state has zero working menus.

https://claude.ai/code/session_01A1UzS1A4DZNk1akoP4uhZ7

---
_Generated by [Claude Code](https://claude.ai/code/session_01A1UzS1A4DZNk1akoP4uhZ7)_