### PR TITLE
fix(dashboard): add loadPii + loadRetention stubs — sidebar nav crashes

### DIFF
--- a/src/dashboard/static/index.html
+++ b/src/dashboard/static/index.html
@@ -6940,6 +6940,49 @@ function loadStandards() {
 }
 
 // ═══════════════════════════════════════════════════
+// MISSING-PAGE STUBS — issue #194 Update #4 (2026-04-29)
+// ═══════════════════════════════════════════════════
+// The sidebar dispatches via `loaders[pageName]()` (line ~2664). The
+// loaders dict referenced `loadPii` and `loadRetention` for sidebar
+// items wired up earlier, but no implementations ever landed in this
+// file — clicking those menus fired:
+//   Uncaught ReferenceError: loadPii is not defined
+//
+// That single ReferenceError was caught by `showPage` but it bubbled
+// to the console and kept the customer's "menüler arası gezinti yok"
+// experience even after PR #193 fixed the prior parse error.
+//
+// These stubs render a "Yakında" placeholder so the menus don't crash;
+// real implementations belong in the next-cycle backlog (frontend
+// integration wave #81 follow-up).
+function loadPii() {
+    const el = document.getElementById('page-pii');
+    if (!el) return;
+    el.innerHTML = `
+        <div style="padding:32px;text-align:center;color:var(--text-muted)">
+            <div style="font-size:48px;margin-bottom:12px">🔒</div>
+            <h2 style="margin:0 0 8px 0;color:var(--text-primary)">PII Bulgular</h2>
+            <p style="margin:0;font-size:13px">Bu sayfa yakında etkinleştirilecek (issue #81 follow-up).
+            Mevcut PII verisi <a href="/api/compliance/pii/findings" target="_blank">/api/compliance/pii/findings</a> endpoint'inden alınabilir.</p>
+        </div>
+    `;
+}
+
+function loadRetention() {
+    const el = document.getElementById('page-retention');
+    if (!el) return;
+    el.innerHTML = `
+        <div style="padding:32px;text-align:center;color:var(--text-muted)">
+            <div style="font-size:48px;margin-bottom:12px">📅</div>
+            <h2 style="margin:0 0 8px 0;color:var(--text-primary)">Saklama Politikaları</h2>
+            <p style="margin:0;font-size:13px">Bu sayfa yakında etkinleştirilecek (issue #81 follow-up).
+            Saklama hesabı için <a href="javascript:loadRetentionAttestation()">attestation endpoint</a>'i
+            kullanılabilir; tam policy CRUD UI yakında gelecek.</p>
+        </div>
+    `;
+}
+
+// ═══════════════════════════════════════════════════
 // PII SUBJECT EXPORT (GDPR Article 17 / 30)
 // ═══════════════════════════════════════════════════
 function openPiiSubjectModal() {


### PR DESCRIPTION
## CRITICAL HOTFIX (stabilization-week prod-blocker exception)

Customer prod 2026-04-29 00:15 — clicking PII Bulgular or Saklama Politikaları menus crashes:

```
Uncaught ReferenceError: loadPii is not defined
    at showPage((index):2664:657)
```

The error fires repeatedly across menu clicks, putting the customer in the same "diğer sayfalar boş" state as the pre-#193 regression.

## Root cause

`showPage` dispatches via `loaders[pageName]()` (line 2664). The `loaders` dict references `loadPii` and `loadRetention` for sidebar items wired up earlier in the project, but **no implementations ever landed in `index.html`**. Every click on those two menus produced a ReferenceError. The error was caught by the click handler but bubbled to the console and broke the page state.

## Fix

Add stubs for the two missing functions. They render a "Yakında" placeholder pointing operators at the existing API endpoints. Real implementations belong in the #81 frontend integration follow-up — explicitly out of scope for stabilization week.

```js
function loadPii() {
    // ... renders "Yakında" placeholder
}
function loadRetention() {
    // ... renders "Yakında" placeholder
}
```

## Same shape as PR #193

Two console-only regressions in 24 hours that local Python-only CI couldn't catch. PR #193 was a parse error (`await` outside async); this one is a runtime error (referenced symbol never declared). 

CLAUDE.md added `node --check` on `index.html` after #193 — but that catches **parse** errors, not undefined-symbol references (JavaScript happily parses `loaders[x]()` even when `x` doesn't exist).

**Follow-up** (tracked in #194 update #4 to be posted): D6 working-pattern fix adds a one-shot grep guard — "every key in `loaders[...]` must have a matching `function ...` declaration" — before merging anything that touches `index.html`.

## Test plan

- [x] `node --check` on extracted script — clean
- [x] Both `loadPii` and `loadRetention` now defined (grep verified)
- [ ] Customer hard-refresh, click PII Bulgular and Saklama Politikaları — should render "Yakında" placeholder, no console error
- [ ] Other menus also stop crashing (the ReferenceError might have been derailing more than just those 2 pages)

Stabilization-week prod-blocker exception applied. Logging to #194 update #4.

https://claude.ai/code/session_01A1UzS1A4DZNk1akoP4uhZ7

---
_Generated by [Claude Code](https://claude.ai/code/session_01A1UzS1A4DZNk1akoP4uhZ7)_