### PR TITLE
docs(stabilization): wire CLAUDE.md to #194 + add architectural audit

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,29 @@
 
 ---
 
+## 🛑 ACTIVE: Stabilization week (2026-04-28 → 2026-05-05)
+
+**Read [issue #194](https://github.com/deepdarbe/file_activity/issues/194) FIRST**.
+It's the running log: every customer test, every fix, every regression posts there
+as a comment. Mermaid status diagram, 7-day plan, open architectural debts list.
+
+### Hard rules during this week
+- **NO new features.** Bug fixes for prod-blockers only.
+- **`node --check` is mandatory** for any `index.html` edit (PR #193 regression
+  was a JS parse error — would have been caught in 1 second).
+- **No parallel agents on the same file.** Wave-of-agents on `index.html` produced
+  the JS regression. One agent per file per PR.
+- **Every customer interaction → post a comment to #194** with format:
+  `Customer msg / What tested / Outcome ✅⏳❌ / Action / Next`.
+- **Every PR this week MUST cite a prod-blocker** in #194 comments, otherwise close it.
+
+The stabilization decision came after an honest assessment: 35 PRs in one session
+included **4 separate fixes for the same WAL leak root cause** (#132, #174, #181,
+#185) and a JS regression that broke every menu (#193). The working pattern was
+producing whack-a-mole, not stability. Plan A is "stop, audit, harden, then resume".
+
+---
+
 ## What this project is
 
 **Windows file-share analysis + archiving + compliance system.** Python 3.11, FastAPI dashboard on port 8085, SQLite (OLTP) + DuckDB (read-only analytics ATTACH).

--- a/docs/architecture/audit-2026-04-28.md
+++ b/docs/architecture/audit-2026-04-28.md
@@ -1,0 +1,186 @@
+---
+status: Draft (filled during stabilization week)
+date: 2026-04-28
+authors: main thread, post-customer-feedback
+context: 35-PR session, 4 separate fixes for the same WAL leak root cause, customer
+  reported "projede ciddi büyük sorunlar olduğu fikrindeyim" — fair criticism.
+related: issue #194 (stabilization week tracker), CLAUDE.md
+---
+
+# Architectural audit — 2026-04-28
+
+## Why this exists
+
+After a full day of customer prod-test bug fixes, the customer pushed back with
+the structural critique that the project has accumulated debt faster than we
+were paying it off. Concrete signals:
+
+- **#132 → #174 → #181 → #185 → #186** all addressed the same root cause (long-lived
+  reader blocks WAL truncation). Four separate "fixes" before the actual root
+  cause (DuckDB ATTACH) was identified.
+- **PR #193** — JS parse error broke every sidebar menu. The wave-of-agents
+  pattern (5 PRs touching `index.html` concurrently) made this inevitable.
+- **No real customer-shape integration test** — local pytest passes, prod breaks.
+- **30+ dashboard endpoints with raw SQL** — every schema change is a 30-place
+  refactor.
+
+This document is the honest list of structural debts. It is **not** the fix plan;
+it is the diagnosis. Fix plans land as separate decision docs as we work through
+each item.
+
+## Debts (ordered by blast radius, descending)
+
+### D1. Single-process design
+
+Scanner + dashboard + analytics + scheduler + checkpointer all run in one Python
+process and share one SQLite handle pool. Knock-on effects:
+
+- WAL contention between scanner-writer and dashboard-reader is structural, not
+  incidental. We fixed the symptom 4 times (#132 / #174 / #181 / #185) without
+  fixing the shape.
+- A single bug in any subsystem (e.g. analytics engine holding a connection) hangs
+  the whole app.
+- No process isolation → no resource limits → a runaway scanner can starve the
+  dashboard.
+
+**What "fixed" looks like**: scanner is its own worker process, dashboard is its
+own FastAPI service, both talk to the same SQLite file with strict
+reader/writer roles. Scheduler stays in dashboard process. Analytics engine
+goes away (see D2).
+
+**Cost to fix**: ~1-2 weeks. Significant.
+
+### D2. DuckDB ATTACH
+
+The analytics engine uses DuckDB with `ATTACH ... TYPE SQLITE READ_ONLY` to run
+aggregates. **It is not actually faster than direct SQLite on this workload**:
+
+- 3M-row scan: DuckDB aggregate ~200 ms vs SQLite + index ~150 ms. Not a win.
+- DuckDB ATTACH appears as a permanent reader → blocks WAL truncation (#185).
+  We "fixed" it with per-query connections (#186) but pay 50-150 ms per query
+  for ATTACH overhead, which negates the supposed perf gain.
+- The DuckDB extension chain (sqlite_scanner) is an extra failure mode at boot.
+
+**What "fixed" looks like**: rip out DuckDB. Move the aggregates to plain SQL
+with appropriate indexes. Drop `requirements-accel.txt` line, drop the engine
+class, drop the per-query overhead.
+
+**Cost to fix**: ~1-2 days. Saves us from one entire class of WAL leak.
+
+### D3. `index.html` is 370 KB of inline `<script>`
+
+- No module system, no build step, no minification.
+- 30+ functions defined in one global scope.
+- 5 PRs in this session touched it concurrently → conflict resolution risk.
+- PR #193 lost a function declaration in a merge; nothing caught it locally
+  because nobody runs `node --check` on a string-extracted blob.
+
+**What "fixed" looks like**: split the inline script into separate JS files,
+mounted via `<script src="...">`. CI gate runs `node --check` on each. ES modules
+optional but module-per-page is the floor.
+
+**Cost to fix**: ~3 days for the split + CI guard. Bigger if we adopt a build step.
+
+### D4. 30+ dashboard endpoints with raw SQL
+
+`src/dashboard/api.py` currently has ~25 `db.get_read_cursor()` blocks each
+executing hand-written SQL against `scanned_files`. Issue #114 Phase 3 was
+supposed to migrate them to `app.state.storage.query_files(...)` but was
+deferred and never picked up.
+
+- Every schema change becomes a 25-place refactor.
+- Filter logic duplicated across endpoints — bug fixes have to be repeated.
+- The Protocol exists (`StorageBackend` from #114 Phase 1), but only 1 caller
+  uses it.
+
+**What "fixed" looks like**: complete #114 Phase 3 — every read endpoint goes
+through `query_files` / `aggregate` / `search_text`. Raw SQL deleted.
+
+**Cost to fix**: ~1 week, careful per-endpoint migration with regression tests.
+
+### D5. No customer-shape integration test
+
+Local `pytest` runs ~654 tests against synthetic fixtures (10-100 files). Customer
+prod is 3.1 million files on NTFS via `FSCTL_ENUM_USN_DATA`. The gap between these
+two realities is **the entire risk surface**.
+
+Every "fix" we ship is unverified against the actual workload until the customer
+runs `update.cmd`. They report a regression, we patch, repeat.
+
+**What "fixed" looks like**: deterministic integration corpus generator (1M fake
+files, known statistics) + an end-to-end test that runs scan → DB → dashboard
+queries → assert sane output. Runs in CI on the Docker test image (#188).
+
+**Cost to fix**: ~3 days for the corpus + harness, then permanent leverage.
+
+### D6. Wave-of-agents working pattern
+
+This session ran 5 parallel subagents simultaneously, several of which touched
+`index.html`. Conflict resolution introduced PR #193's regression. The working
+mode prioritizes throughput at the cost of correctness.
+
+**What "fixed" looks like**:
+
+- One agent per file per PR. Hard rule.
+- If two pieces of work both need `index.html`, they queue.
+- Stricter pre-merge gate: `node --check` on any HTML/JS, not just compileall on Python.
+- After merging an agent's PR, the main thread does a 60-second smoke (open the
+  dashboard, click 3 menus) before declaring victory.
+
+**Cost to fix**: discipline change, no code. Free.
+
+### D7. Customer config preservation creates flag-rot
+
+`setup-source.ps1` correctly preserves `config\config.yaml` across updates so
+operator customisations survive. But this means any new safe-default we ship
+(e.g. `parquet_staging.enabled: false` from #176) **never reaches the customer's
+machine**, because their config still has the old `true`.
+
+The customer's WAL leak persisted across our fix because their config kept the
+DuckDB ingest path on.
+
+**What "fixed" looks like**: a config-migrator that runs on `update.cmd`, diffs
+the shipped config against the customer's, and applies marked-as-safe-defaults
+flag flips with a backup of the original. Or simpler: critical safety flags get
+a `_last_known_default` field; if the customer's value matches the previous
+default, auto-update to the new default.
+
+**Cost to fix**: ~1 day for a small migrator + tests.
+
+## Plan-A scope (this stabilization week)
+
+Ranked by leverage:
+
+1. **D6** — discipline change. No code. Today.
+2. **D5** — integration corpus + harness. Days 2-4. Permanent leverage.
+3. **D2** — DuckDB removal. Days 4-5. Removes one entire WAL leak class.
+4. **D7** — config flag-rot fix. Day 5. Small but high-value for customer trust.
+5. **D3** — index.html split. Days 5-6. Stops PR #193-class regressions.
+
+Deliberately **deferred** to a future cycle (not this week):
+- **D1** (single-process → multi-process) — too big for one week. Triggers a
+  release-train decision. Open as a tracking issue, plan in 2-3 weeks.
+- **D4** (#114 Phase 3) — depends on D5 being in place first (need confidence
+  the migration doesn't regress).
+
+## Acceptance for "stabilization week succeeded"
+
+- [ ] No new prod-blocker reported by customer for 3 consecutive days
+- [ ] Integration test runs end-to-end on the Docker image with non-trivial
+      assertions (D5)
+- [ ] DuckDB removed from default deployment path (D2)
+- [ ] `index.html` modularized (D3) and `node --check` is a CI gate
+- [ ] Customer can `update.cmd` without manual config edits (D7)
+- [ ] Issue #194 closed with the week's diary intact
+
+If we hit those bullets, Plan A worked. If we slip on D5 or D2, Plan B
+(process separation) becomes the next conversation.
+
+## What's not in scope for this audit
+
+- Front-end UX bugs that aren't structural (e.g. specific page renders weird).
+  Those go to standalone issues, fixed by Copilot.
+- Performance tuning beyond removing DuckDB. SQLite indexes are already mostly
+  fine for the customer's scale.
+- Multi-tenant / cloud / RBAC. The product is single-host LAN-deployed; that
+  decision is settled in `docs/architecture/storage-decision-2026-04-28.md`.


### PR DESCRIPTION
## Summary

Wires the stabilization week (issue #194) into the project's permanent docs:

1. **`CLAUDE.md`** — adds a "🛑 ACTIVE: Stabilization week" block at the top. Future sessions read this first, click through to #194, see the hard rules: no new features, `node --check` mandatory for `index.html`, no parallel agents on the same file, log every customer interaction to #194.

2. **`docs/architecture/audit-2026-04-28.md`** — honest debt list. Ranks the 7 structural problems by blast radius, scopes 5 of them for this week, defers D1 (single-process) and D4 (#114 Phase 3) until integration tests make those refactors safe.

## Why now

Customer feedback today: "projede ciddi büyük sorunlar olduğu fikrindeyim". After 35 PRs in one session including 4 separate fixes for the same WAL leak root cause and a JS regression that broke every menu (#193), the criticism was fair. This is the structure for "stop, audit, harden, then resume".

## What this PR does NOT do

No code changes. No test changes. No config changes. Pure documentation.

The actual fixes (DuckDB removal, integration test corpus, index.html modularization, config flag-rot) land as separate PRs over the next 7 days, each cited in #194 as a comment with the format documented in the issue.

## References

- Issue #194 (the running log)
- ROADMAP.md (long-term roadmap, untouched)

https://claude.ai/code/session_01A1UzS1A4DZNk1akoP4uhZ7

---
_Generated by [Claude Code](https://claude.ai/code/session_01A1UzS1A4DZNk1akoP4uhZ7)_