### PR TITLE
fix(dashboard): /api/risk-score self-heal when summary_json is stale-empty

### DIFF
--- a/src/dashboard/api.py
+++ b/src/dashboard/api.py
@@ -2615,6 +2615,29 @@ def create_app(db, config, analytics=None, ad_lookup=None, email_notifier=None,
 
         # Hizli yol: pre-computed summary varsa oradan hesapla
         kpi = db.get_scan_summary(scan_id)
+        # Issue #194 update #5 — self-heal stale summary_json. Customer
+        # observed Genel Bakis showing TOPLAM DOSYA: 0 while scan_runs
+        # had real totals AND scanned_files clearly populated (Treemap +
+        # Dosya Turleri rendered correctly off the same scan_id). The
+        # cached summary_json was written at a partial moment and never
+        # refreshed. If summary's total_files==0 but the scan_runs row
+        # has non-zero total_files, the cache is stale — bypass it and
+        # fall through to the live SQL path below, which always tells
+        # the truth.
+        if kpi and (kpi.get("total_files") or 0) == 0:
+            with db.get_read_cursor() as _cur:
+                _row = _cur.execute(
+                    "SELECT total_files FROM scan_runs WHERE id=?",
+                    (scan_id,),
+                ).fetchone()
+            if _row and (_row["total_files"] or 0) > 0:
+                logger.info(
+                    "risk_score: summary_json shows total_files=0 but "
+                    "scan_runs.total_files=%d for scan_id=%d — "
+                    "treating cache as stale, falling through",
+                    _row["total_files"], scan_id,
+                )
+                kpi = None
         if kpi:
             total = kpi.get("total_files", 0) or 1
             risky = kpi.get("risky_count", 0)


### PR DESCRIPTION
## Stabilization-week prod-blocker exception

Customer 2026-04-29 00:35 — Genel Bakis renders inconsistent state:
- TOPLAM DOSYA: 0
- TOPLAM BOYUT: 0 B  
- RİSKLİ DOSYALAR: 79

Same source's Treemap shows 144.8 GB .pst + 123.1 GB .ccc; Dosya Turleri lists 10 .pst files, 127 .ccc files, 5,566 .jpg files etc. — `scanned_files` is clearly populated. The 79 in RİSKLİ DOSYALAR proves the cached summary IS being read, but with `total_files=0` cached — structural inconsistency.

## Root cause (probable)

`scan_runs.summary_json` was written at a partial moment — either `compute_scan_summary` was called when `scanned_files` rows for this `scan_id` weren't yet visible (WAL snapshot race), or a prior empty-state summary was never invalidated. The `risky_count=79` was somehow captured later but `total_files` stayed at 0.

This is exactly the kind of scenario D5 (integration test corpus) is designed to catch — write-side timing with read-side cache visibility.

## Fix (this PR — read-side self-heal)

If `summary_json.total_files == 0` BUT `scan_runs.total_files > 0`, treat the cache as stale and fall through to the live SQL path that's already in the function. Live SQL always reflects ground truth.

```python
if kpi and (kpi.get("total_files") or 0) == 0:
    if scan_runs row has non-zero total_files:
        kpi = None  # fall through to live SQL
```

This is intentionally a band-aid, not a real fix. The real fix is finding where `compute_scan_summary` produces inconsistent output. Tracked in #194 audit follow-up.

## Test plan

- [x] `python -m compileall src/dashboard/api.py` clean
- [ ] Customer hard-refresh Genel Bakis → TOPLAM DOSYA shows real count, TOPLAM BOYUT shows real bytes
- [ ] No regression: when summary_json is healthy, fast path still taken (logged when cache treated as stale)

## Linked

- Companion to PR #198 (Erisim Sikligi `freq.forEach` shape fix)
- Both update #5 of stabilization log #194

https://claude.ai/code/session_01A1UzS1A4DZNk1akoP4uhZ7

---
_Generated by [Claude Code](https://claude.ai/code/session_01A1UzS1A4DZNk1akoP4uhZ7)_