### PR TITLE
stabilization week: wave 0-8 close-out (Genel Bakış + crash siperi + CI gates + D7 migrator)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,10 +31,8 @@ jobs:
         run: |
           python -m compileall -q src/ main.py dev_server.py
 
-      - name: YAML config smoke check (catch unresolved merge markers)
+      - name: Conflict-marker grep (catch unresolved merges)
         run: |
-          python -c "import yaml; yaml.safe_load(open('config.yaml'))"
-          # Bare grep guard for stray conflict markers in any tracked text file.
           # Only flag the unambiguous <<<<<<< / >>>>>>> markers — git always
           # emits both, so checking just these is sufficient. The middle
           # ======= marker is dropped because it collides with reStructuredText

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,35 @@ jobs:
             exit 1
           fi
 
+      # Issue #194 stabilization-week Wave 5 — frontend + config CI guards.
+      # ci_guards.py runs five lightweight, deterministic checks that
+      # would have caught today's hotfix regressions (PR #193 / #197 /
+      # #200 / #202) in seconds. Gating because every check is
+      # deterministic — flaky CI cannot misfire here.
+      - name: Frontend + config guards (scripts/ci_guards.py)
+        run: |
+          python scripts/ci_guards.py
+
+      # node --check on the extracted <script> blob inside index.html
+      # would have caught PR #193's JS parse regression in one second.
+      # Uses the system node from setup-node, not a project dep.
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+
+      - name: node --check on extracted dashboard script
+        run: |
+          python -c "
+          import re, sys
+          html = open('src/dashboard/static/index.html').read()
+          scripts = re.findall(r'<script(?![^>]*src=)[^>]*>(.*?)</script>', html, re.DOTALL)
+          if not scripts:
+              print('::error::no inline <script> block found in index.html', file=sys.stderr)
+              sys.exit(1)
+          open('/tmp/extracted.js','w').write('\n//---next-block---\n'.join(scripts))
+          "
+          node --check /tmp/extracted.js
+
       # NOTE: the previous "Import-level smoke test for cross-platform
       # modules" step (pip install duckdb pydantic + heredoc importing
       # AnalyticsEngine) was removed in #68. The new `tests` job below

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,8 +34,13 @@ jobs:
       - name: YAML config smoke check (catch unresolved merge markers)
         run: |
           python -c "import yaml; yaml.safe_load(open('config.yaml'))"
-          # Bare grep guard for stray conflict markers in any tracked text file
-          if grep -RnE '^(<<<<<<< |======= ?$|>>>>>>> )' \
+          # Bare grep guard for stray conflict markers in any tracked text file.
+          # Only flag the unambiguous <<<<<<< / >>>>>>> markers — git always
+          # emits both, so checking just these is sufficient. The middle
+          # ======= marker is dropped because it collides with reStructuredText
+          # heading underlines (e.g. src/compliance/dcat.py:9), which produced
+          # a latent false positive that lived in master from PR #169 onward.
+          if grep -RnE '^(<<<<<<<|>>>>>>>) ' \
               --include='*.py' --include='*.yml' --include='*.yaml' \
               --include='*.md' --include='*.html' --include='*.cmd' \
               --include='*.ps1' --include='*.txt' \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,13 @@ jobs:
           python-version: "3.11"
           cache: pip
 
+      # ci_guards.py imports PyYAML for the D-YAML + S-YAML checks
+      # (duplicate-key detection + compliance schema assertion). The
+      # ubuntu-latest runner Python doesn't ship pyyaml so install
+      # explicitly. Single dep, pip-cache hit on every subsequent run.
+      - name: Install ci_guards deps
+        run: python -m pip install --quiet pyyaml
+
       - name: py_compile across src/ and entry points
         run: |
           python -m compileall -q src/ main.py dev_server.py

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Dashboard: **http://localhost:8085**
 
 ## Dashboard authentication (issue #158)
 
-Since v1.9.0-rc2 the dashboard ships with a **bearer-token gate enabled by default** and binds to **127.0.0.1** unless the operator explicitly opts into a LAN bind. The token never lives in `config.yaml` — it is read from the `FILEACTIVITY_DASHBOARD_TOKEN` environment variable.
+Since v1.9 the dashboard ships with a **bearer-token gate enabled by default** and binds to **127.0.0.1** unless the operator explicitly opts into a LAN bind. The token never lives in `config.yaml` — it is read from the `FILEACTIVITY_DASHBOARD_TOKEN` environment variable.
 
 ### Local single-host install (no token needed)
 

--- a/config.yaml
+++ b/config.yaml
@@ -379,27 +379,6 @@ compliance:
     patterns: {}               # extend DEFAULT_PATTERNS
   retention:
     enabled: false
-
-audit:
-  # Tamper-evident hash-chained audit log (issue #38).
-  # When chain_enabled=true, every audit event written via the
-  # chained variant also appends a row to audit_log_chain whose
-  # row_hash = SHA-256(seq | event_id | prev_hash | canonical(event)).
-  # Verification (GET /api/audit/verify) re-hashes the chain and
-  # detects any retroactive tampering of file_audit_events rows.
-  # Default: false (opt-in, no behaviour change).
-  chain_enabled: false
-  # WORM-storable JSONL exports — point this at a path you can later
-  # promote to write-once storage (S3 Object Lock / Azure Immutable /
-  # ZFS snapshot). Each export = one .jsonl file + optional .sig.
-  worm_export_dir: "data/audit_export"
-  # 7 years for HIPAA-style §164.312(b) audit-control retention.
-  worm_retention_days: 2555
-  # Optional Ed25519 PEM (or raw 32-byte) private key for detached
-  # signatures over the export's SHA-256. Empty = no signing.
-  signing_key_path: ""
-
-compliance:
   # Legal hold registry (issue #59). Glob-tabanli yol donduruculer
   # arsiv / retention / cleanup adimlarinda eslesen yollari atlatir.
   # Hold'lar silinemez — sadece release edilebilir; tum add/release
@@ -423,6 +402,25 @@ compliance:
     # DCAT catalog. Override with an SPDX URL when distributing the
     # catalog externally.
     license_uri: "internal-use"
+
+audit:
+  # Tamper-evident hash-chained audit log (issue #38).
+  # When chain_enabled=true, every audit event written via the
+  # chained variant also appends a row to audit_log_chain whose
+  # row_hash = SHA-256(seq | event_id | prev_hash | canonical(event)).
+  # Verification (GET /api/audit/verify) re-hashes the chain and
+  # detects any retroactive tampering of file_audit_events rows.
+  # Default: false (opt-in, no behaviour change).
+  chain_enabled: false
+  # WORM-storable JSONL exports — point this at a path you can later
+  # promote to write-once storage (S3 Object Lock / Azure Immutable /
+  # ZFS snapshot). Each export = one .jsonl file + optional .sig.
+  worm_export_dir: "data/audit_export"
+  # 7 years for HIPAA-style §164.312(b) audit-control retention.
+  worm_retention_days: 2555
+  # Optional Ed25519 PEM (or raw 32-byte) private key for detached
+  # signatures over the export's SHA-256. Empty = no signing.
+  signing_key_path: ""
 
 approvals:
   # Two-person approval framework (issue #112). Phase 1 wires the

--- a/deploy/auto-update.ps1
+++ b/deploy/auto-update.ps1
@@ -182,9 +182,9 @@ git log --oneline "$localHash..$remoteHash" 2>&1 | ForEach-Object {
 
 # 7. Servisi/dashboard'u durdur
 Write-Log "Dashboard durduruluyor..." "INFO"
-$service = Get-Service -Name "FileActivityService" -ErrorAction SilentlyContinue
+$service = Get-Service -Name "FileActivity" -ErrorAction SilentlyContinue
 if ($service -and $service.Status -eq "Running") {
-    Stop-Service "FileActivityService" -Force -ErrorAction SilentlyContinue
+    Stop-Service "FileActivity" -Force -ErrorAction SilentlyContinue
     Write-Log "Servis durduruldu" "OK"
     $wasService = $true
 } else {
@@ -233,7 +233,7 @@ if ($Mode -eq "exe") {
 # 11. Servisi/dashboard'u yeniden baslat
 Write-Log "Dashboard baslatiliyor..." "INFO"
 if ($wasService) {
-    Start-Service "FileActivityService" -ErrorAction SilentlyContinue
+    Start-Service "FileActivity" -ErrorAction SilentlyContinue
     Write-Log "Servis yeniden baslatildi" "OK"
 } else {
     if ($Mode -eq "source") {

--- a/deploy/setup-source.ps1
+++ b/deploy/setup-source.ps1
@@ -376,6 +376,31 @@ try {
 Remove-Item $zipPath -Force -ErrorAction SilentlyContinue
 Remove-Item $extractPath -Recurse -Force -ErrorAction SilentlyContinue
 
+# --- Config migration (issue #194 Wave 8 / D7) ---
+# setup-source.ps1 preserves the customer's config.yaml across updates so
+# operator customisations survive. But that means any new safe-default we
+# ship (e.g. parquet_staging.enabled: false from PR #174) never reaches
+# the customer's machine — they keep running the old unsafe value.
+# scripts/migrate_config.py flips ONLY keys whose current value matches
+# the documented pre-flip default; any operator-chosen value is left
+# alone. Backup is mandatory before any write.
+$migratorPy   = Join-Path $InstallDir 'scripts\migrate_config.py'
+$customerCfg  = Join-Path $InstallDir 'config\config.yaml'
+if ((Test-Path $migratorPy) -and (Test-Path $customerCfg) -and (Test-Path $venvPy)) {
+    Write-Host ""
+    Write-Host "Config flag-rot migrator (PR #194 / D7)..." -ForegroundColor Yellow
+    try {
+        & $venvPy $migratorPy $customerCfg
+        if ($LASTEXITCODE -eq 0) {
+            Write-Host "  [OK] config migrator basarili" -ForegroundColor Green
+        } else {
+            Write-Host "  [UYARI] config migrator hata kodu $LASTEXITCODE — kontrol edin: $InstallDir\logs\" -ForegroundColor Yellow
+        }
+    } catch {
+        Write-Host "  [UYARI] config migrator calistirilamadi: $_" -ForegroundColor Yellow
+    }
+}
+
 # --- Ozet ---
 Write-Host ""
 Write-Host "  +==========================================+" -ForegroundColor Green

--- a/deploy/update.bat
+++ b/deploy/update.bat
@@ -17,9 +17,9 @@ if errorlevel 1 (
 
 REM 1. Stop service if running
 echo [1/7] Stopping service...
-sc query FileActivityService >nul 2>&1
+sc query FileActivity >nul 2>&1
 if not errorlevel 1 (
-    net stop FileActivityService >nul 2>&1
+    net stop FileActivity >nul 2>&1
     echo   Service stopped.
     set SERVICE_EXISTS=1
 ) else (
@@ -77,7 +77,7 @@ copy /y "update.bat" "%INSTALL_DIR%\update.bat" >nul 2>&1
 REM 7. Restart service or dashboard
 echo [7/7] Starting...
 if "%SERVICE_EXISTS%"=="1" (
-    net start FileActivityService
+    net start FileActivity
     echo   Service restarted.
 ) else (
     echo   No service found. Start manually:

--- a/main.py
+++ b/main.py
@@ -193,7 +193,10 @@ def check_system(ctx):
 @cli.command("version")
 def version():
     """Versiyon bilgisi."""
-    click.echo("FILE ACTIVITY v1.0.0")
+    # Single source of truth — same VERSION file the --version eager
+    # callback reads. The literal "v1.0.0" that used to live here
+    # drifted years past the actual release tag (#194 config audit).
+    click.echo(f"FILE ACTIVITY v{_read_version_string()}")
     click.echo("Windows File Share Analysis & Archiving System")
 
 

--- a/scripts/ci_guards.py
+++ b/scripts/ci_guards.py
@@ -1,0 +1,321 @@
+"""CI guards for FILE_ACTIVITY (issue #194 stabilization week / Wave 5).
+
+A single script bundling the lightweight, deterministic checks that should
+have caught today's hotfix regressions before they shipped:
+
+  * D-YAML  — duplicate-key detection on config.yaml. PyYAML's default
+    loader silently overrides earlier keys; the live ``compliance:``
+    duplicate that dropped PII + retention config slipped through
+    `.github/workflows/ci.yml` because `yaml.safe_load` reported success
+    on a half-loaded document.
+  * S-YAML  — schema assertion: the documented top-level keys exist
+    under ``compliance`` (pii, retention, legal_hold, standards).
+  * LOADERS — every key referenced in the dashboard's ``loaders = {...}``
+    dict has a matching function/const declaration. PR #197's
+    ``loadPii is not defined`` regression.
+  * HTML-BUDGET — the count of raw ``innerHTML =`` writes in
+    index.html must not rise above the checked-in baseline. Forces a
+    reviewer-visible decision before adding to the XSS / null-crash
+    surface (PR #200 / #202 class).
+  * SVC-PARITY — every deploy script that touches the Windows service
+    by name must use the same service name. ``update.bat`` and
+    ``auto-update.ps1`` drifted to ``FileActivityService`` while
+    ``setup-source.ps1`` and ``install_service.ps1`` use
+    ``FileActivity`` — silent no-op when update.bat tries to stop the
+    service.
+
+Each check prints a GitHub Actions ``::error::`` annotation on failure
+and exits the script with a non-zero status. ``--check NAME`` lets the
+workflow run a single check at a time; with no flag every check runs.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+CONFIG_YAML = REPO_ROOT / "config.yaml"
+INDEX_HTML = REPO_ROOT / "src" / "dashboard" / "static" / "index.html"
+
+# innerHTML write count threshold. Baseline captured after Wave 3
+# (2026-05-16) once the highest-impact null-guard sweep landed. New
+# additions are not forbidden but every increase must be approved by a
+# reviewer who has read the audit doc.
+INNERHTML_BUDGET = 180
+
+# Windows service name used by the FileActivity service. Set in
+# install_service.ps1 / setup-source.ps1; the older update.bat and
+# auto-update.ps1 references must agree exactly.
+SERVICE_NAME = "FileActivity"
+
+# Files that name the Windows service in a service-management context
+# (Stop-Service, Start-Service, sc query, net stop/start).
+SVC_PARITY_FILES = [
+    "deploy/setup-source.ps1",
+    "deploy/install_service.ps1",
+    "deploy/uninstall_service.ps1",
+    "deploy/auto-update.ps1",
+    "deploy/update.bat",
+    "deploy/install_tray.ps1",
+]
+
+
+def _err(check: str, msg: str) -> None:
+    """Emit a GitHub Actions error annotation."""
+    print(f"::error title=ci_guards/{check}::{msg}", file=sys.stderr)
+
+
+def _ok(check: str, msg: str) -> None:
+    print(f"[OK] {check}: {msg}")
+
+
+# ---------------------------------------------------------------------------
+# D-YAML — duplicate-key detection
+# ---------------------------------------------------------------------------
+
+
+def _yaml_no_duplicates_loader():
+    """Return a yaml.SafeLoader subclass that raises on duplicate keys.
+
+    PyYAML's default ``construct_mapping`` does not check for duplicates
+    — the later key silently overrides. We override
+    ``construct_mapping`` to track seen keys per mapping node and raise
+    ``yaml.constructor.ConstructorError`` on the first duplicate.
+    """
+    import yaml
+
+    class _NoDupLoader(yaml.SafeLoader):
+        pass
+
+    def _construct_mapping(loader, node, deep=False):
+        mapping = {}
+        for key_node, value_node in node.value:
+            key = loader.construct_object(key_node, deep=deep)
+            if key in mapping:
+                raise yaml.constructor.ConstructorError(
+                    None, None,
+                    f"duplicate key {key!r} (line {key_node.start_mark.line + 1})",
+                    key_node.start_mark,
+                )
+            mapping[key] = loader.construct_object(value_node, deep=deep)
+        return mapping
+
+    _NoDupLoader.add_constructor(
+        yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG,
+        _construct_mapping,
+    )
+    return _NoDupLoader
+
+
+def check_yaml_duplicates() -> bool:
+    try:
+        import yaml
+    except Exception as e:
+        _err("D-YAML", f"PyYAML unavailable: {e}")
+        return False
+    if not CONFIG_YAML.exists():
+        _err("D-YAML", f"{CONFIG_YAML} not found")
+        return False
+    loader_cls = _yaml_no_duplicates_loader()
+    with open(CONFIG_YAML, "r", encoding="utf-8") as f:
+        try:
+            yaml.load(f, Loader=loader_cls)
+        except yaml.constructor.ConstructorError as e:
+            _err("D-YAML", f"config.yaml: {e}")
+            return False
+        except yaml.YAMLError as e:
+            _err("D-YAML", f"config.yaml parse failure: {e}")
+            return False
+    _ok("D-YAML", "config.yaml has no duplicate keys")
+    return True
+
+
+# ---------------------------------------------------------------------------
+# S-YAML — compliance schema assertion
+# ---------------------------------------------------------------------------
+
+
+COMPLIANCE_REQUIRED_KEYS = ("pii", "retention", "legal_hold", "standards")
+
+
+def check_yaml_schema() -> bool:
+    try:
+        import yaml
+    except Exception as e:
+        _err("S-YAML", f"PyYAML unavailable: {e}")
+        return False
+    with open(CONFIG_YAML, "r", encoding="utf-8") as f:
+        cfg = yaml.safe_load(f)
+    if not isinstance(cfg, dict):
+        _err("S-YAML", "config.yaml root is not a mapping")
+        return False
+    compliance = cfg.get("compliance")
+    if not isinstance(compliance, dict):
+        _err("S-YAML", "config.yaml has no top-level 'compliance' mapping")
+        return False
+    missing = [k for k in COMPLIANCE_REQUIRED_KEYS if k not in compliance]
+    if missing:
+        _err(
+            "S-YAML",
+            "compliance section missing required children: "
+            + ", ".join(missing),
+        )
+        return False
+    _ok("S-YAML", "compliance has all required children")
+    return True
+
+
+# ---------------------------------------------------------------------------
+# LOADERS — every loaders = {...} value has a matching declaration
+# ---------------------------------------------------------------------------
+
+
+def check_loaders_consistency() -> bool:
+    if not INDEX_HTML.exists():
+        _err("LOADERS", f"{INDEX_HTML} not found")
+        return False
+    html = INDEX_HTML.read_text(encoding="utf-8")
+    # Find: const loaders = { key: ident, ... } — single-line per the
+    # current shape. Regex matches the dict body lazily up to the
+    # closing }.
+    m = re.search(
+        r"const\s+loaders\s*=\s*\{(?P<body>[^}]*)\}",
+        html,
+    )
+    if not m:
+        _err("LOADERS", "could not find `const loaders = { ... }`")
+        return False
+    body = m.group("body")
+    # Each entry is `key: identifier` (key may be quoted). Extract the
+    # identifier after the colon.
+    pairs = re.findall(
+        r"(?:'[^']+'|\"[^\"]+\"|\w+)\s*:\s*([A-Za-z_$][A-Za-z0-9_$]*)",
+        body,
+    )
+    if not pairs:
+        _err("LOADERS", "loaders dict appears empty")
+        return False
+    missing: list[str] = []
+    for ident in pairs:
+        decl = re.search(
+            rf"\b(?:async\s+)?function\s+{re.escape(ident)}\s*\("
+            rf"|\bconst\s+{re.escape(ident)}\s*="
+            rf"|\blet\s+{re.escape(ident)}\s*="
+            rf"|\bvar\s+{re.escape(ident)}\s*=",
+            html,
+        )
+        if not decl:
+            missing.append(ident)
+    if missing:
+        _err(
+            "LOADERS",
+            "loaders reference undeclared function(s): " + ", ".join(missing),
+        )
+        return False
+    _ok("LOADERS", f"all {len(pairs)} loaders declarations resolve")
+    return True
+
+
+# ---------------------------------------------------------------------------
+# HTML-BUDGET — innerHTML write-site budget
+# ---------------------------------------------------------------------------
+
+
+def check_innerhtml_budget() -> bool:
+    if not INDEX_HTML.exists():
+        _err("HTML-BUDGET", f"{INDEX_HTML} not found")
+        return False
+    html = INDEX_HTML.read_text(encoding="utf-8")
+    # Count assignments to .innerHTML or [innerHTML] across the whole
+    # file. Both stored-ref and direct-chain patterns hit this.
+    count = len(re.findall(r"\.innerHTML\s*=", html))
+    if count > INNERHTML_BUDGET:
+        _err(
+            "HTML-BUDGET",
+            f"index.html has {count} innerHTML writes (budget={INNERHTML_BUDGET}). "
+            "Migrate new writes to _setHtmlSafe / textContent, "
+            "or raise INNERHTML_BUDGET in scripts/ci_guards.py with reviewer "
+            "sign-off.",
+        )
+        return False
+    _ok("HTML-BUDGET", f"{count}/{INNERHTML_BUDGET} innerHTML writes")
+    return True
+
+
+# ---------------------------------------------------------------------------
+# SVC-PARITY — service-name agreement across deploy/*
+# ---------------------------------------------------------------------------
+
+
+# Match Windows service-management call sites where the service NAME
+# argument follows immediately. We're looking for the literal
+# 'FileActivityService' as a misnamed reference; anything matching
+# SERVICE_NAME-prefixed identifiers (FileActivityDashboard, etc.) is fine.
+_BAD_SERVICE_PATTERN = re.compile(
+    r"\b(?:Stop-Service|Start-Service|Get-Service|net\s+(?:stop|start)|sc\s+query"
+    r"|nssm\s+(?:stop|start|install|remove))\b[^\n]*?"
+    r"\"?FileActivityService\b\"?",
+    re.IGNORECASE,
+)
+
+
+def check_service_name_parity() -> bool:
+    offenders: list[tuple[str, int, str]] = []
+    for rel in SVC_PARITY_FILES:
+        path = REPO_ROOT / rel
+        if not path.exists():
+            continue
+        for i, line in enumerate(
+            path.read_text(encoding="utf-8").splitlines(), start=1
+        ):
+            if _BAD_SERVICE_PATTERN.search(line):
+                offenders.append((rel, i, line.strip()))
+    if offenders:
+        for rel, ln, line in offenders:
+            _err(
+                "SVC-PARITY",
+                f"{rel}:{ln} uses 'FileActivityService' but the installed service is "
+                f"named '{SERVICE_NAME}' (install_service.ps1). This is a silent "
+                f"no-op at runtime: {line!r}",
+            )
+        return False
+    _ok("SVC-PARITY", f"service name '{SERVICE_NAME}' consistent across deploy/*")
+    return True
+
+
+# ---------------------------------------------------------------------------
+# Entrypoint
+# ---------------------------------------------------------------------------
+
+
+CHECKS = {
+    "yaml-dup": check_yaml_duplicates,
+    "yaml-schema": check_yaml_schema,
+    "loaders": check_loaders_consistency,
+    "html-budget": check_innerhtml_budget,
+    "svc-parity": check_service_name_parity,
+}
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument(
+        "--check",
+        choices=list(CHECKS.keys()) + ["all"],
+        default="all",
+        help="Run a single check or all (default).",
+    )
+    args = ap.parse_args(argv)
+    if args.check == "all":
+        results = [fn() for fn in CHECKS.values()]
+    else:
+        results = [CHECKS[args.check]()]
+    return 0 if all(results) else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ci_guards.py
+++ b/scripts/ci_guards.py
@@ -32,7 +32,6 @@ workflow run a single check at a time; with no flag every check runs.
 from __future__ import annotations
 
 import argparse
-import os
 import re
 import sys
 from pathlib import Path

--- a/scripts/config_migrations.yaml
+++ b/scripts/config_migrations.yaml
@@ -1,0 +1,54 @@
+# Config migration rules — issue #194 stabilization week / Wave 8 / D7
+#
+# Each rule documents a safe-default flag flip we've shipped where the
+# pre-flip value was unsafe enough that operators should be migrated
+# even if their config.yaml is preserved across updates by
+# setup-source.ps1. The migrator (scripts/migrate_config.py) only
+# touches a key when the customer's CURRENT value equals
+# ``old_default`` — that is the "this looks like the previous shipped
+# default, not an operator customisation" signal. Any other value (an
+# explicit operator choice) is left alone.
+#
+# Format (each entry):
+#   - path:         "dot.separated.yaml.path"
+#     old_default:  <previous shipped value>
+#     new_default:  <current shipped value>
+#     reason:       short string written to the migration log
+#     pr:           "#NNN" of the shipping PR (audit trail)
+
+migrations:
+  # PR #174 — DuckDB ATTACH(READ_WRITE) per flush window deadlocks
+  # against the writer pool on multi-million-row scans. Customer's WAL
+  # leaked to 13+ GB and the scan kept hitting "database is locked".
+  # New default is the executemany path which uses busy_timeout + retry.
+  - path: "scanner.parquet_staging.enabled"
+    old_default: true
+    new_default: false
+    reason: "PR #174 — parquet_staging caused WAL contention + 'database is locked' on multi-million-row scans"
+    pr: "#174"
+
+  # PR #158 H-1 — dashboard previously bound 0.0.0.0:8085 unauth on
+  # every install. Default flipped to loopback + bearer-token gate.
+  - path: "dashboard.host"
+    old_default: "0.0.0.0"
+    new_default: "127.0.0.1"
+    reason: "PR #158 — dashboard now binds loopback by default; operators on a LAN deployment must explicitly set 0.0.0.0"
+    pr: "#158"
+
+  # PR #131 — corruption_check=quick used to open the DB read-only at
+  # startup and run an `integrity_check` that took 60+ seconds on
+  # multi-GB DBs while the service appeared to hang.
+  - path: "backup.corruption_check_mode"
+    old_default: "quick"
+    new_default: "skip"
+    reason: "PR #131 — quick mode added 60+s startup pause on multi-GB DBs"
+    pr: "#131"
+
+  # PR #14 — polling watcher backend was the bootstrap default before
+  # watchdog landed. On local NTFS the event-driven backend is
+  # strictly better (sub-second event latency vs. 60s poll loop).
+  - path: "watcher.backend"
+    old_default: "polling"
+    new_default: "watchdog"
+    reason: "PR #14 — watchdog backend supersedes polling for local NTFS"
+    pr: "#14"

--- a/scripts/migrate_config.py
+++ b/scripts/migrate_config.py
@@ -1,0 +1,379 @@
+"""Config flag-rot migrator (issue #194 stabilization week / Wave 8 / D7).
+
+setup-source.ps1 preserves `config\\config.yaml` verbatim across
+updates so operator customisations survive. The unintended side
+effect: any new safe-default we ship (e.g. ``parquet_staging.enabled:
+false`` from #174) never reaches the customer's machine because
+their config still has the old ``true``.
+
+This script reads ``scripts/config_migrations.yaml`` for the list of
+rules and applies them to a target config file. A rule fires only
+when the customer's CURRENT value matches the documented
+``old_default`` — that is the "this looks like the previous shipped
+default, not an operator customisation" signal. Any other value
+(including an explicit operator choice) is left alone.
+
+The text-level edit is intentional: PyYAML's round-trip would strip
+comments, and the customer's config has long inline rationale (e.g.
+the parquet_staging block has 13 lines of explanation). We track
+indent context to identify the right ``leaf: value`` line and rewrite
+only that line. Backup-then-write is mandatory; the original lands
+next to the file with a timestamp suffix.
+
+Usage:
+    python scripts/migrate_config.py CONFIG_PATH [--dry-run]
+
+Exit codes:
+    0 — no migrations needed, or all migrations applied successfully
+    1 — at least one rule failed (parse error, ambiguity, etc.); file
+        unchanged
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import re
+import shutil
+import sys
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Iterator
+
+import yaml
+
+logger = logging.getLogger("file_activity.migrate_config")
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+RULES_FILE = REPO_ROOT / "scripts" / "config_migrations.yaml"
+
+
+# ---------------------------------------------------------------------------
+# Rule loading
+# ---------------------------------------------------------------------------
+
+
+def load_rules(path: Path = RULES_FILE) -> list[dict]:
+    with open(path, "r", encoding="utf-8") as f:
+        doc = yaml.safe_load(f) or {}
+    rules = doc.get("migrations") or []
+    if not isinstance(rules, list):
+        raise ValueError(f"{path}: 'migrations' must be a list")
+    out: list[dict] = []
+    for i, r in enumerate(rules):
+        if not isinstance(r, dict):
+            raise ValueError(f"{path}: migration #{i} is not a mapping")
+        for k in ("path", "old_default", "new_default"):
+            if k not in r:
+                raise ValueError(
+                    f"{path}: migration #{i} missing required key {k!r}"
+                )
+        out.append(r)
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Customer config inspection
+# ---------------------------------------------------------------------------
+
+
+def _navigate(doc: Any, path: str) -> tuple[bool, Any]:
+    """Return (found, value) for a dotted path inside a parsed mapping."""
+    cur = doc
+    for part in path.split("."):
+        if not isinstance(cur, dict) or part not in cur:
+            return False, None
+        cur = cur[part]
+    return True, cur
+
+
+# ---------------------------------------------------------------------------
+# Text-level edit (preserves comments / formatting)
+# ---------------------------------------------------------------------------
+
+
+def _indent_of(line: str) -> int:
+    """Number of leading-space chars; tabs not supported by spec."""
+    return len(line) - len(line.lstrip(" "))
+
+
+def _iter_leaf_assignments(
+    lines: list[str],
+) -> Iterator[tuple[int, str, list[str]]]:
+    """Yield ``(line_index, leaf_key, dotted_path_parts)`` for every line
+    that looks like a ``key: value`` assignment.
+
+    Tracks an indent stack so nested keys resolve to their full path.
+    Comments and blank lines are skipped. Sequence members (``- ...``)
+    are ignored — we never migrate inside a list. List headers (``key:``
+    with no value) push the key onto the path for the children.
+    """
+    # Stack of (indent, key) pairs; deepest entry is the current parent.
+    stack: list[tuple[int, str]] = []
+    leaf_pattern = re.compile(
+        r"^(?P<indent> *)(?P<key>[A-Za-z_][\w\-]*)\s*:\s*(?P<rest>.*)$"
+    )
+    for idx, raw in enumerate(lines):
+        line = raw.rstrip("\n")
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        # We don't traverse into list items
+        if stripped.startswith("- "):
+            continue
+        m = leaf_pattern.match(line)
+        if not m:
+            continue
+        indent = len(m.group("indent"))
+        key = m.group("key")
+        rest = m.group("rest")
+        # Pop deeper-or-equal-indent entries off the stack
+        while stack and stack[-1][0] >= indent:
+            stack.pop()
+        # Strip trailing comment to detect "container" vs "leaf"
+        value_part = rest.split("#", 1)[0].strip()
+        path_parts = [k for _, k in stack] + [key]
+        if value_part == "":
+            # Container — push onto stack for children, do not emit
+            stack.append((indent, key))
+            continue
+        # Leaf assignment — emit
+        yield idx, key, path_parts
+
+
+def _format_scalar(value: Any) -> str:
+    """Render a Python value back to YAML scalar text the way PyYAML
+    would emit it on a single line. Conservative: only handles the
+    types we accept in migration rules (bool, int, str, None)."""
+    if value is True:
+        return "true"
+    if value is False:
+        return "false"
+    if value is None:
+        return "null"
+    if isinstance(value, (int, float)):
+        return str(value)
+    # String — quote if it contains characters YAML would re-interpret
+    s = str(value)
+    if re.search(r"[\s:#'\"\[\]\{\},&*!|>%@`]", s) or s in {
+        "true", "false", "null", "yes", "no", "on", "off"
+    } or s == "":
+        return '"' + s.replace("\\", "\\\\").replace('"', '\\"') + '"'
+    return s
+
+
+def _replace_value_on_line(line: str, new_value: Any) -> str:
+    """Rewrite the value portion of a ``  key: <value>`` line while
+    preserving the indent, the key, the colon, the trailing comment if
+    any, and the line ending. The pattern is anchored so it never
+    matches sequence items or comments.
+
+    Quote style is preserved for string values: if the operator wrote
+    ``host: "0.0.0.0"`` (double-quoted), the replacement is
+    ``host: "127.0.0.1"`` — not the bare YAML form. This keeps the
+    visual change minimal so the operator scanning the file after a
+    migration sees only the value flip, not a style rewrite.
+    """
+    m = re.match(
+        r"^(?P<prefix> *[A-Za-z_][\w\-]*\s*:\s*)"
+        r"(?P<value>(?:'[^']*'|\"[^\"]*\"|[^#\r\n]*?))"
+        r"(?P<trail>\s*(?:#.*)?(?:\r?\n)?)$",
+        line,
+    )
+    if not m:
+        raise ValueError(f"unparseable assignment line: {line!r}")
+    old_value = m["value"].strip()
+    new_scalar = _format_scalar(new_value)
+    # If the operator's old value used double or single quotes AND the
+    # new value is a string that doesn't strictly require them, mirror
+    # the quote style. We don't downgrade a value that needs quotes.
+    if isinstance(new_value, str):
+        if old_value.startswith('"') and old_value.endswith('"'):
+            new_scalar = '"' + new_value.replace("\\", "\\\\").replace('"', '\\"') + '"'
+        elif old_value.startswith("'") and old_value.endswith("'"):
+            new_scalar = "'" + new_value.replace("'", "''") + "'"
+    return f"{m['prefix']}{new_scalar}{m['trail']}"
+
+
+# ---------------------------------------------------------------------------
+# Driver
+# ---------------------------------------------------------------------------
+
+
+class MigrationResult:
+    def __init__(self, path: str, action: str, detail: str = ""):
+        self.path = path
+        self.action = action  # "applied" | "skipped" | "missing" | "error"
+        self.detail = detail
+
+    def __repr__(self) -> str:
+        return f"<MigrationResult {self.path} {self.action} {self.detail!r}>"
+
+
+def migrate(
+    config_path: Path,
+    rules: list[dict],
+    dry_run: bool = False,
+) -> list[MigrationResult]:
+    """Apply migration rules to ``config_path``. Returns a per-rule
+    result list. The file is modified atomically (write to a temp,
+    rename over the original) only when at least one rule fires AND
+    re-parsing the resulting text yields the expected values.
+    """
+    results: list[MigrationResult] = []
+
+    if not config_path.exists():
+        for r in rules:
+            results.append(
+                MigrationResult(r["path"], "error", "config file not found")
+            )
+        return results
+
+    text = config_path.read_text(encoding="utf-8")
+    try:
+        doc = yaml.safe_load(text) or {}
+    except yaml.YAMLError as e:
+        for r in rules:
+            results.append(
+                MigrationResult(r["path"], "error", f"parse failure: {e}")
+            )
+        return results
+
+    # Decide per-rule whether to apply.
+    to_apply: list[tuple[dict, int]] = []  # (rule, line_index)
+    lines = text.splitlines(keepends=True)
+
+    # Build an index of leaf assignments keyed by dotted path.
+    leaf_lookup: dict[str, list[int]] = {}
+    for line_idx, _key, path_parts in _iter_leaf_assignments(lines):
+        leaf_lookup.setdefault(".".join(path_parts), []).append(line_idx)
+
+    for rule in rules:
+        path = rule["path"]
+        found, current = _navigate(doc, path)
+        if not found:
+            results.append(MigrationResult(path, "missing", "key not present"))
+            continue
+        if current != rule["old_default"]:
+            results.append(MigrationResult(
+                path, "skipped",
+                f"current={current!r} != old_default={rule['old_default']!r}",
+            ))
+            continue
+        line_idxs = leaf_lookup.get(path, [])
+        if len(line_idxs) != 1:
+            results.append(MigrationResult(
+                path, "error",
+                f"found {len(line_idxs)} candidate lines (need exactly 1)",
+            ))
+            continue
+        to_apply.append((rule, line_idxs[0]))
+        results.append(MigrationResult(
+            path, "applied",
+            f"{current!r} -> {rule['new_default']!r}",
+        ))
+
+    if not to_apply or dry_run:
+        return results
+
+    # Apply edits.
+    new_lines = list(lines)
+    for rule, line_idx in to_apply:
+        try:
+            new_lines[line_idx] = _replace_value_on_line(
+                new_lines[line_idx], rule["new_default"],
+            )
+        except Exception as e:
+            for r_existing in results:
+                if r_existing.path == rule["path"]:
+                    r_existing.action = "error"
+                    r_existing.detail = f"line rewrite failed: {e}"
+            return results
+
+    new_text = "".join(new_lines)
+
+    # Verify the result still parses AND the new values are present.
+    try:
+        new_doc = yaml.safe_load(new_text) or {}
+    except yaml.YAMLError as e:
+        for r in results:
+            if r.action == "applied":
+                r.action = "error"
+                r.detail = f"post-edit parse failed: {e}"
+        return results
+    for rule, _line_idx in to_apply:
+        _, new_val = _navigate(new_doc, rule["path"])
+        if new_val != rule["new_default"]:
+            for r_existing in results:
+                if r_existing.path == rule["path"]:
+                    r_existing.action = "error"
+                    r_existing.detail = (
+                        f"post-edit value {new_val!r} != expected "
+                        f"{rule['new_default']!r}"
+                    )
+            return results
+
+    # Backup + atomic write.
+    ts = datetime.now().strftime("%Y%m%d-%H%M%S")
+    backup = config_path.with_suffix(config_path.suffix + f".bak-{ts}")
+    shutil.copy2(config_path, backup)
+    tmp = config_path.with_suffix(config_path.suffix + ".tmp")
+    tmp.write_text(new_text, encoding="utf-8")
+    tmp.replace(config_path)
+    logger.info("migrated %s (backup at %s)", config_path, backup)
+
+    return results
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument(
+        "config",
+        help="Path to the customer's config.yaml",
+    )
+    ap.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Report what would change, don't write.",
+    )
+    ap.add_argument(
+        "--rules",
+        default=str(RULES_FILE),
+        help=f"Path to migration rules file (default: {RULES_FILE}).",
+    )
+    args = ap.parse_args(argv)
+
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s | %(levelname)-8s | %(message)s",
+    )
+
+    rules = load_rules(Path(args.rules))
+    results = migrate(Path(args.config), rules, dry_run=args.dry_run)
+
+    applied = [r for r in results if r.action == "applied"]
+    errors = [r for r in results if r.action == "error"]
+
+    for r in results:
+        prefix = "::error::" if r.action == "error" else ""
+        logger.info("%s%-9s %s — %s", prefix, r.action, r.path, r.detail)
+
+    if errors:
+        logger.error("config migration FAILED — %d rule(s) errored", len(errors))
+        return 1
+    if applied:
+        verb = "WOULD APPLY" if args.dry_run else "applied"
+        logger.info("config migration: %s %d rule(s)", verb, len(applied))
+    else:
+        logger.info("config migration: no changes needed")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,27 @@
 """FILE ACTIVITY - Setup script."""
 
+from pathlib import Path
+
 from setuptools import setup, find_packages
+
+
+def _read_version() -> str:
+    """Resolve the VERSION file content (single source of truth, also
+    read by main.py:_read_version_string at runtime). Falls back to
+    "0.0.0+unknown" if the file is missing so a malformed checkout
+    doesn't break `pip install -e .` — but in a normal source tree
+    the value is always the tagged release (e.g. "1.9.0-rc1").
+    """
+    vp = Path(__file__).parent / "VERSION"
+    try:
+        return vp.read_text(encoding="utf-8").strip() or "0.0.0+unknown"
+    except OSError:
+        return "0.0.0+unknown"
+
 
 setup(
     name="file-activity",
-    version="1.0.0",
+    version=_read_version(),
     description="Windows Dosya Paylaşım Analiz ve Arşivleme Sistemi",
     packages=find_packages(),
     include_package_data=True,

--- a/src/dashboard/api.py
+++ b/src/dashboard/api.py
@@ -790,6 +790,28 @@ def create_app(db, config, analytics=None, ad_lookup=None, email_notifier=None,
             "reason": reason,
         }
 
+    def _is_summary_stale(scan_id: int, kpi: Optional[dict]) -> bool:
+        """Issue #194 — cached summary_json went stale when computed
+        before _run_size_enrich landed (scanner ordering bug, fixed in
+        the same wave). A scan_runs row with total_files>0 but a kpi
+        with total_files==0 is the signature. PR #199 added this check
+        inline at /api/risk-score only; this helper extends it to every
+        cached-read site (overview, dashboard_init).
+        """
+        if not kpi:
+            return False
+        if (kpi.get("total_files") or 0) > 0:
+            return False
+        try:
+            with db.get_read_cursor() as _cur:
+                _row = _cur.execute(
+                    "SELECT total_files FROM scan_runs WHERE id=?",
+                    (scan_id,),
+                ).fetchone()
+        except Exception:
+            return False
+        return bool(_row and (_row["total_files"] or 0) > 0)
+
     static_dir = os.path.join(os.path.dirname(__file__), "static")
     if os.path.exists(static_dir):
         app.mount("/static", StaticFiles(directory=static_dir), name="static")
@@ -842,7 +864,10 @@ def create_app(db, config, analytics=None, ad_lookup=None, email_notifier=None,
                     file_count = scan["total_files"] or 0
                     total_size = scan["total_size"] or 0
 
-                    # 2) FALLBACK: total_files=0 ama dosyalar var olabilir
+                    # 2) FALLBACK: total_files=0 ama dosyalar var olabilir.
+                    # Skip the UPDATE when a scan is running for this source
+                    # so the dashboard load doesn't contend with the scanner's
+                    # bulk inserts on the writer pool (backend audit Class 8).
                     if file_count == 0:
                         cur.execute("""
                             SELECT COUNT(*) as cnt, COALESCE(SUM(file_size),0) as sz
@@ -852,16 +877,19 @@ def create_app(db, config, analytics=None, ad_lookup=None, email_notifier=None,
                         if real["cnt"] > 0:
                             file_count = real["cnt"]
                             total_size = real["sz"]
-                            # scan_runs'i da guncelle (bir dahaki sefere hizli gelsin)
-                            cur.execute("""
-                                UPDATE scan_runs SET total_files=?, total_size=?
-                                WHERE id=? AND total_files=0
-                            """, (file_count, total_size, scan["id"]))
+                            if db.is_scan_running(s.id) is None:
+                                cur.execute("""
+                                    UPDATE scan_runs SET total_files=?, total_size=?
+                                    WHERE id=? AND total_files=0
+                                """, (file_count, total_size, scan["id"]))
 
-                    # Pre-computed KPI summary (scan tamamlanirken
-                    # yazilmisti). Varsa Overview bu satirdan render eder,
-                    # scanned_files tablosuna hic dokunmaz.
+                    # Pre-computed KPI summary. If the cache is stale
+                    # (total_files==0 while scan_runs has real totals),
+                    # surface None so the frontend falls through to the
+                    # live path — same self-heal pattern as risk-score.
                     kpi = db.get_scan_summary(scan["id"])
+                    if _is_summary_stale(scan["id"], kpi):
+                        kpi = None
 
                     summaries[s.id] = {
                         "has_data": file_count > 0,
@@ -876,7 +904,8 @@ def create_app(db, config, analytics=None, ad_lookup=None, email_notifier=None,
                         },
                         "kpi": kpi,  # None ise frontend eski yola duser
                     }
-            except Exception:
+            except Exception as e:
+                logger.warning("dashboard_init source %d failed: %s", s.id, e)
                 summaries[s.id] = {"has_data": False, "scan_id": None}
 
         return {
@@ -2407,6 +2436,8 @@ def create_app(db, config, analytics=None, ad_lookup=None, email_notifier=None,
         scan_id = db.get_latest_scan_id(source_id, include_running=False)
         if scan_id:
             kpi = db.get_scan_summary(scan_id)
+            if _is_summary_stale(scan_id, kpi):
+                kpi = None
             if kpi:
                 # Boyutlari formatla
                 kpi["total_size_formatted"] = format_size(kpi.get("total_size", 0))
@@ -2608,43 +2639,39 @@ def create_app(db, config, analytics=None, ad_lookup=None, email_notifier=None,
 
     @app.get("/api/risk-score/{source_id}")
     async def risk_score(source_id: int):
-        """Supervisor risk score - TEK optimized sorgu (6 yerine 2)."""
-        scan_id = db.get_latest_scan_id(source_id, include_running=True)
+        """Supervisor risk score - TEK optimized sorgu (6 yerine 2).
+
+        Issue #194 — fast-path response shape MUST match the live path
+        below: top-level risk_level/total_files/total_size, kpis with
+        stale_count/dup_groups names (not stale_files/duplicate_groups).
+        Genel Bakis frontend reads the live names; a drifted fast path
+        silently renders zero for stale_count, owner_count, dup_groups.
+
+        include_running=False matches /api/overview/{source_id} so both
+        endpoints on Genel Bakis reference the same scan_id (backend
+        audit Class 4).
+        """
+        scan_id = db.get_latest_scan_id(source_id, include_running=False)
         if not scan_id:
             return {"risk_score": 0, "kpis": {}}
 
-        # Hizli yol: pre-computed summary varsa oradan hesapla
         kpi = db.get_scan_summary(scan_id)
-        # Issue #194 update #5 — self-heal stale summary_json. Customer
-        # observed Genel Bakis showing TOPLAM DOSYA: 0 while scan_runs
-        # had real totals AND scanned_files clearly populated (Treemap +
-        # Dosya Turleri rendered correctly off the same scan_id). The
-        # cached summary_json was written at a partial moment and never
-        # refreshed. If summary's total_files==0 but the scan_runs row
-        # has non-zero total_files, the cache is stale — bypass it and
-        # fall through to the live SQL path below, which always tells
-        # the truth.
-        if kpi and (kpi.get("total_files") or 0) == 0:
-            with db.get_read_cursor() as _cur:
-                _row = _cur.execute(
-                    "SELECT total_files FROM scan_runs WHERE id=?",
-                    (scan_id,),
-                ).fetchone()
-            if _row and (_row["total_files"] or 0) > 0:
-                logger.info(
-                    "risk_score: summary_json shows total_files=0 but "
-                    "scan_runs.total_files=%d for scan_id=%d — "
-                    "treating cache as stale, falling through",
-                    _row["total_files"], scan_id,
-                )
-                kpi = None
+        if _is_summary_stale(scan_id, kpi):
+            kpi = None
         if kpi:
-            total = kpi.get("total_files", 0) or 1
-            risky = kpi.get("risky_count", 0)
-            stale = kpi.get("stale_count", 0)
-            dup_waste = kpi.get("duplicate_waste_size", 0)
-            total_size = kpi.get("total_size", 0) or 1
-            # Basit formul: risky % + stale % + (dup_waste / total_size) %
+            # NULL coercion: ``kpi.get(k, 0)`` only kicks in when the KEY
+            # is missing; SQLite NULL → Python None still flows through.
+            # Use ``or 0`` so arithmetic never crashes.
+            total = (kpi.get("total_files") or 0) or 1
+            total_size = (kpi.get("total_size") or 0) or 1
+            risky = kpi.get("risky_count") or 0
+            stale = kpi.get("stale_count") or 0
+            dup_waste = kpi.get("duplicate_waste_size") or 0
+            owner_count = kpi.get("owner_count") or 0
+            large_count = kpi.get("large_count") or 0
+            large_size = kpi.get("large_size") or 0
+            dup_groups = kpi.get("duplicate_groups") or 0
+            stale_size = kpi.get("stale_size") or 0
             score = int(min(100,
                 (risky / total) * 40 +
                 (stale / total) * 30 +
@@ -2652,15 +2679,19 @@ def create_app(db, config, analytics=None, ad_lookup=None, email_notifier=None,
             ))
             return {
                 "risk_score": score,
+                "risk_level": "critical" if score >= 70 else "warning" if score >= 40 else "good",
+                "total_files": kpi.get("total_files") or 0,
+                "total_size": kpi.get("total_size") or 0,
                 "kpis": {
-                    "total_files": kpi.get("total_files"),
-                    "risky_files": risky,
-                    "stale_files": stale,
-                    "duplicate_groups": kpi.get("duplicate_groups"),
-                    "total_size": kpi.get("total_size"),
-                    "stale_size": kpi.get("stale_size"),
-                    "risky_pct": round(risky * 100 / total, 1),
                     "stale_pct": round(stale * 100 / total, 1),
+                    "stale_count": stale,
+                    "stale_size": stale_size,
+                    "risky_files": risky,
+                    "owner_count": owner_count,
+                    "large_files": large_count,
+                    "large_size": large_size,
+                    "dup_groups": dup_groups,
+                    "changes_24h": 0,
                 },
                 "source": "precomputed",
             }

--- a/src/dashboard/api.py
+++ b/src/dashboard/api.py
@@ -920,6 +920,14 @@ def create_app(db, config, analytics=None, ad_lookup=None, email_notifier=None,
         s = Source(name=data.name, unc_path=data.unc_path, archive_dest=data.archive_dest)
         try:
             sid = db.add_source(s)
+            try:
+                db.insert_audit_event_simple(
+                    source_id=sid, event_type="source_created", username="admin",
+                    file_path=None,
+                    details=f"name={data.name};unc_path={data.unc_path}",
+                )
+            except Exception as e:  # pragma: no cover - audit is best-effort
+                logger.warning("audit emit failed for source_created: %s", e)
             return {"id": sid, "message": f"Kaynak eklendi: {data.name}"}
         except Exception as e:
             raise HTTPException(400, str(e))
@@ -928,6 +936,14 @@ def create_app(db, config, analytics=None, ad_lookup=None, email_notifier=None,
     async def remove_source(source_id: int):
         src = _get_source(db, source_id)
         if db.remove_source(src.name):
+            try:
+                db.insert_audit_event_simple(
+                    source_id=source_id, event_type="source_deleted", username="admin",
+                    file_path=None,
+                    details=f"name={src.name};unc_path={src.unc_path}",
+                )
+            except Exception as e:  # pragma: no cover - audit is best-effort
+                logger.warning("audit emit failed for source_deleted: %s", e)
             return {"message": f"Kaynak silindi: {src.name}"}
         raise HTTPException(500, "Silme basarisiz")
 
@@ -1538,6 +1554,14 @@ def create_app(db, config, analytics=None, ad_lookup=None, email_notifier=None,
         )
         pol = ArchivePolicy(name=data.name, source_id=data.source_id, rules_json=rules)
         pid = db.add_policy(pol)
+        try:
+            db.insert_audit_event_simple(
+                source_id=data.source_id, event_type="policy_created", username="admin",
+                file_path=None,
+                details=f"policy_id={pid};name={data.name}",
+            )
+        except Exception as e:  # pragma: no cover - audit is best-effort
+            logger.warning("audit emit failed for policy_created: %s", e)
         return {"id": pid, "message": f"Politika olusturuldu: {data.name}"}
 
     @app.delete("/api/policies/{policy_id}")
@@ -1546,6 +1570,14 @@ def create_app(db, config, analytics=None, ad_lookup=None, email_notifier=None,
         if not pol:
             raise HTTPException(404, "Politika bulunamadi")
         if db.remove_policy(pol["name"]):
+            try:
+                db.insert_audit_event_simple(
+                    source_id=pol.get("source_id"), event_type="policy_deleted",
+                    username="admin", file_path=None,
+                    details=f"policy_id={policy_id};name={pol['name']}",
+                )
+            except Exception as e:  # pragma: no cover - audit is best-effort
+                logger.warning("audit emit failed for policy_deleted: %s", e)
             return {"message": f"Politika silindi: {pol['name']}"}
         raise HTTPException(500, "Silme basarisiz")
 
@@ -1578,11 +1610,26 @@ def create_app(db, config, analytics=None, ad_lookup=None, email_notifier=None,
             policy_id=policy_id, cron_expression=data.cron_expression
         )
         tid = db.add_scheduled_task(task)
+        try:
+            db.insert_audit_event_simple(
+                source_id=source_id_val, event_type="schedule_created", username="admin",
+                file_path=None,
+                details=f"task_id={tid};type={data.task_type};cron={data.cron_expression}",
+            )
+        except Exception as e:  # pragma: no cover - audit is best-effort
+            logger.warning("audit emit failed for schedule_created: %s", e)
         return {"id": tid, "message": "Zamanlanmis gorev olusturuldu"}
 
     @app.delete("/api/schedules/{task_id}")
     async def remove_schedule(task_id: int):
         if db.remove_scheduled_task(task_id):
+            try:
+                db.insert_audit_event_simple(
+                    source_id=None, event_type="schedule_deleted", username="admin",
+                    file_path=None, details=f"task_id={task_id}",
+                )
+            except Exception as e:  # pragma: no cover - audit is best-effort
+                logger.warning("audit emit failed for schedule_deleted: %s", e)
             return {"message": "Gorev silindi"}
         raise HTTPException(404, "Gorev bulunamadi")
 
@@ -1960,6 +2007,13 @@ def create_app(db, config, analytics=None, ad_lookup=None, email_notifier=None,
     @app.post("/api/anomalies/{anomaly_id}/acknowledge")
     async def acknowledge_anomaly(anomaly_id: int, by_user: str = "admin"):
         db.acknowledge_anomaly(anomaly_id, by_user)
+        try:
+            db.insert_audit_event_simple(
+                source_id=None, event_type="anomaly_acknowledged", username=by_user,
+                file_path=None, details=f"anomaly_id={anomaly_id}",
+            )
+        except Exception as e:  # pragma: no cover - audit is best-effort
+            logger.warning("audit emit failed for anomaly_acknowledged: %s", e)
         return {"message": "Anomali onaylandi"}
 
     # --- FILE WATCHER API ---
@@ -1981,6 +2035,13 @@ def create_app(db, config, analytics=None, ad_lookup=None, email_notifier=None,
         watcher = FileWatcher(db, src.id, src.unc_path, interval,
                                 ransomware_detector=ransomware)
         watcher.start()
+        try:
+            db.insert_audit_event_simple(
+                source_id=src.id, event_type="watcher_started", username="admin",
+                file_path=None, details=f"interval={watcher.interval}",
+            )
+        except Exception as e:  # pragma: no cover - audit is best-effort
+            logger.warning("audit emit failed for watcher_started: %s", e)
         return {"status": "started", "interval": watcher.interval}
 
     @app.post("/api/watcher/{source_id}/stop")
@@ -1988,6 +2049,13 @@ def create_app(db, config, analytics=None, ad_lookup=None, email_notifier=None,
         from src.scanner.file_watcher import _watchers
         if source_id in _watchers:
             _watchers[source_id].stop()
+            try:
+                db.insert_audit_event_simple(
+                    source_id=source_id, event_type="watcher_stopped", username="admin",
+                    file_path=None, details=None,
+                )
+            except Exception as e:  # pragma: no cover - audit is best-effort
+                logger.warning("audit emit failed for watcher_stopped: %s", e)
             return {"status": "stopped"}
         return {"status": "not_running"}
 
@@ -4291,6 +4359,13 @@ def create_app(db, config, analytics=None, ad_lookup=None, email_notifier=None,
             cwd=os.path.dirname(update_cmd),
         )
         logger.info("Guncelleme tetiklendi: %s", update_cmd)
+        try:
+            db.insert_audit_event_simple(
+                source_id=None, event_type="system_update_triggered", username="admin",
+                file_path=update_cmd, details="dashboard-initiated update.cmd",
+            )
+        except Exception as e:  # pragma: no cover - audit is best-effort
+            logger.warning("audit emit failed for system_update_triggered: %s", e)
         return {
             "status": "started",
             "message": "Guncelleme baslatildi. 30-60 saniye sonra dashboard'u yenileyin.",
@@ -4721,6 +4796,13 @@ def create_app(db, config, analytics=None, ad_lookup=None, email_notifier=None,
             )
             if cur.rowcount == 0:
                 raise HTTPException(404, f"Uyari bulunamadi (ID: {alert_id})")
+        try:
+            db.insert_audit_event_simple(
+                source_id=None, event_type="ransomware_alert_acknowledged",
+                username=by_user, file_path=None, details=f"alert_id={alert_id}",
+            )
+        except Exception as e:  # pragma: no cover - audit is best-effort
+            logger.warning("audit emit failed for ransomware_alert_acknowledged: %s", e)
         return {"acknowledged": True, "id": alert_id, "by": by_user}
 
     @app.post("/api/security/ransomware/canaries/{source_id}/deploy")
@@ -4729,6 +4811,14 @@ def create_app(db, config, analytics=None, ad_lookup=None, email_notifier=None,
         src = _get_source(db, source_id)
         det = _get_detector()
         placed = det.deploy_canaries(src.id, src.unc_path)
+        try:
+            db.insert_audit_event_simple(
+                source_id=src.id, event_type="ransomware_canaries_deployed",
+                username="admin", file_path=src.unc_path,
+                details=f"placed={placed};names={sorted(det.canary_names)}",
+            )
+        except Exception as e:  # pragma: no cover - audit is best-effort
+            logger.warning("audit emit failed for ransomware_canaries_deployed: %s", e)
         return {
             "source_id": src.id,
             "share_root": src.unc_path,
@@ -5274,6 +5364,15 @@ def create_app(db, config, analytics=None, ad_lookup=None, email_notifier=None,
                 (by_user, f"-{int(since_minutes)}"),
             )
             rowcount = cur.rowcount or 0
+        try:
+            db.insert_audit_event_simple(
+                source_id=None,
+                event_type="ransomware_alerts_acknowledged_bulk",
+                username=by_user, file_path=None,
+                details=f"rows_updated={int(rowcount)};since_minutes={int(since_minutes)}",
+            )
+        except Exception as e:  # pragma: no cover - audit is best-effort
+            logger.warning("audit emit failed for ransomware bulk-ack: %s", e)
         return {
             "acknowledged": True,
             "rows_updated": int(rowcount),

--- a/src/dashboard/api.py
+++ b/src/dashboard/api.py
@@ -3919,8 +3919,9 @@ def create_app(db, config, analytics=None, ad_lookup=None, email_notifier=None,
     @app.post("/api/system/open-folder")
     async def open_folder(request: Request):
         """Dizini Windows Explorer'da ac (yalnizca yerel istemci icin)."""
+        from src.security.dashboard_auth import resolve_effective_client_host
         body = await request.json()
-        client_host = (request.client.host if request.client else "")
+        client_host = resolve_effective_client_host(request)
         return open_folder_impl(body, client_host)
 
     @app.get("/api/system/list-dir")
@@ -3934,8 +3935,13 @@ def create_app(db, config, analytics=None, ad_lookup=None, email_notifier=None,
         Bos ``path`` -> mantiksal kokleri dondurur (Windows surucu harfleri
         veya POSIX "/"). 5000 girisle sinirlanmis, 'dir'>'file' siralanmis.
         Uzaktan istemci icin 403; var olmayan yol icin 404.
+
+        Uses ``resolve_effective_client_host`` (honours X-Forwarded-For
+        when peer is loopback) so a reverse proxy on the same host
+        cannot turn every LAN request into a fake "localhost" call.
         """
-        client_host = (request.client.host if request.client else "")
+        from src.security.dashboard_auth import resolve_effective_client_host
+        client_host = resolve_effective_client_host(request)
         return list_dir_impl(path, client_host, show_hidden=show_hidden)
 
     @app.get("/api/system/health")

--- a/src/dashboard/static/index.html
+++ b/src/dashboard/static/index.html
@@ -5287,7 +5287,7 @@ async function loadNaming() {
                         </td>
                         <td><span class="badge ${r.severity==='critical'?'badge-danger':r.severity==='warning'?'badge-warning':'badge-info'}">${escapeHtml(r.severity||'')}</span></td>
                         <td style="font-size:11px;color:var(--text-muted);max-width:250px;word-break:break-word">${(r.samples||[]).slice(0,3).map(escapeHtml).join('<br>')}</td>
-                        <td><button class="btn btn-sm btn-outline" onclick="showNamingFiles('${escapeHtml(r.code)}', ${sourceId})">Dosyalari Gor</button></td>
+                        <td><button class="btn btn-sm btn-outline" onclick="showNamingFiles('${escapeHtml(r.code)}', ${Number(sourceId)||0})">Dosyalari Gor</button></td>
                     </tr>`).join('')}</tbody>
                 `;
             } else {
@@ -5316,7 +5316,7 @@ async function loadNaming() {
                         </td>
                         <td><span class="badge ${b.severity==='warning'?'badge-warning':'badge-info'}">${escapeHtml(b.severity||'')}</span></td>
                         <td style="font-size:11px;color:var(--text-muted);max-width:250px;word-break:break-word">${(b.samples||[]).slice(0,3).map(escapeHtml).join('<br>')}</td>
-                        <td><button class="btn btn-sm btn-outline" onclick="showNamingFiles('${escapeHtml(b.code)}', ${sourceId})">Dosyalari Gor</button></td>
+                        <td><button class="btn btn-sm btn-outline" onclick="showNamingFiles('${escapeHtml(b.code)}', ${Number(sourceId)||0})">Dosyalari Gor</button></td>
                     </tr>`).join('')}</tbody>
                 `;
             } else {

--- a/src/dashboard/static/index.html
+++ b/src/dashboard/static/index.html
@@ -2758,6 +2758,7 @@ function populateSourceSelect(id) {
 
 function renderSources() {
     const c = document.getElementById('source-list');
+    if (!c) return;
     if (!sources.length) { c.innerHTML = '<div class="empty-state"><div class="icon">📁</div><h3>Kaynak Bulunamadi</h3><p>"+ Kaynak Ekle" ile dosya paylasim kaynagi ekleyin.</p></div>'; return; }
     c.innerHTML = sources.map(s => {
         // Issue #177 — build delta line from cached trend data
@@ -3778,20 +3779,24 @@ async function loadFrequency() {
         if (labels.length) {
             const counts = labels.map(k => ab[k] || 0);
             const barColors = bucketDays.map(d => d >= 365 ? '#ef4444' : d >= 180 ? '#f59e0b' : d >= 90 ? '#eab308' : '#10b981');
-            document.getElementById('freq-cards').innerHTML = labels.map((k, i) => {
+            _setHtmlSafe('freq-cards', labels.map((k, i) => {
                 const d = bucketDays[i] || 0;
                 const c = counts[i];
                 const color = d >= 365 ? 'var(--danger)' : d >= 180 ? 'var(--warning)' : d >= 90 ? '#eab308' : 'var(--success)';
                 return `<div class="card" style="border-top:3px solid ${color}"><div class="card-label">${escapeHtml(k)}</div><div class="card-value" style="font-size:22px">${formatNum(c)}</div><div class="card-sub">Kismi veri</div></div>`;
-            }).join('');
+            }).join(''));
             destroyChart('freq-chart');
-            chartInstances['freq-chart'] = new Chart(document.getElementById('freq-chart'), {
-                type: 'bar', data: { labels, datasets: [{ label: 'Dosya Sayisi', data: counts, backgroundColor: barColors.map(c=>c+'99'), borderColor: barColors, borderWidth: 1, borderRadius: 6, yAxisID: 'y' }] },
-                options: { responsive: true, plugins: { legend: { display: true } }, scales: { y: { beginAtZero: true, grid: { color: '#1e293b' } }, x: { grid: { display: false } } } }
-            });
-            document.getElementById('freq-table-wrap').style.display = 'none';
+            const freqCanvas = document.getElementById('freq-chart');
+            if (freqCanvas) {
+                chartInstances['freq-chart'] = new Chart(freqCanvas, {
+                    type: 'bar', data: { labels, datasets: [{ label: 'Dosya Sayisi', data: counts, backgroundColor: barColors.map(c=>c+'99'), borderColor: barColors, borderWidth: 1, borderRadius: 6, yAxisID: 'y' }] },
+                    options: { responsive: true, plugins: { legend: { display: true } }, scales: { y: { beginAtZero: true, grid: { color: '#1e293b' } }, x: { grid: { display: false } } } }
+                });
+            }
+            const tw = document.getElementById('freq-table-wrap');
+            if (tw) tw.style.display = 'none';
         } else {
-            document.getElementById('freq-cards').innerHTML = '<div style="padding:20px;color:var(--text-muted)">Kismi veri yok \u2014 Tarama tamamlandiktan sonra goruntulenecek</div>';
+            _setHtmlSafe('freq-cards', '<div style="padding:20px;color:var(--text-muted)">Kismi veri yok \u2014 Tarama tamamlandiktan sonra goruntulenecek</div>');
         }
         _psv2StartPoll(sid, 'frequency', loadFrequency);
         return;
@@ -3844,16 +3849,17 @@ async function loadFrequency() {
             <button class="btn btn-sm btn-success" onclick="showDrilldown('365+ Gun Arsivle', '/drilldown/frequency/${sid}?min_days=365', {source_id:${parseInt(sid)}, filter_type:'frequency', min_days:365})">Arsivle</button>
         </div>` + cardsHtml;
     }
-    document.getElementById('freq-cards').innerHTML = cardsHtml;
+    _setHtmlSafe('freq-cards', cardsHtml);
 
     // Chart
     destroyChart('freq-chart');
-    if (freq.length) {
+    const freqCanvas = freq.length ? document.getElementById('freq-chart') : null;
+    if (freqCanvas) {
         const barColors = freq.map(f => {
             const d = f.days || 0;
             return d >= 365 ? '#ef4444' : d >= 180 ? '#f59e0b' : d >= 90 ? '#eab308' : '#10b981';
         });
-        chartInstances['freq-chart'] = new Chart(document.getElementById('freq-chart'), {
+        chartInstances['freq-chart'] = new Chart(freqCanvas, {
             type: 'bar', data: {
                 labels: freq.map(f => f.label),
                 datasets: [
@@ -3864,8 +3870,9 @@ async function loadFrequency() {
     }
 
     // Table
-    document.getElementById('freq-table-wrap').style.display = 'block';
-    document.getElementById('freq-table').innerHTML = `
+    const fTableWrap = document.getElementById('freq-table-wrap');
+    if (fTableWrap) fTableWrap.style.display = 'block';
+    _setHtmlSafe('freq-table', `
         <thead><tr><th>Kriter</th><th>Durum</th><th>Dosya Sayisi</th><th>Toplam Boyut</th><th>Yuzde</th></tr></thead>
         <tbody>${freq.map((f, i) => {
             const minD = f.days || 0;
@@ -3873,7 +3880,7 @@ async function loadFrequency() {
             const maxParam = maxD ? `&max_days=${maxD}` : '';
             return `<tr class="clickable-row" onclick="showDrilldown('${escapeHtml(f.label)}', '/drilldown/frequency/${sid}?min_days=${minD}${maxParam}', {source_id:${sid}, filter_type:'frequency', min_days:${minD}${maxD?`, max_days:${maxD}`:''}})"><td>${escapeHtml(f.label)}</td><td>${staleBadge(minD)}</td><td>${formatNum(f.file_count)}</td><td>${escapeHtml(f.total_size_formatted)}</td><td>${total ? (f.file_count/total*100).toFixed(1)+'%' : '-'}</td></tr>`;
         }).join('')}</tbody>
-    `;
+    `);
 
     // Issue #84 — wire view toggle (visual = histogram above; grid = file list).
     window.__freqLastSourceId = sid;
@@ -3970,23 +3977,25 @@ async function loadTypes() {
         const byExt = (ps.summary && ps.summary.by_extension) || [];
         const top = byExt.slice(0, 15);
         destroyChart('types-pie-chart');
-        if (top.length) {
-            chartInstances['types-pie-chart'] = new Chart(document.getElementById('types-pie-chart'), {
+        const tPieCanvas = top.length ? document.getElementById('types-pie-chart') : null;
+        if (tPieCanvas) {
+            chartInstances['types-pie-chart'] = new Chart(tPieCanvas, {
                 type: 'doughnut', data: { labels: top.map(t=>'.'+escapeHtml(t.ext||'')), datasets: [{ data: top.map(t=>t.size_bytes||0), backgroundColor: COLORS, borderWidth: 0 }] },
                 options: { responsive: true, cutout: '60%', plugins: { legend: { position: 'right', labels: { boxWidth: 10, padding: 6, font: { size: 11 } } } } }
             });
         }
         destroyChart('types-count-chart');
-        if (top.length) {
-            chartInstances['types-count-chart'] = new Chart(document.getElementById('types-count-chart'), {
+        const tCntCanvas = top.length ? document.getElementById('types-count-chart') : null;
+        if (tCntCanvas) {
+            chartInstances['types-count-chart'] = new Chart(tCntCanvas, {
                 type: 'bar', data: { labels: top.map(t=>'.'+escapeHtml(t.ext||'')), datasets: [{ label: 'Dosya Sayisi', data: top.map(t=>t.count||0), backgroundColor: COLORS.map(c=>c+'99'), borderColor: COLORS, borderWidth: 1, borderRadius: 4 }] },
                 options: { indexAxis: 'y', responsive: true, plugins: { legend: { display: false } }, scales: { x: { beginAtZero: true, grid: { color: '#1e293b' } }, y: { grid: { display: false } } } }
             });
         }
-        document.getElementById('types-table').innerHTML = `
+        _setHtmlSafe('types-table', `
             <thead><tr><th>Uzanti</th><th>Sayi</th><th>Toplam Boyut</th></tr></thead>
             <tbody>${byExt.slice(0,30).map(t => `<tr><td><strong>.${escapeHtml(t.ext||'')}</strong></td><td>${formatNum(t.count||0)}</td><td>${formatSize(t.size_bytes||0)}</td></tr>`).join('')}</tbody>
-        `;
+        `);
         _psv2StartPoll(sid, 'types', loadTypes);
         return;
     }
@@ -4003,15 +4012,17 @@ async function loadTypes() {
     const top = types.slice(0, 15);
 
     destroyChart('types-pie-chart');
-    if (top.length) {
-        chartInstances['types-pie-chart'] = new Chart(document.getElementById('types-pie-chart'), {
+    const tPieCanvas2 = top.length ? document.getElementById('types-pie-chart') : null;
+    if (tPieCanvas2) {
+        chartInstances['types-pie-chart'] = new Chart(tPieCanvas2, {
             type: 'doughnut', data: { labels: top.map(t=>'.'+t.extension), datasets: [{ data: top.map(t=>t.total_size||0), backgroundColor: COLORS, borderWidth: 0 }] },
             options: { responsive: true, cutout: '60%', plugins: { legend: { position: 'right', labels: { boxWidth: 10, padding: 6, font: { size: 11 } } } } }
         });
     }
     destroyChart('types-count-chart');
-    if (top.length) {
-        chartInstances['types-count-chart'] = new Chart(document.getElementById('types-count-chart'), {
+    const tCntCanvas2 = top.length ? document.getElementById('types-count-chart') : null;
+    if (tCntCanvas2) {
+        chartInstances['types-count-chart'] = new Chart(tCntCanvas2, {
             type: 'bar', data: { labels: top.map(t=>'.'+t.extension), datasets: [{ label: 'Dosya Sayisi', data: top.map(t=>t.file_count), backgroundColor: COLORS.map(c=>c+'99'), borderColor: COLORS, borderWidth: 1, borderRadius: 4 }] },
             options: { indexAxis: 'y', responsive: true, plugins: { legend: { display: false } }, scales: { x: { beginAtZero: true, grid: { color: '#1e293b' } }, y: { grid: { display: false } } } }
         });
@@ -4026,10 +4037,10 @@ async function loadTypes() {
         return '';
     }
 
-    document.getElementById('types-table').innerHTML = `
+    _setHtmlSafe('types-table', `
         <thead><tr><th>Uzanti</th><th>Risk</th><th>Sayi</th><th>Toplam</th><th>Ortalama</th><th>Min</th><th>Max</th></tr></thead>
         <tbody>${types.slice(0,30).map(t => `<tr class="clickable-row" onclick="showDrilldown('.${t.extension} Dosyalari', '/drilldown/type/${sid}?extension=${encodeURIComponent(t.extension)}', {source_id:${sid}, filter_type:'type', extension:'${t.extension}'})"><td><strong>.${t.extension}</strong></td><td>${typeRiskBadge(t.extension, t.total_size||0)}</td><td>${formatNum(t.file_count)}</td><td>${t.total_size_formatted}</td><td>${t.avg_size_formatted}</td><td>${t.min_size_formatted}</td><td>${t.max_size_formatted}</td></tr>`).join('')}</tbody>
-    `;
+    `);
 }
 
 // ═══════════════════════════════════════════════════
@@ -4050,23 +4061,26 @@ async function loadSizes() {
         const labels = bucketOrder.filter(k => sb.hasOwnProperty(k));
         if (labels.length) {
             const counts = labels.map(k => sb[k] || 0);
-            document.getElementById('sizes-cards').innerHTML = labels.map((k, i) => `
+            _setHtmlSafe('sizes-cards', labels.map((k, i) => `
                 <div class="card" style="border-top:3px solid ${COLORS[i%COLORS.length]}">
                     <div class="card-label">${escapeHtml(k)}</div>
                     <div class="card-value" style="font-size:22px">${formatNum(counts[i])}</div>
                     <div class="card-sub">Kismi veri</div>
-                </div>`).join('');
+                </div>`).join(''));
             destroyChart('sizes-chart');
-            chartInstances['sizes-chart'] = new Chart(document.getElementById('sizes-chart'), {
-                type: 'bar', data: { labels, datasets: [{ label: 'Dosya Sayisi', data: counts, backgroundColor: COLORS.map(c=>c+'99'), borderColor: COLORS, borderWidth: 1, borderRadius: 6 }] },
-                options: { responsive: true, plugins: { legend: { display: false } }, scales: { y: { beginAtZero: true, grid: { color: '#1e293b' } }, x: { grid: { display: false } } } }
-            });
-            document.getElementById('sizes-table').innerHTML = `
+            const sChartCanvas = document.getElementById('sizes-chart');
+            if (sChartCanvas) {
+                chartInstances['sizes-chart'] = new Chart(sChartCanvas, {
+                    type: 'bar', data: { labels, datasets: [{ label: 'Dosya Sayisi', data: counts, backgroundColor: COLORS.map(c=>c+'99'), borderColor: COLORS, borderWidth: 1, borderRadius: 6 }] },
+                    options: { responsive: true, plugins: { legend: { display: false } }, scales: { y: { beginAtZero: true, grid: { color: '#1e293b' } }, x: { grid: { display: false } } } }
+                });
+            }
+            _setHtmlSafe('sizes-table', `
                 <thead><tr><th>Kategori</th><th>Dosya Sayisi</th></tr></thead>
                 <tbody>${labels.map((k, i) => `<tr><td>${escapeHtml(k)}</td><td>${formatNum(counts[i])}</td></tr>`).join('')}</tbody>
-            `;
+            `);
         } else {
-            document.getElementById('sizes-cards').innerHTML = '<div style="padding:20px;color:var(--text-muted)">Kismi veri yok \u2014 Tarama tamamlandiktan sonra goruntulenecek</div>';
+            _setHtmlSafe('sizes-cards', '<div style="padding:20px;color:var(--text-muted)">Kismi veri yok \u2014 Tarama tamamlandiktan sonra goruntulenecek</div>');
         }
         _psv2StartPoll(sid, 'sizes', loadSizes);
         return;
@@ -4082,7 +4096,7 @@ async function loadSizes() {
     const data = await api(`/reports/sizes/${sid}`);
     const sizes = data.sizes || [];
 
-    document.getElementById('sizes-cards').innerHTML = sizes.map((s, i) => {
+    _setHtmlSafe('sizes-cards', sizes.map((s, i) => {
         const maxParam = s.max_bytes != null ? `&max_bytes=${s.max_bytes}` : '';
         return `
         <div class="card clickable-row" style="border-top:3px solid ${COLORS[i%COLORS.length]}"
@@ -4092,22 +4106,25 @@ async function loadSizes() {
             <div class="card-value" style="font-size:22px">${formatNum(s.file_count)}</div>
             <div class="card-sub">${s.total_size_formatted}</div>
         </div>`;
-    }).join('');
+    }).join(''));
 
     destroyChart('sizes-chart');
-    chartInstances['sizes-chart'] = new Chart(document.getElementById('sizes-chart'), {
-        type: 'bar', data: { labels: sizes.map(s=>s.label), datasets: [
-            { label: 'Dosya Sayisi', data: sizes.map(s=>s.file_count), backgroundColor: COLORS.map(c=>c+'99'), borderColor: COLORS, borderWidth: 1, borderRadius: 6 }
-        ] }, options: { responsive: true, plugins: { legend: { display: false } }, scales: { y: { beginAtZero: true, grid: { color: '#1e293b' } }, x: { grid: { display: false } } } }
-    });
+    const sChartCanvas2 = document.getElementById('sizes-chart');
+    if (sChartCanvas2) {
+        chartInstances['sizes-chart'] = new Chart(sChartCanvas2, {
+            type: 'bar', data: { labels: sizes.map(s=>s.label), datasets: [
+                { label: 'Dosya Sayisi', data: sizes.map(s=>s.file_count), backgroundColor: COLORS.map(c=>c+'99'), borderColor: COLORS, borderWidth: 1, borderRadius: 6 }
+            ] }, options: { responsive: true, plugins: { legend: { display: false } }, scales: { y: { beginAtZero: true, grid: { color: '#1e293b' } }, x: { grid: { display: false } } } }
+        });
+    }
 
-    document.getElementById('sizes-table').innerHTML = `
+    _setHtmlSafe('sizes-table', `
         <thead><tr><th>Kategori</th><th>Aralik</th><th>Dosya Sayisi</th><th>Toplam Boyut</th></tr></thead>
         <tbody>${sizes.map(s => {
             const maxParam = s.max_bytes != null ? `&max_bytes=${s.max_bytes}` : '';
             return `<tr class="clickable-row" onclick="showDrilldown('${s.label}', '/drilldown/size/${sid}?min_bytes=${s.min_bytes||0}${maxParam}', {source_id:${sid}, filter_type:'size', min_bytes:${s.min_bytes||0}${s.max_bytes!=null?`, max_bytes:${s.max_bytes}`:''}})"><td>${s.label}</td><td>${s.range_formatted || '-'}</td><td>${formatNum(s.file_count)}</td><td>${s.total_size_formatted}</td></tr>`;
         }).join('')}</tbody>
-    `;
+    `);
 }
 
 // ═══════════════════════════════════════════════════
@@ -4273,16 +4290,17 @@ async function loadUsers() {
             if (byOwner.length) {
                 const totalSize = byOwner.reduce((s, o) => s + (o.size_bytes || 0), 0);
                 const totalFiles = byOwner.reduce((s, o) => s + (o.count || 0), 0);
-                document.getElementById('user-cards').innerHTML = `
+                _setHtmlSafe('user-cards', `
                     <div class="card accent"><div class="card-label">Dosya Sahipleri</div><div class="card-value">${byOwner.length}</div></div>
                     <div class="card success"><div class="card-label">Toplam Boyut</div><div class="card-value" style="font-size:18px">${formatSize(totalSize)}</div></div>
                     <div class="card purple"><div class="card-label">Toplam Dosya</div><div class="card-value">${formatNum(totalFiles)}</div></div>
                     <div class="card warning"><div class="card-label">Veri Kaynagi</div><div class="card-value" style="font-size:14px">Kismi Veri</div><div class="card-sub">Tarama devam ediyor</div></div>
-                `;
+                `);
                 const topBySize = byOwner.slice(0, 8);
                 destroyChart('users-donut-chart');
-                if (topBySize.length) {
-                    chartInstances['users-donut-chart'] = new Chart(document.getElementById('users-donut-chart'), {
+                const uDonut = topBySize.length ? document.getElementById('users-donut-chart') : null;
+                if (uDonut) {
+                    chartInstances['users-donut-chart'] = new Chart(uDonut, {
                         type: 'doughnut', data: { labels: topBySize.map(o => o.owner || 'Bilinmiyor'), datasets: [{ data: topBySize.map(o => o.size_bytes || 0), backgroundColor: COLORS.slice(0, topBySize.length), borderWidth: 0 }] },
                         options: { responsive: true, cutout: '60%', plugins: { legend: { position: 'right', labels: { boxWidth: 10, padding: 6, font: { size: 11 } } },
                             tooltip: { callbacks: { label: (ctx) => ctx.label + ': ' + formatSize(ctx.raw) } } } }
@@ -4290,19 +4308,20 @@ async function loadUsers() {
                 }
                 destroyChart('users-top-chart');
                 const topByCount = byOwner.slice(0, 10);
-                if (topByCount.length) {
-                    chartInstances['users-top-chart'] = new Chart(document.getElementById('users-top-chart'), {
+                const uTop = topByCount.length ? document.getElementById('users-top-chart') : null;
+                if (uTop) {
+                    chartInstances['users-top-chart'] = new Chart(uTop, {
                         type: 'bar', data: { labels: topByCount.map(o => o.owner || 'Bilinmiyor'), datasets: [{ label: 'Dosya Sayisi', data: topByCount.map(o => o.count || 0), backgroundColor: COLORS.map(c=>c+'99'), borderColor: COLORS, borderWidth: 1, borderRadius: 4 }] },
                         options: { indexAxis: 'y', responsive: true, plugins: { legend: { display: false } }, scales: { x: { beginAtZero: true, grid: { color: '#1e293b' } }, y: { grid: { display: false } } } }
                     });
                 }
-                document.getElementById('users-table').innerHTML = `
+                _setHtmlSafe('users-table', `
                     <thead><tr><th>Sahip</th><th>Dosya Sayisi</th><th>Toplam Boyut</th></tr></thead>
                     <tbody>${byOwner.map(o => `<tr><td><strong>${escapeHtml(o.owner||'Bilinmiyor')}</strong></td><td>${formatNum(o.count||0)}</td><td>${formatSize(o.size_bytes||0)}</td></tr>`).join('')}</tbody>
-                `;
-                document.getElementById('users-heatmap').innerHTML = '<div style="padding:20px;color:var(--text-muted);font-size:12px">Heatmap tarama tamamlandiktan sonra goruntulenecek</div>';
+                `);
+                _setHtmlSafe('users-heatmap', '<div style="padding:20px;color:var(--text-muted);font-size:12px">Heatmap tarama tamamlandiktan sonra goruntulenecek</div>');
             } else {
-                document.getElementById('user-cards').innerHTML = '<div style="padding:20px;color:var(--text-muted)">Kismi veri yok \u2014 Tarama tamamlandiktan sonra goruntulenecek</div>';
+                _setHtmlSafe('user-cards', '<div style="padding:20px;color:var(--text-muted)">Kismi veri yok \u2014 Tarama tamamlandiktan sonra goruntulenecek</div>');
             }
             _psv2StartPoll(psSid, 'users', loadUsers);
             return;
@@ -4324,22 +4343,23 @@ async function loadUsers() {
             const totalSize = owners.reduce((s, o) => s + (o.total_size || 0), 0);
             const totalFiles = owners.reduce((s, o) => s + (o.file_count || 0), 0);
 
-            document.getElementById('user-cards').innerHTML = `
+            _setHtmlSafe('user-cards', `
                 <div class="card accent"><div class="card-label">Dosya Sahipleri</div><div class="card-value">${owners.length}</div></div>
                 <div class="card success"><div class="card-label">Toplam Boyut</div><div class="card-value" style="font-size:18px">${formatSize(totalSize)}</div></div>
                 <div class="card purple"><div class="card-label">Toplam Dosya</div><div class="card-value">${formatNum(totalFiles)}</div></div>
                 <div class="card warning"><div class="card-label">Veri Kaynagi</div><div class="card-value" style="font-size:14px">Dosya Sahipligi</div><div class="card-sub">Event Log yok</div></div>
-            `;
+            `);
 
             // Donut chart: owner distribution by SIZE
             destroyChart('users-donut-chart');
             const topBySize = owners.slice(0, 8);
-            if (topBySize.length) {
+            const uDonutFO = topBySize.length ? document.getElementById('users-donut-chart') : null;
+            if (uDonutFO) {
                 const otherSize = totalSize - topBySize.reduce((s, o) => s + (o.total_size || 0), 0);
                 const labels = topBySize.map(o => o.owner || 'Bilinmiyor');
                 const sizes = topBySize.map(o => o.total_size || 0);
                 if (otherSize > 0 && owners.length > 8) { labels.push('Diger'); sizes.push(otherSize); }
-                chartInstances['users-donut-chart'] = new Chart(document.getElementById('users-donut-chart'), {
+                chartInstances['users-donut-chart'] = new Chart(uDonutFO, {
                     type: 'doughnut', data: { labels, datasets: [{ data: sizes, backgroundColor: COLORS.slice(0, labels.length), borderWidth: 0 }] },
                     options: { responsive: true, cutout: '60%', plugins: { legend: { position: 'right', labels: { boxWidth: 10, padding: 6, font: { size: 11 } } },
                         tooltip: { callbacks: { label: (ctx) => ctx.label + ': ' + formatSize(ctx.raw) + ' (' + ((ctx.raw/Math.max(totalSize,1))*100).toFixed(1) + '%)' } } } }
@@ -4349,20 +4369,21 @@ async function loadUsers() {
             // Bar chart: top 10 owners by file count
             destroyChart('users-top-chart');
             const topByCount = owners.slice(0, 10);
-            if (topByCount.length) {
-                chartInstances['users-top-chart'] = new Chart(document.getElementById('users-top-chart'), {
+            const uTopFO = topByCount.length ? document.getElementById('users-top-chart') : null;
+            if (uTopFO) {
+                chartInstances['users-top-chart'] = new Chart(uTopFO, {
                     type: 'bar', data: { labels: topByCount.map(o=>o.owner||'Bilinmiyor'), datasets: [{ label: 'Dosya Sayisi', data: topByCount.map(o=>o.file_count||0), backgroundColor: COLORS.map(c=>c+'99'), borderColor: COLORS, borderWidth: 1, borderRadius: 4 }] },
                     options: { indexAxis: 'y', responsive: true, plugins: { legend: { display: false } }, scales: { x: { beginAtZero: true, grid: { color: '#1e293b' } }, y: { grid: { display: false } } } }
                 });
             }
 
             // Heatmap: empty
-            document.getElementById('users-heatmap').innerHTML = '<div style="padding:20px;color:var(--text-muted);font-size:12px">Event log verisi yok - heatmap kullanilamiyor</div>';
+            _setHtmlSafe('users-heatmap', '<div style="padding:20px;color:var(--text-muted);font-size:12px">Event log verisi yok - heatmap kullanilamiyor</div>');
 
             // Owner table with drill-down + archive button
             const srcSelect = document.getElementById('freq-source') || document.getElementById('types-source') || document.getElementById('overview-source');
             const defaultSid = srcSelect ? srcSelect.value : (sources.length ? sources[0].id : '');
-            document.getElementById('users-table').innerHTML = `
+            _setHtmlSafe('users-table', `
                 <thead><tr><th>Sahip</th><th>Dosya Sayisi</th><th>Toplam Boyut</th><th>Yuzde</th><th>Islem</th></tr></thead>
                 <tbody>${owners.length ? owners.map(o => {
                     const pct = totalSize > 0 ? ((o.total_size||0)/totalSize*100).toFixed(1) : '0';
@@ -4374,46 +4395,53 @@ async function loadUsers() {
                         <td style="display:flex;gap:4px"><button class="btn btn-sm btn-outline" onclick="event.stopPropagation();drilldownOwner('${ownerEsc}', '${defaultSid}')">Dosyalar</button><button class="btn btn-sm btn-danger" onclick="event.stopPropagation();showDrilldown('Arsivle: ${ownerEsc}', '/drilldown/owner/${defaultSid}?owner=${encodeURIComponent(o.owner||'')}', {source_id:${parseInt(defaultSid)||0}, filter_type:'owner', owner:'${ownerEsc}'})">Arsivle</button></td>
                     </tr>`;
                 }).join('') : '<tr><td colspan="5" style="text-align:center;padding:40px;color:var(--text-muted)">Sahiplik verisi bulunamadi. config.yaml dosyasinda read_owner: true yapin.</td></tr>'}</tbody>
-            `;
+            `);
         } else {
             // Normal: event log data available
             const topUsers = data.top_users || [];
 
-            document.getElementById('user-cards').innerHTML = `
+            _setHtmlSafe('user-cards', `
                 <div class="card accent"><div class="card-label">Aktif Kullanici</div><div class="card-value">${topUsers.length}</div></div>
-            `;
+            `);
 
             destroyChart('users-donut-chart');
             destroyChart('users-top-chart');
             if (topUsers.length) {
                 // Donut by access count
-                chartInstances['users-donut-chart'] = new Chart(document.getElementById('users-donut-chart'), {
-                    type: 'doughnut', data: { labels: topUsers.slice(0,8).map(u=>u.username), datasets: [{ data: topUsers.slice(0,8).map(u=>u.access_count||u.count||0), backgroundColor: COLORS.slice(0,8), borderWidth: 0 }] },
-                    options: { responsive: true, cutout: '60%', plugins: { legend: { position: 'right', labels: { boxWidth: 10, padding: 6, font: { size: 11 } } } } }
-                });
-                chartInstances['users-top-chart'] = new Chart(document.getElementById('users-top-chart'), {
-                    type: 'bar', data: { labels: topUsers.slice(0,10).map(u=>u.username), datasets: [{ label: 'Erisim', data: topUsers.slice(0,10).map(u=>u.access_count||u.count||0), backgroundColor: COLORS.map(c=>c+'99'), borderColor: COLORS, borderWidth: 1, borderRadius: 4 }] },
-                    options: { indexAxis: 'y', responsive: true, plugins: { legend: { display: false } }, scales: { x: { beginAtZero: true, grid: { color: '#1e293b' } }, y: { grid: { display: false } } } }
-                });
+                const uDonutEL = document.getElementById('users-donut-chart');
+                if (uDonutEL) {
+                    chartInstances['users-donut-chart'] = new Chart(uDonutEL, {
+                        type: 'doughnut', data: { labels: topUsers.slice(0,8).map(u=>u.username), datasets: [{ data: topUsers.slice(0,8).map(u=>u.access_count||u.count||0), backgroundColor: COLORS.slice(0,8), borderWidth: 0 }] },
+                        options: { responsive: true, cutout: '60%', plugins: { legend: { position: 'right', labels: { boxWidth: 10, padding: 6, font: { size: 11 } } } } }
+                    });
+                }
+                const uTopEL = document.getElementById('users-top-chart');
+                if (uTopEL) {
+                    chartInstances['users-top-chart'] = new Chart(uTopEL, {
+                        type: 'bar', data: { labels: topUsers.slice(0,10).map(u=>u.username), datasets: [{ label: 'Erisim', data: topUsers.slice(0,10).map(u=>u.access_count||u.count||0), backgroundColor: COLORS.map(c=>c+'99'), borderColor: COLORS, borderWidth: 1, borderRadius: 4 }] },
+                        options: { indexAxis: 'y', responsive: true, plugins: { legend: { display: false } }, scales: { x: { beginAtZero: true, grid: { color: '#1e293b' } }, y: { grid: { display: false } } } }
+                    });
+                }
             }
 
             const heatData = data.heatmap || await api('/users/heatmap', { silent: true }).catch(()=>({matrix:[], days:[], max_value:1}));
             renderHeatmap(heatData);
 
-            document.getElementById('users-table').innerHTML = `
+            _setHtmlSafe('users-table', `
                 <thead><tr><th>Kullanici</th><th>Erisim</th><th>Islem</th></tr></thead>
                 <tbody>${topUsers.slice(0,20).map(u => { const userEsc = escapeHtml(u.username||''); return `<tr><td><strong>${userEsc}</strong></td><td>${formatNum(u.access_count||u.count||0)}</td>
                     <td style="display:flex;gap:4px">
                         <button class="btn btn-sm btn-outline" onclick="loadUserDetail('${userEsc}')">Detay</button>
                         <button class="btn btn-sm btn-outline" style="border-color:var(--accent);color:var(--accent)" onclick="loadUserEfficiency('${userEsc}')">Verimlilik</button>
                     </td></tr>`; }).join('')}</tbody>
-            `;
+            `);
         }
     } catch(e) { console.error(e); }
 }
 
 function renderHeatmap(data) {
     const el = document.getElementById('users-heatmap');
+    if (!el) return;
     if (!data || !data.matrix || !data.matrix.length) { el.innerHTML = '<div style="padding:20px;color:var(--text-muted);font-size:12px">Heatmap verisi yok</div>'; return; }
     const days = data.days || ['Pzt','Sal','Car','Per','Cum','Cmt','Paz'];
     const max = data.max_value || 1;
@@ -4582,19 +4610,19 @@ async function loadAnomalies() {
             const naming = anom.naming || 0;
             const extension = anom.extension || 0;
             const ransomware = anom.ransomware || 0;
-            document.getElementById('anomaly-cards').innerHTML = `
+            _setHtmlSafe('anomaly-cards', `
                 <div class="card danger"><div class="card-label">Adlandirma</div><div class="card-value">${formatNum(naming)}</div><div class="card-sub">Kismi veri</div></div>
                 <div class="card warning"><div class="card-label">Uzanti Anomalisi</div><div class="card-value">${formatNum(extension)}</div><div class="card-sub">Kismi veri</div></div>
                 <div class="card accent"><div class="card-label">Ransomware Belirtisi</div><div class="card-value">${formatNum(ransomware)}</div><div class="card-sub">Kismi veri</div></div>
-            `;
-            document.getElementById('anomaly-table').innerHTML = `
+            `);
+            _setHtmlSafe('anomaly-table', `
                 <thead><tr><th>Tur</th><th>Sayim</th><th>Not</th></tr></thead>
                 <tbody>
                     <tr><td>Adlandirma</td><td>${formatNum(naming)}</td><td style="color:var(--text-muted)">Tarama tamamlandiktan sonra detay goruntulenecek</td></tr>
                     <tr><td>Uzanti Anomalisi</td><td>${formatNum(extension)}</td><td style="color:var(--text-muted)">Tarama tamamlandiktan sonra detay goruntulenecek</td></tr>
                     <tr><td>Ransomware Belirtisi</td><td>${formatNum(ransomware)}</td><td style="color:var(--text-muted)">Tarama tamamlandiktan sonra detay goruntulenecek</td></tr>
                 </tbody>
-            `;
+            `);
             _psv2StartPoll(psSid, 'anomalies', loadAnomalies);
             return;
         }
@@ -4612,22 +4640,24 @@ async function loadAnomalies() {
         const alerts = Array.isArray(data) ? data : [];
 
         const badge = document.getElementById('anomaly-badge');
-        if (alerts.length > 0) { badge.style.display = 'inline'; badge.textContent = alerts.length; }
-        else { badge.style.display = 'none'; }
+        if (badge) {
+            if (alerts.length > 0) { badge.style.display = 'inline'; badge.textContent = alerts.length; }
+            else { badge.style.display = 'none'; }
+        }
 
         const crit = alerts.filter(a => a.severity === 'critical').length;
         const warn = alerts.filter(a => a.severity === 'warning').length;
 
-        document.getElementById('anomaly-cards').innerHTML = `
+        _setHtmlSafe('anomaly-cards', `
             <div class="card danger"><div class="card-label">Kritik</div><div class="card-value">${crit}</div></div>
             <div class="card warning"><div class="card-label">Uyari</div><div class="card-value">${warn}</div></div>
             <div class="card accent"><div class="card-label">Toplam</div><div class="card-value">${alerts.length}</div></div>
-        `;
+        `);
 
-        document.getElementById('anomaly-table').innerHTML = `
+        _setHtmlSafe('anomaly-table', `
             <thead><tr><th>Tur</th><th>Ciddiyet</th><th>Kullanici</th><th>Aciklama</th></tr></thead>
             <tbody>${alerts.length ? alerts.map(a => `<tr><td>${escapeHtml(a.alert_type||a.type||'')}</td><td><span class="badge badge-${a.severity==='critical'?'danger':'warning'}">${escapeHtml(a.severity||'')}</span></td><td>${escapeHtml(a.username||'-')}</td><td>${escapeHtml(a.description||'')}</td></tr>`).join('') : '<tr><td colspan="4" style="text-align:center;padding:40px;color:var(--text-muted)">Anomali bulunamadi ✅</td></tr>'}</tbody>
-        `;
+        `);
     } catch(e) { console.error(e); }
 }
 
@@ -4637,39 +4667,41 @@ async function loadAnomalies() {
 async function loadArchive() {
     try {
         const stats = await api('/archive/stats', { silent: true });
-        document.getElementById('archive-cards').innerHTML = `
+        _setHtmlSafe('archive-cards', `
             <div class="card accent"><div class="card-label">Arsivlenen</div><div class="card-value">${formatNum(stats.total_archived)}</div></div>
             <div class="card success"><div class="card-label">Su An Arsivde</div><div class="card-value">${formatNum(stats.currently_archived)}</div></div>
             <div class="card warning"><div class="card-label">Geri Yuklenen</div><div class="card-value">${formatNum(stats.total_restored)}</div></div>
             <div class="card purple"><div class="card-label">Arsiv Boyutu</div><div class="card-value">${formatSize(stats.archived_size)}</div></div>
-        `;
+        `);
     } catch(e) {}
 
     // Islem gecmisi yukle
     try {
         const ops = await api('/archive/operations', { silent: true });
         const opTable = document.getElementById('archive-operations-table');
-        if (ops && ops.length) {
-            const statusBadge = (s) => {
-                const colors = { completed: 'badge-success', running: 'badge-info', failed: 'badge-danger', partial: 'badge-warning' };
-                return `<span class="badge ${colors[s]||'badge-info'}">${s}</span>`;
-            };
-            const typeBadge = (t) => t === 'archive' ? '<span class="badge badge-accent">Arsiv</span>' : '<span class="badge badge-success">Geri Yukleme</span>';
-            opTable.innerHTML = `
-                <thead><tr><th>ID</th><th>Tarih</th><th>Tur</th><th>Tetikleyen</th><th>Dosya</th><th>Boyut</th><th>Durum</th><th>Islem</th></tr></thead>
-                <tbody>${ops.map(o => `<tr style="cursor:pointer" onclick="showOperationDetail(${o.id})">
-                    <td>${o.id}</td>
-                    <td>${(o.started_at||'').substring(0,19)}</td>
-                    <td>${typeBadge(o.operation_type)}</td>
-                    <td><span style="font-size:11px">${o.trigger_type||'-'} ${o.trigger_detail ? '('+o.trigger_detail+')' : ''}</span></td>
-                    <td>${formatNum(o.total_files)}</td>
-                    <td>${formatSize(o.total_size)}</td>
-                    <td>${statusBadge(o.status)}</td>
-                    <td>${o.operation_type==='archive' && o.status==='completed' ? `<button class="btn btn-sm btn-success" onclick="event.stopPropagation();restoreByOperation(${o.id})">Geri Yukle</button>` : ''}</td>
-                </tr>`).join('')}</tbody>
-            `;
-        } else {
-            opTable.innerHTML = '<div style="text-align:center;padding:40px;color:var(--text-muted);font-size:12px">Henuz arsiv islemi yapilmamis</div>';
+        if (opTable) {
+            if (ops && ops.length) {
+                const statusBadge = (s) => {
+                    const colors = { completed: 'badge-success', running: 'badge-info', failed: 'badge-danger', partial: 'badge-warning' };
+                    return `<span class="badge ${colors[s]||'badge-info'}">${s}</span>`;
+                };
+                const typeBadge = (t) => t === 'archive' ? '<span class="badge badge-accent">Arsiv</span>' : '<span class="badge badge-success">Geri Yukleme</span>';
+                opTable.innerHTML = `
+                    <thead><tr><th>ID</th><th>Tarih</th><th>Tur</th><th>Tetikleyen</th><th>Dosya</th><th>Boyut</th><th>Durum</th><th>Islem</th></tr></thead>
+                    <tbody>${ops.map(o => `<tr style="cursor:pointer" onclick="showOperationDetail(${o.id})">
+                        <td>${o.id}</td>
+                        <td>${(o.started_at||'').substring(0,19)}</td>
+                        <td>${typeBadge(o.operation_type)}</td>
+                        <td><span style="font-size:11px">${o.trigger_type||'-'} ${o.trigger_detail ? '('+o.trigger_detail+')' : ''}</span></td>
+                        <td>${formatNum(o.total_files)}</td>
+                        <td>${formatSize(o.total_size)}</td>
+                        <td>${statusBadge(o.status)}</td>
+                        <td>${o.operation_type==='archive' && o.status==='completed' ? `<button class="btn btn-sm btn-success" onclick="event.stopPropagation();restoreByOperation(${o.id})">Geri Yukle</button>` : ''}</td>
+                    </tr>`).join('')}</tbody>
+                `;
+            } else {
+                opTable.innerHTML = '<div style="text-align:center;padding:40px;color:var(--text-muted);font-size:12px">Henuz arsiv islemi yapilmamis</div>';
+            }
         }
     } catch(e) { console.error('Operations load error:', e); }
 }

--- a/src/dashboard/static/index.html
+++ b/src/dashboard/static/index.html
@@ -2653,6 +2653,15 @@ function _setHtmlSafe(id, html) {
     }
 }
 
+function _setTextSafe(id, text) {
+    const el = document.getElementById(id);
+    if (el) {
+        el.textContent = text == null ? '' : String(text);
+    } else if (window && window.console) {
+        console.warn('_setTextSafe: element not found:', id);
+    }
+}
+
 function destroyChart(id) { if (chartInstances[id]) { chartInstances[id].destroy(); delete chartInstances[id]; } }
 
 const COLORS = ['#3b82f6','#10b981','#f59e0b','#ef4444','#8b5cf6','#06b6d4','#ec4899','#f97316','#14b8a6','#a855f7','#6366f1','#84cc16','#e11d48','#0ea5e9','#d946ef','#facc15','#22d3ee','#fb923c','#4ade80','#c084fc'];
@@ -3506,7 +3515,7 @@ async function loadOverview() {
         ['ov-files','ov-size','ov-stale-pct','ov-owners','ov-risky','ov-dups'].forEach(id => {
             const el = document.getElementById(id); if(el) el.textContent = '-';
         });
-        document.getElementById('ov-risk-text').textContent = '--';
+        _setTextSafe('ov-risk-text', '--');
         updatePartialBanner(null, null);
         return;
     }
@@ -3538,40 +3547,44 @@ async function loadOverview() {
         const rs = riskData.risk_score || 0;
         const kpi = riskData.kpis || {};
 
-        // Risk gauge
+        // Risk gauge — all DOM access guarded so stale HTML / missing
+        // page wrapper doesn't crash the whole loader.
         const circumference = 213.6;
         const offset = circumference - (circumference * rs / 100);
         const gauge = document.getElementById('ov-risk-gauge');
-        gauge.style.strokeDashoffset = offset;
-        gauge.style.stroke = rs >= 70 ? 'var(--danger)' : rs >= 40 ? 'var(--warning)' : 'var(--success)';
-        document.getElementById('ov-risk-text').textContent = rs;
+        if (gauge) {
+            gauge.style.strokeDashoffset = offset;
+            gauge.style.stroke = rs >= 70 ? 'var(--danger)' : rs >= 40 ? 'var(--warning)' : 'var(--success)';
+        }
+        _setTextSafe('ov-risk-text', rs);
         const lvl = riskData.risk_level || 'good';
         const lvlMap = {critical:'Kritik', warning:'Uyari', good:'Iyi'};
-        document.getElementById('ov-risk-level').textContent = lvlMap[lvl] || lvl;
+        _setTextSafe('ov-risk-level', lvlMap[lvl] || lvl);
 
-        document.getElementById('ov-stale-pct').textContent = (kpi.stale_pct || 0) + '%';
-        document.getElementById('ov-stale-sub').textContent = formatNum(kpi.stale_count || 0) + ' dosya, ' + formatSize(kpi.stale_size || 0);
+        _setTextSafe('ov-stale-pct', (kpi.stale_pct || 0) + '%');
+        _setTextSafe('ov-stale-sub', formatNum(kpi.stale_count || 0) + ' dosya, ' + formatSize(kpi.stale_size || 0));
 
-        document.getElementById('ov-files').textContent = formatNum(riskData.total_files || 0);
+        _setTextSafe('ov-files', formatNum(riskData.total_files || 0));
         const growth = trendData.growth;
-        document.getElementById('ov-files-sub').textContent = growth ? ((growth.file_diff >= 0 ? '+' : '') + formatNum(growth.file_diff) + ' son tarama') : '';
+        _setTextSafe('ov-files-sub', growth ? ((growth.file_diff >= 0 ? '+' : '') + formatNum(growth.file_diff) + ' son tarama') : '');
 
-        document.getElementById('ov-size').textContent = formatSize(riskData.total_size || 0);
-        document.getElementById('ov-size-sub').textContent = growth ? ((growth.size_diff >= 0 ? '+' : '') + formatSize(growth.size_diff) + ' son tarama') : '';
+        _setTextSafe('ov-size', formatSize(riskData.total_size || 0));
+        _setTextSafe('ov-size-sub', growth ? ((growth.size_diff >= 0 ? '+' : '') + formatSize(growth.size_diff) + ' son tarama') : '');
 
-        document.getElementById('ov-owners').textContent = kpi.owner_count || 0;
-        document.getElementById('ov-owners-sub').textContent = kpi.owner_count <= 1 ? 'read_owner aktif edin' : 'benzersiz sahip';
+        _setTextSafe('ov-owners', kpi.owner_count || 0);
+        _setTextSafe('ov-owners-sub', kpi.owner_count <= 1 ? 'read_owner aktif edin' : 'benzersiz sahip');
 
-        document.getElementById('ov-risky').textContent = formatNum(kpi.risky_files || 0);
+        _setTextSafe('ov-risky', formatNum(kpi.risky_files || 0));
 
-        document.getElementById('ov-dups').textContent = formatNum(kpi.dup_groups || 0);
+        _setTextSafe('ov-dups', formatNum(kpi.dup_groups || 0));
 
         // Age distribution chart (horizontal bar) — frequency endpoint'i yavas
         // olabilir, arka planda doldur. Once bos yer tut, cevap gelince ciz.
         destroyChart('ov-age-chart');
         freqPromise.then(freqData => {
             const freq = freqData.frequency || [];
-            if (freq.length) {
+            const ageCanvas = document.getElementById('ov-age-chart');
+            if (freq.length && ageCanvas) {
                 const ageColors = freq.map(f => {
                     const d = f.days || 0;
                     if (d >= 365) return '#ef4444';
@@ -3579,7 +3592,7 @@ async function loadOverview() {
                     if (d >= 90) return '#eab308';
                     return '#10b981';
                 });
-                chartInstances['ov-age-chart'] = new Chart(document.getElementById('ov-age-chart'), {
+                chartInstances['ov-age-chart'] = new Chart(ageCanvas, {
                     type: 'bar', data: {
                         labels: freq.map(f => f.label),
                         datasets: [{
@@ -3595,8 +3608,9 @@ async function loadOverview() {
         // Growth trend chart (line)
         const scans = trendData.scans || [];
         destroyChart('ov-trend-chart');
-        if (scans.length) {
-            chartInstances['ov-trend-chart'] = new Chart(document.getElementById('ov-trend-chart'), {
+        const trendCanvas = document.getElementById('ov-trend-chart');
+        if (scans.length && trendCanvas) {
+            chartInstances['ov-trend-chart'] = new Chart(trendCanvas, {
                 type: 'line', data: {
                     labels: scans.map(s => (s.started_at || '').substring(5, 16)),
                     datasets: [
@@ -4189,8 +4203,8 @@ function renderTreemap() {
 
     svg.attr('viewBox', `0 0 ${w} ${h}`);
 
-    const colorMode = document.getElementById('treemap-color').value;
-    const sizeMode = document.getElementById('treemap-size').value;
+    const colorMode = document.getElementById('treemap-color')?.value || 'extension';
+    const sizeMode = document.getElementById('treemap-size')?.value || 'size';
 
     const root = d3.hierarchy(treemapData)
         .sum(d => sizeMode === 'count' ? (d.count || 1) : (d.value || d.size || 1))
@@ -5101,21 +5115,25 @@ async function loadInsights() {
         const circumference = 326.7;
         const offset = circumference - (circumference * score / 100);
         const gauge = document.getElementById('insights-gauge');
-        gauge.style.strokeDashoffset = offset;
-        gauge.style.stroke = score >= 70 ? 'var(--success)' : score >= 40 ? 'var(--warning)' : 'var(--danger)';
-        document.getElementById('insights-score-text').textContent = score;
+        if (gauge) {
+            gauge.style.strokeDashoffset = offset;
+            gauge.style.stroke = score >= 70 ? 'var(--success)' : score >= 40 ? 'var(--warning)' : 'var(--danger)';
+        }
+        _setTextSafe('insights-score-text', score);
 
         const desc = score >= 80 ? 'Cok iyi durumda' : score >= 60 ? 'Iyi, iyilestirme mevcut' : score >= 40 ? 'Orta - aksiyon gerekli' : 'Kritik - acil mudahale';
-        document.getElementById('insights-score-desc').textContent = desc;
+        _setTextSafe('insights-score-desc', desc);
 
         // Reclaimable space
         const reclaim = insights.find(i => i.category === 'recommendation' && i.impact_size);
         const reclaimEl = document.getElementById('insights-reclaimable');
-        if (reclaim) {
-            reclaimEl.style.display = 'block';
-            document.getElementById('insights-reclaim-value').textContent = formatSize(reclaim.impact_size);
-        } else {
-            reclaimEl.style.display = 'none';
+        if (reclaimEl) {
+            if (reclaim) {
+                reclaimEl.style.display = 'block';
+                _setTextSafe('insights-reclaim-value', formatSize(reclaim.impact_size));
+            } else {
+                reclaimEl.style.display = 'none';
+            }
         }
 
         // Render insight cards
@@ -5123,7 +5141,7 @@ async function loadInsights() {
         const sevIcons = { critical: '🔴', warning: '🟡', info: '🔵', success: '🟢' };
         const catIcons = { storage: '💾', stale: '📅', duplicates: '📋', security: '🔒', growth: '📈', recommendation: '✨', audit: '📝' };
 
-        document.getElementById('insights-list').innerHTML = insights.length ? insights.map(i => `
+        _setHtmlSafe('insights-list', insights.length ? insights.map(i => `
             <div style="background:var(--bg-card);border:1px solid var(--border);border-left:4px solid ${sevColors[i.severity] || 'var(--border-light)'};border-radius:var(--radius);padding:16px 20px;display:flex;align-items:flex-start;gap:14px">
                 <div style="font-size:22px;flex-shrink:0">${catIcons[i.category] || sevIcons[i.severity] || '📌'}</div>
                 <div style="flex:1;min-width:0">
@@ -5141,7 +5159,7 @@ async function loadInsights() {
                     </div>
                 </div>
             </div>
-        `).join('') : '<div style="text-align:center;padding:60px;color:var(--text-muted)">Insight bulunamadi. Once bir tarama yapin.</div>';
+        `).join('') : '<div style="text-align:center;padding:60px;color:var(--text-muted)">Insight bulunamadi. Once bir tarama yapin.</div>');
     } catch(e) { notify(e.message, 'error'); }
 }
 
@@ -5208,67 +5226,74 @@ async function loadNaming() {
         const circumference = 213.6;
         const offset = circumference - (circumference * score / 100);
         const gauge = document.getElementById('naming-gauge');
-        gauge.style.strokeDashoffset = offset;
-        gauge.style.stroke = score >= 70 ? 'var(--success)' : score >= 40 ? 'var(--warning)' : 'var(--danger)';
-        document.getElementById('naming-score-text').textContent = Math.round(score);
-        document.getElementById('naming-req-pct').textContent = (data.requirement_compliance || 0) + '%';
-        document.getElementById('naming-full-pct').textContent = (data.full_compliance || 0) + '%';
+        if (gauge) {
+            gauge.style.strokeDashoffset = offset;
+            gauge.style.stroke = score >= 70 ? 'var(--success)' : score >= 40 ? 'var(--warning)' : 'var(--danger)';
+        }
+        _setTextSafe('naming-score-text', Math.round(score));
+        _setTextSafe('naming-req-pct', (data.requirement_compliance || 0) + '%');
+        _setTextSafe('naming-full-pct', (data.full_compliance || 0) + '%');
 
         // Zorunlu kurallar tablosu
         const reqs = data.requirements || [];
         const reqTable = document.getElementById('naming-req-table');
-        if (reqs.length) {
-            reqTable.innerHTML = `
-                <thead><tr><th>Kod</th><th>Kural</th><th>Ihlal Sayisi</th><th>Oran</th><th>Ciddiyet</th><th>Ornekler</th><th>Islem</th></tr></thead>
-                <tbody>${reqs.map(r => `<tr>
-                    <td><strong>${escapeHtml(r.code)}</strong></td>
-                    <td>${escapeHtml(r.label)}</td>
-                    <td>${formatNum(r.count)}</td>
-                    <td>
-                        <div style="display:flex;align-items:center;gap:8px">
-                            <div style="flex:1;height:6px;background:var(--bg-secondary);border-radius:3px;overflow:hidden;min-width:60px">
-                                <div style="width:${Math.min(r.percentage, 100)}%;height:100%;background:${r.severity==='critical'?'var(--danger)':'var(--warning)'};border-radius:3px"></div>
+        if (reqTable) {
+            if (reqs.length) {
+                reqTable.innerHTML = `
+                    <thead><tr><th>Kod</th><th>Kural</th><th>Ihlal Sayisi</th><th>Oran</th><th>Ciddiyet</th><th>Ornekler</th><th>Islem</th></tr></thead>
+                    <tbody>${reqs.map(r => `<tr>
+                        <td><strong>${escapeHtml(r.code)}</strong></td>
+                        <td>${escapeHtml(r.label)}</td>
+                        <td>${formatNum(r.count)}</td>
+                        <td>
+                            <div style="display:flex;align-items:center;gap:8px">
+                                <div style="flex:1;height:6px;background:var(--bg-secondary);border-radius:3px;overflow:hidden;min-width:60px">
+                                    <div style="width:${Math.min(r.percentage, 100)}%;height:100%;background:${r.severity==='critical'?'var(--danger)':'var(--warning)'};border-radius:3px"></div>
+                                </div>
+                                <span style="font-size:11px;min-width:40px">${r.percentage}%</span>
                             </div>
-                            <span style="font-size:11px;min-width:40px">${r.percentage}%</span>
-                        </div>
-                    </td>
-                    <td><span class="badge ${r.severity==='critical'?'badge-danger':r.severity==='warning'?'badge-warning':'badge-info'}">${escapeHtml(r.severity||'')}</span></td>
-                    <td style="font-size:11px;color:var(--text-muted);max-width:250px;word-break:break-word">${(r.samples||[]).slice(0,3).map(escapeHtml).join('<br>')}</td>
-                    <td><button class="btn btn-sm btn-outline" onclick="showNamingFiles('${escapeHtml(r.code)}', ${sourceId})">Dosyalari Gor</button></td>
-                </tr>`).join('')}</tbody>
-            `;
-        } else {
-            reqTable.innerHTML = '<div style="text-align:center;padding:20px;color:var(--success);font-size:13px">Tum dosyalar zorunlu kurallara uyumlu!</div>';
+                        </td>
+                        <td><span class="badge ${r.severity==='critical'?'badge-danger':r.severity==='warning'?'badge-warning':'badge-info'}">${escapeHtml(r.severity||'')}</span></td>
+                        <td style="font-size:11px;color:var(--text-muted);max-width:250px;word-break:break-word">${(r.samples||[]).slice(0,3).map(escapeHtml).join('<br>')}</td>
+                        <td><button class="btn btn-sm btn-outline" onclick="showNamingFiles('${escapeHtml(r.code)}', ${sourceId})">Dosyalari Gor</button></td>
+                    </tr>`).join('')}</tbody>
+                `;
+            } else {
+                reqTable.innerHTML = '<div style="text-align:center;padding:20px;color:var(--success);font-size:13px">Tum dosyalar zorunlu kurallara uyumlu!</div>';
+            }
         }
 
         // Best practices tablosu
         const bps = data.best_practices || [];
         const bpTable = document.getElementById('naming-bp-table');
-        if (bps.length) {
-            bpTable.innerHTML = `
-                <thead><tr><th>Kod</th><th>Uygulama</th><th>Sapma Sayisi</th><th>Oran</th><th>Ciddiyet</th><th>Ornekler</th><th>Islem</th></tr></thead>
-                <tbody>${bps.map(b => `<tr>
-                    <td><strong>${escapeHtml(b.code)}</strong></td>
-                    <td>${escapeHtml(b.label)}</td>
-                    <td>${formatNum(b.count)}</td>
-                    <td>
-                        <div style="display:flex;align-items:center;gap:8px">
-                            <div style="flex:1;height:6px;background:var(--bg-secondary);border-radius:3px;overflow:hidden;min-width:60px">
-                                <div style="width:${Math.min(b.percentage, 100)}%;height:100%;background:${b.severity==='warning'?'var(--warning)':'var(--info)'};border-radius:3px"></div>
+        if (bpTable) {
+            if (bps.length) {
+                bpTable.innerHTML = `
+                    <thead><tr><th>Kod</th><th>Uygulama</th><th>Sapma Sayisi</th><th>Oran</th><th>Ciddiyet</th><th>Ornekler</th><th>Islem</th></tr></thead>
+                    <tbody>${bps.map(b => `<tr>
+                        <td><strong>${escapeHtml(b.code)}</strong></td>
+                        <td>${escapeHtml(b.label)}</td>
+                        <td>${formatNum(b.count)}</td>
+                        <td>
+                            <div style="display:flex;align-items:center;gap:8px">
+                                <div style="flex:1;height:6px;background:var(--bg-secondary);border-radius:3px;overflow:hidden;min-width:60px">
+                                    <div style="width:${Math.min(b.percentage, 100)}%;height:100%;background:${b.severity==='warning'?'var(--warning)':'var(--info)'};border-radius:3px"></div>
+                                </div>
+                                <span style="font-size:11px;min-width:40px">${b.percentage}%</span>
                             </div>
-                            <span style="font-size:11px;min-width:40px">${b.percentage}%</span>
-                        </div>
-                    </td>
-                    <td><span class="badge ${b.severity==='warning'?'badge-warning':'badge-info'}">${escapeHtml(b.severity||'')}</span></td>
-                    <td style="font-size:11px;color:var(--text-muted);max-width:250px;word-break:break-word">${(b.samples||[]).slice(0,3).map(escapeHtml).join('<br>')}</td>
-                    <td><button class="btn btn-sm btn-outline" onclick="showNamingFiles('${escapeHtml(b.code)}', ${sourceId})">Dosyalari Gor</button></td>
-                </tr>`).join('')}</tbody>
-            `;
-        } else {
-            bpTable.innerHTML = '<div style="text-align:center;padding:20px;color:var(--success);font-size:13px">Tum dosyalar en iyi uygulamalara uyumlu!</div>';
+                        </td>
+                        <td><span class="badge ${b.severity==='warning'?'badge-warning':'badge-info'}">${escapeHtml(b.severity||'')}</span></td>
+                        <td style="font-size:11px;color:var(--text-muted);max-width:250px;word-break:break-word">${(b.samples||[]).slice(0,3).map(escapeHtml).join('<br>')}</td>
+                        <td><button class="btn btn-sm btn-outline" onclick="showNamingFiles('${escapeHtml(b.code)}', ${sourceId})">Dosyalari Gor</button></td>
+                    </tr>`).join('')}</tbody>
+                `;
+            } else {
+                bpTable.innerHTML = '<div style="text-align:center;padding:20px;color:var(--success);font-size:13px">Tum dosyalar en iyi uygulamalara uyumlu!</div>';
+            }
         }
         // Export butonunu goster
-        document.getElementById('naming-export-btn').style.display = '';
+        const exportBtn = document.getElementById('naming-export-btn');
+        if (exportBtn) exportBtn.style.display = '';
 
         // Issue #80: reusable entity-list ile ihlal eden dosyalari listele
         renderMitNamingEntityList(sourceId, data);
@@ -5718,11 +5743,11 @@ async function loadArchiveHistory(page) {
         const totalOps = data.total || 0;
         const archiveOps = ops.filter(o => o.operation_type === 'archive').length;
         const restoreOps = ops.filter(o => o.operation_type === 'restore').length;
-        document.getElementById('ah-summary-cards').innerHTML = `
+        _setHtmlSafe('ah-summary-cards', `
             <div class="card accent"><div class="card-label">Toplam Islem</div><div class="card-value">${formatNum(totalOps)}</div></div>
             <div class="card warning"><div class="card-label">Bu Sayfada</div><div class="card-value">${ops.length}</div></div>
             <div class="card purple"><div class="card-label">Sayfa</div><div class="card-value">${data.page}/${data.total_pages}</div></div>
-        `;
+        `);
 
         // Tablo
         const statusBadge = (s) => {
@@ -5732,39 +5757,43 @@ async function loadArchiveHistory(page) {
         const typeBadge = (t) => t === 'archive' ? '<span class="badge badge-accent">Arsiv</span>' : '<span class="badge badge-success">Geri Yukleme</span>';
 
         const table = document.getElementById('ah-table');
-        if (ops.length) {
-            table.innerHTML = `
-                <thead><tr><th>ID</th><th>Tarih</th><th>Tur</th><th>Tetikleyen</th><th>Dosya</th><th>Boyut</th><th>Durum</th><th>Detay</th></tr></thead>
-                <tbody>${ops.map(o => `<tr>
-                    <td>${o.id}</td>
-                    <td>${(o.started_at||'').substring(0,19)}</td>
-                    <td>${typeBadge(o.operation_type)}</td>
-                    <td><span style="font-size:11px">${o.trigger_type||'-'} ${o.trigger_detail ? '('+o.trigger_detail+')' : ''}</span></td>
-                    <td>${formatNum(o.total_files)}</td>
-                    <td>${o.total_size_formatted || formatSize(o.total_size)}</td>
-                    <td>${statusBadge(o.status)}</td>
-                    <td>
-                        <button class="btn btn-sm btn-outline" onclick="showOperationFiles(${o.id})">Dosyalar</button>
-                        ${o.operation_type==='archive' && o.status==='completed' ? `<button class="btn btn-sm btn-success" onclick="restoreByOperation(${o.id})">Geri Yukle</button>` : ''}
-                    </td>
-                </tr>`).join('')}</tbody>
-            `;
-        } else {
-            table.innerHTML = '<div style="text-align:center;padding:40px;color:var(--text-muted);font-size:12px">Filtrelere uygun islem bulunamadi</div>';
+        if (table) {
+            if (ops.length) {
+                table.innerHTML = `
+                    <thead><tr><th>ID</th><th>Tarih</th><th>Tur</th><th>Tetikleyen</th><th>Dosya</th><th>Boyut</th><th>Durum</th><th>Detay</th></tr></thead>
+                    <tbody>${ops.map(o => `<tr>
+                        <td>${o.id}</td>
+                        <td>${(o.started_at||'').substring(0,19)}</td>
+                        <td>${typeBadge(o.operation_type)}</td>
+                        <td><span style="font-size:11px">${o.trigger_type||'-'} ${o.trigger_detail ? '('+o.trigger_detail+')' : ''}</span></td>
+                        <td>${formatNum(o.total_files)}</td>
+                        <td>${o.total_size_formatted || formatSize(o.total_size)}</td>
+                        <td>${statusBadge(o.status)}</td>
+                        <td>
+                            <button class="btn btn-sm btn-outline" onclick="showOperationFiles(${o.id})">Dosyalar</button>
+                            ${o.operation_type==='archive' && o.status==='completed' ? `<button class="btn btn-sm btn-success" onclick="restoreByOperation(${o.id})">Geri Yukle</button>` : ''}
+                        </td>
+                    </tr>`).join('')}</tbody>
+                `;
+            } else {
+                table.innerHTML = '<div style="text-align:center;padding:40px;color:var(--text-muted);font-size:12px">Filtrelere uygun islem bulunamadi</div>';
+            }
         }
 
         // Sayfalama
         const pag = document.getElementById('ah-pagination');
-        if (data.total_pages > 1) {
-            let html = '';
-            if (ahCurrentPage > 1) html += `<button class="btn btn-sm btn-outline" onclick="loadArchiveHistory(${ahCurrentPage-1})">Onceki</button>`;
-            for (let i = Math.max(1, ahCurrentPage-2); i <= Math.min(data.total_pages, ahCurrentPage+2); i++) {
-                html += `<button class="btn btn-sm ${i===ahCurrentPage?'btn-primary':'btn-outline'}" onclick="loadArchiveHistory(${i})">${i}</button>`;
+        if (pag) {
+            if (data.total_pages > 1) {
+                let html = '';
+                if (ahCurrentPage > 1) html += `<button class="btn btn-sm btn-outline" onclick="loadArchiveHistory(${ahCurrentPage-1})">Onceki</button>`;
+                for (let i = Math.max(1, ahCurrentPage-2); i <= Math.min(data.total_pages, ahCurrentPage+2); i++) {
+                    html += `<button class="btn btn-sm ${i===ahCurrentPage?'btn-primary':'btn-outline'}" onclick="loadArchiveHistory(${i})">${i}</button>`;
+                }
+                if (ahCurrentPage < data.total_pages) html += `<button class="btn btn-sm btn-outline" onclick="loadArchiveHistory(${ahCurrentPage+1})">Sonraki</button>`;
+                pag.innerHTML = html;
+            } else {
+                pag.innerHTML = '';
             }
-            if (ahCurrentPage < data.total_pages) html += `<button class="btn btn-sm btn-outline" onclick="loadArchiveHistory(${ahCurrentPage+1})">Sonraki</button>`;
-            pag.innerHTML = html;
-        } else {
-            pag.innerHTML = '';
         }
         _attachArchiveHistoryViewToggle();
     } catch(e) { console.error('Archive history error:', e); }
@@ -6000,14 +6029,17 @@ async function loadDuplicates(page) {
 
 // Issue #84 — Gorsel ↔ Profesyonel mod toggle for Kopya Dosyalar.
 function _renderDuplicatesVisual() {
-    document.getElementById('dup-visual-host').style.display = '';
-    document.getElementById('dup-grid-host').style.display = 'none';
-    document.getElementById('dup-grid-host').innerHTML = '';
+    const v = document.getElementById('dup-visual-host');
+    const g = document.getElementById('dup-grid-host');
+    if (v) v.style.display = '';
+    if (g) { g.style.display = 'none'; g.innerHTML = ''; }
 }
 
 function _renderDuplicatesGrid() {
     const host = document.getElementById('dup-grid-host');
-    document.getElementById('dup-visual-host').style.display = 'none';
+    const v = document.getElementById('dup-visual-host');
+    if (v) v.style.display = 'none';
+    if (!host) return;
     host.style.display = '';
     if (typeof renderEntityList !== 'function') {
         host.innerHTML = '<div style="padding:20px;color:var(--text-muted)">entity-list yuklenmedi</div>';
@@ -6590,8 +6622,9 @@ async function loadGrowth() {
         `);
 
         // Yillik grafik
-        if (yearly.length) {
-            const ctx = document.getElementById('growth-yearly-chart').getContext('2d');
+        const yCanvas = yearly.length ? document.getElementById('growth-yearly-chart') : null;
+        if (yCanvas) {
+            const ctx = yCanvas.getContext('2d');
             if (growthCharts.yearly) growthCharts.yearly.destroy();
             growthCharts.yearly = new Chart(ctx, {
                 type: 'bar',
@@ -6625,8 +6658,9 @@ async function loadGrowth() {
         }
 
         // Aylik grafik
-        if (monthly.length) {
-            const ctx = document.getElementById('growth-monthly-chart').getContext('2d');
+        const mCanvas = monthly.length ? document.getElementById('growth-monthly-chart') : null;
+        if (mCanvas) {
+            const ctx = mCanvas.getContext('2d');
             if (growthCharts.monthly) growthCharts.monthly.destroy();
             growthCharts.monthly = new Chart(ctx, {
                 type: 'line',
@@ -6652,8 +6686,9 @@ async function loadGrowth() {
         }
 
         // Gunluk grafik
-        if (daily.length) {
-            const ctx = document.getElementById('growth-daily-chart').getContext('2d');
+        const dCanvas = daily.length ? document.getElementById('growth-daily-chart') : null;
+        if (dCanvas) {
+            const ctx = dCanvas.getContext('2d');
             if (growthCharts.daily) growthCharts.daily.destroy();
             growthCharts.daily = new Chart(ctx, {
                 type: 'line',
@@ -6688,27 +6723,29 @@ async function loadGrowth() {
         // En cok dosya olusturanlar
         const creators = data.top_creators || [];
         const creatorsTable = document.getElementById('growth-creators-table');
-        if (creators.length) {
-            creatorsTable.innerHTML = `
-                <thead><tr><th>Kullanici</th><th>Dosya Sayisi</th><th>Toplam Boyut</th><th>Oran</th></tr></thead>
-                <tbody>${creators.map(c => `
-                    <tr>
-                        <td><strong>${escapeHtml(c.owner || 'Bilinmiyor')}</strong></td>
-                        <td>${formatNum(c.file_count)}</td>
-                        <td>${formatSize(c.total_size)}</td>
-                        <td>
-                            <div style="display:flex;align-items:center;gap:8px">
-                                <div style="flex:1;height:6px;background:var(--bg-secondary);border-radius:3px;overflow:hidden">
-                                    <div style="width:${c.percentage || 0}%;height:100%;background:var(--accent);border-radius:3px"></div>
+        if (creatorsTable) {
+            if (creators.length) {
+                creatorsTable.innerHTML = `
+                    <thead><tr><th>Kullanici</th><th>Dosya Sayisi</th><th>Toplam Boyut</th><th>Oran</th></tr></thead>
+                    <tbody>${creators.map(c => `
+                        <tr>
+                            <td><strong>${escapeHtml(c.owner || 'Bilinmiyor')}</strong></td>
+                            <td>${formatNum(c.file_count)}</td>
+                            <td>${formatSize(c.total_size)}</td>
+                            <td>
+                                <div style="display:flex;align-items:center;gap:8px">
+                                    <div style="flex:1;height:6px;background:var(--bg-secondary);border-radius:3px;overflow:hidden">
+                                        <div style="width:${c.percentage || 0}%;height:100%;background:var(--accent);border-radius:3px"></div>
+                                    </div>
+                                    <span style="font-size:11px;color:var(--text-muted)">${(c.percentage || 0).toFixed(1)}%</span>
                                 </div>
-                                <span style="font-size:11px;color:var(--text-muted)">${(c.percentage || 0).toFixed(1)}%</span>
-                            </div>
-                        </td>
-                    </tr>
-                `).join('')}</tbody>
-            `;
-        } else {
-            creatorsTable.innerHTML = '<div style="text-align:center;padding:20px;color:var(--text-muted);font-size:12px">Veri bulunamadi</div>';
+                            </td>
+                        </tr>
+                    `).join('')}</tbody>
+                `;
+            } else {
+                creatorsTable.innerHTML = '<div style="text-align:center;padding:20px;color:var(--text-muted);font-size:12px">Veri bulunamadi</div>';
+            }
         }
     } catch(e) { console.error('Growth load error:', e); }
 }
@@ -7718,9 +7755,9 @@ async function executeApproval(id, btn) {
                 // Ozet bilgiyi aninda goster (ağır sorguları beklemeden)
                 const summary = initData.summaries?.[autoId];
                 if (summary?.has_data) {
-                    document.getElementById('ov-files').textContent = formatNum(summary.file_count);
-                    document.getElementById('ov-size').textContent = summary.total_size_formatted || formatSize(summary.total_size);
-                    document.getElementById('ov-risk-text').textContent = '...';
+                    _setTextSafe('ov-files', formatNum(summary.file_count));
+                    _setTextSafe('ov-size', summary.total_size_formatted || formatSize(summary.total_size));
+                    _setTextSafe('ov-risk-text', '...');
 
                     // Yukleniyor gostergesi — loadOverview insightsPromise'i
                     // arka planda baslatacak, hazir olunca icerik gelecek.
@@ -7901,11 +7938,13 @@ function renderEntityList(containerId, items, columns, opts = {}) {
 async function loadOrphanSids() {
     const flags = await getSecurityFlags();
     const banner = document.getElementById('orphan-sids-banner');
-    if (!flags.orphan_sid.enabled) {
-        banner.style.display = 'block';
-        banner.textContent = 'Bu ozellik kapali — config.yaml > security.orphan_sid.enabled: true ile aciliyor.';
-    } else {
-        banner.style.display = 'none';
+    if (banner) {
+        if (!flags.orphan_sid.enabled) {
+            banner.style.display = 'block';
+            banner.textContent = 'Bu ozellik kapali — config.yaml > security.orphan_sid.enabled: true ile aciliyor.';
+        } else {
+            banner.style.display = 'none';
+        }
     }
 
     const sourceId = document.getElementById('orphan-sids-source')?.value;
@@ -7914,7 +7953,7 @@ async function loadOrphanSids() {
     const csvBtn = document.getElementById('orphan-sids-csv-btn');
     const reBtn = document.getElementById('orphan-sids-reassign-btn');
     if (!sourceId) {
-        summary.innerHTML = '';
+        if (summary) summary.innerHTML = '';
         renderEntityList('orphan-sids-container', [], [], { emptyHtml: 'Lutfen bir kaynak secin' });
         if (xlsxBtn) xlsxBtn.style.display = 'none';
         if (csvBtn) csvBtn.style.display = 'none';
@@ -7927,7 +7966,7 @@ async function loadOrphanSids() {
 
     try {
         const data = await api(`/security/orphan-sids/${sourceId}`);
-        summary.innerHTML = `
+        if (summary) summary.innerHTML = `
             <div class="card accent"><div class="card-label">Toplam Dosya</div><div class="card-value">${formatNum(data.total_files || 0)}</div></div>
             <div class="card warning"><div class="card-label">Yetim Dosya</div><div class="card-value">${formatNum(data.total_orphan_files || 0)}</div></div>
             <div class="card danger"><div class="card-label">Yetim SID</div><div class="card-value">${formatNum((data.orphan_sids || []).length)}</div></div>
@@ -8012,20 +8051,23 @@ async function submitOrphanReassign() {
 async function loadRansomwareAlerts() {
     const flags = await getSecurityFlags();
     const banner = document.getElementById('ransomware-banner');
-    if (!flags.ransomware.enabled) {
-        banner.style.display = 'block';
-        banner.textContent = 'Bu ozellik kapali — config.yaml > security.ransomware.enabled: true ile aciliyor.';
-    } else {
-        banner.style.display = 'none';
+    if (banner) {
+        if (!flags.ransomware.enabled) {
+            banner.style.display = 'block';
+            banner.textContent = 'Bu ozellik kapali — config.yaml > security.ransomware.enabled: true ile aciliyor.';
+        } else {
+            banner.style.display = 'none';
+        }
     }
-    const win = parseInt(document.getElementById('ransomware-window').value || '1440', 10);
+    const win = parseInt(document.getElementById('ransomware-window')?.value || '1440', 10);
     const summary = document.getElementById('ransomware-summary');
     try {
-        const alerts = await api(`/security/ransomware/alerts?since_minutes=${win}`);
+        const rawAlerts = await api(`/security/ransomware/alerts?since_minutes=${win}`);
+        const alerts = Array.isArray(rawAlerts) ? rawAlerts : [];
         const total = alerts.length;
         const ackd = alerts.filter(a => a.acknowledged_at).length;
         const critical = alerts.filter(a => (a.severity || '').toLowerCase() === 'critical').length;
-        summary.innerHTML = `
+        if (summary) summary.innerHTML = `
             <div class="card ${total ? 'danger' : 'success'}"><div class="card-label">Toplam Uyari</div><div class="card-value">${formatNum(total)}</div><div class="card-sub">${win} dk pencere</div></div>
             <div class="card warning"><div class="card-label">Kritik</div><div class="card-value">${formatNum(critical)}</div></div>
             <div class="card success"><div class="card-label">Onaylanan</div><div class="card-value">${formatNum(ackd)}</div></div>
@@ -8173,11 +8215,13 @@ let _extAnomalyRows = [];               // last fetched rows
 async function loadExtensionAnomalies() {
     const flags = await getSecurityFlags();
     const banner = document.getElementById('ext-anomaly-banner');
-    if (!flags.extension_anomalies || !flags.extension_anomalies.enabled) {
-        banner.style.display = 'block';
-        banner.textContent = 'Bu ozellik kapali — config.yaml > scanner.detect_wrong_extensions: true ile aciliyor (libmagic gerektirir).';
-    } else {
-        banner.style.display = 'none';
+    if (banner) {
+        if (!flags.extension_anomalies || !flags.extension_anomalies.enabled) {
+            banner.style.display = 'block';
+            banner.textContent = 'Bu ozellik kapali — config.yaml > scanner.detect_wrong_extensions: true ile aciliyor (libmagic gerektirir).';
+        } else {
+            banner.style.display = 'none';
+        }
     }
 
     const sourceId = document.getElementById('ext-anomaly-source')?.value;
@@ -8185,7 +8229,7 @@ async function loadExtensionAnomalies() {
     const summary = document.getElementById('ext-anomaly-summary');
     const xlsxBtn = document.getElementById('ext-anomaly-xlsx-btn');
     if (!sourceId) {
-        summary.innerHTML = '';
+        if (summary) summary.innerHTML = '';
         renderEntityList('ext-anomaly-container', [], [], { emptyHtml: 'Lutfen bir kaynak secin' });
         if (xlsxBtn) xlsxBtn.style.display = 'none';
         return;
@@ -8199,7 +8243,7 @@ async function loadExtensionAnomalies() {
         _psv2PrevWasPartial['extension-anomalies'] = true;
         _psv2ShowBanner('ext-anomaly-partial-banner', ps.scan_state, ps.progress);
         const extCount = (ps.summary && ps.summary.anomalies_so_far && ps.summary.anomalies_so_far.extension) || 0;
-        summary.innerHTML = `
+        if (summary) summary.innerHTML = `
             <div class="card warning"><div class="card-label">Tahmini Uzanti Anomalisi</div><div class="card-value">${formatNum(extCount)}</div><div class="card-sub">Kismi veri</div></div>
             <div class="card accent"><div class="card-label">Detay</div><div class="card-value" style="font-size:14px">Tarama devam ediyor</div><div class="card-sub">Tarama bitince detay goruntulenecek</div></div>
         `;
@@ -8220,7 +8264,7 @@ async function loadExtensionAnomalies() {
         if (severity) qs.set('severity', severity);
         const data = await api(`/security/extension-anomalies?${qs.toString()}`);
         const bs = data.by_severity || {};
-        summary.innerHTML = `
+        if (summary) summary.innerHTML = `
             <div class="card danger"><div class="card-label">Kritik</div><div class="card-value">${formatNum(bs.critical || 0)}</div></div>
             <div class="card warning"><div class="card-label">Yuksek</div><div class="card-value">${formatNum(bs.high || 0)}</div></div>
             <div class="card accent"><div class="card-label">Orta</div><div class="card-value">${formatNum(bs.medium || 0)}</div></div>
@@ -9214,11 +9258,14 @@ async function loadImageDuplicates() {
     const xlsxBtn = document.getElementById('imgdup-xlsx-btn');
     const featureBanner = document.getElementById('imgdup-feature-banner');
 
-    // Populate source dropdown once
+    // Populate source dropdown once.
+    // GET /api/sources returns a raw list — not {sources: [...]} like
+    // /api/dashboard/init does. The previous `srcs.sources || []` always
+    // resolved to [] so the dropdown stayed empty.
     if (sourceEl && sourceEl.options.length <= 1) {
         try {
             const srcs = await api('/sources');
-            (srcs.sources || []).forEach(s => {
+            (Array.isArray(srcs) ? srcs : (srcs && srcs.sources) || []).forEach(s => {
                 const o = document.createElement('option');
                 o.value = s.id;
                 o.textContent = s.name;

--- a/src/scanner/file_scanner.py
+++ b/src/scanner/file_scanner.py
@@ -1024,6 +1024,58 @@ class FileScanner:
         # falling back to scan_runs).
         if status == "completed" and file_count > 0:
             progress["phase"] = "analysis"
+
+            # Issue #175 — size-enrich must run BEFORE compute_scan_summary
+            # and AI insights. MFT enumeration emits file_size=0 for every
+            # row; enrich populates real sizes via os.stat. Computing the
+            # summary or insights before enrich produces the customer-visible
+            # "TOPLAM DOSYA: 0 / BOYUT: 0 B" bug on Genel Bakis.
+            try:
+                self._run_size_enrich(scan_id)
+                if v2_builder is not None:
+                    try:
+                        elapsed_so_far = max(
+                            0.001, time.time() - start_time,
+                        )
+                        v2_builder.flush_to_db(
+                            scan_state="enrich",
+                            rate_per_sec=float(file_count) / elapsed_so_far,
+                            active_dir=progress.get("current_dir", "") or "",
+                        )
+                    except Exception as e:  # pragma: no cover
+                        logger.debug(
+                            "v2_builder enrich flush failed: %s", e,
+                        )
+            except Exception as e:
+                logger.warning(
+                    "Size-enrich pasi basarisiz (scan_id=%d): %s",
+                    scan_id, e,
+                )
+
+            # Issue #144 Phase 1 — opt-in wrong-extension detection.
+            # Default OFF (perf cost: libmagic.from_file() per scanned
+            # file). When enabled, run as a separate post-scan phase so
+            # the main MFT/SMB walk never blocks on libmagic.
+            if self.config.get("detect_wrong_extensions", False):
+                try:
+                    ext_result = self._run_extension_check(scan_id)
+                    if v2_builder is not None and isinstance(ext_result, dict):
+                        try:
+                            v2_builder.increment_anomaly(
+                                "extension",
+                                int(ext_result.get("anomalies", 0) or 0),
+                            )
+                        except Exception:  # pragma: no cover
+                            pass
+                except Exception as e:
+                    logger.warning(
+                        "Extension-check pasi basarisiz (scan_id=%d): %s",
+                        scan_id, e,
+                    )
+
+            # KPI summary + AI insights — these read scanned_files
+            # aggregates and MUST run after _run_size_enrich above so that
+            # summary_json carries real total_size / size_buckets / age_buckets.
             try:
                 t0 = time.time()
                 self.db.compute_scan_summary(scan_id)
@@ -1046,61 +1098,6 @@ class FileScanner:
                 )
             except Exception as e:
                 logger.warning("AI insights hesaplanamadi (scan_id=%d): %s", scan_id, e)
-
-            # Issue #144 Phase 1 — opt-in wrong-extension detection.
-            # Default OFF (perf cost: libmagic.from_file() per scanned
-            # file). When enabled, run as a separate post-scan phase so
-            # the main MFT/SMB walk never blocks on libmagic.
-            if self.config.get("detect_wrong_extensions", False):
-                try:
-                    ext_result = self._run_extension_check(scan_id)
-                    # Issue #181 Track B1 — fold the anomaly count into
-                    # the v2 builder so the dashboard's anomalies card
-                    # lights up before the scan completes.
-                    if v2_builder is not None and isinstance(ext_result, dict):
-                        try:
-                            v2_builder.increment_anomaly(
-                                "extension",
-                                int(ext_result.get("anomalies", 0) or 0),
-                            )
-                        except Exception:  # pragma: no cover
-                            pass
-                except Exception as e:
-                    logger.warning(
-                        "Extension-check pasi basarisiz (scan_id=%d): %s",
-                        scan_id, e,
-                    )
-
-            # Issue #175 — post-walk size + timestamp enrich. Streams
-            # scanned_files rows for this scan, fills file_size / mtime
-            # via os.stat (or FSCTL on local NTFS). Gated by
-            # scanner.enrich_sizes (default ON because the customer's #1
-            # KPI was BOYUT showing 0 B).
-            try:
-                self._run_size_enrich(scan_id)
-                # Issue #181 Track B1 — after enrich, size + age buckets
-                # finally have data to populate. Flush the v2 dict with
-                # the ``enrich`` scan_state so the dashboard knows it's
-                # safe to render the BOYUT/YAS cards.
-                if v2_builder is not None:
-                    try:
-                        elapsed_so_far = max(
-                            0.001, time.time() - start_time,
-                        )
-                        v2_builder.flush_to_db(
-                            scan_state="enrich",
-                            rate_per_sec=float(file_count) / elapsed_so_far,
-                            active_dir=progress.get("current_dir", "") or "",
-                        )
-                    except Exception as e:  # pragma: no cover
-                        logger.debug(
-                            "v2_builder enrich flush failed: %s", e,
-                        )
-            except Exception as e:
-                logger.warning(
-                    "Size-enrich pasi basarisiz (scan_id=%d): %s",
-                    scan_id, e,
-                )
 
         # Issue #181 Track B1 — final flush at scan completion. Always
         # runs (even on failure / cancel) so the dashboard's last

--- a/src/security/dashboard_auth.py
+++ b/src/security/dashboard_auth.py
@@ -44,6 +44,44 @@ logger = logging.getLogger("file_activity.security.dashboard_auth")
 _LOCAL_HOSTS = frozenset({"127.0.0.1", "::1", "localhost"})
 
 
+def resolve_effective_client_host(request: Any) -> str:
+    """Return the client IP to use for security decisions.
+
+    Without this helper, ``request.client.host`` is the IMMEDIATE TCP
+    peer — which behind a reverse proxy (nginx/IIS on loopback) is
+    always 127.0.0.1, so a localhost bypass like ``allow_unauth_localhost``
+    or the ``/api/system/list-dir`` localhost-only check would silently
+    fire for every remote request reaching the proxy.
+
+    Rule: only honour ``X-Forwarded-For`` when the immediate peer is
+    itself a loopback address — that is the trusted-proxy signal. A
+    remote attacker who is NOT going through a loopback-bound proxy
+    cannot forge their way to ``client.host == 127.0.0.1`` and therefore
+    cannot inject a fake XFF either.
+
+    XFF format per RFC 7239 / convention: ``client, proxy1, proxy2``.
+    The leftmost entry is the original client; we use that for the
+    "is this localhost" check.
+    """
+    client = getattr(request, "client", None)
+    direct_host = (getattr(client, "host", "") or "") if client is not None else ""
+
+    if direct_host not in _LOCAL_HOSTS:
+        return direct_host
+
+    headers = getattr(request, "headers", None)
+    if headers is None:
+        return direct_host
+    try:
+        xff = headers.get("X-Forwarded-For", "") or ""
+    except Exception:
+        return direct_host
+    if not xff:
+        return direct_host
+    first = xff.split(",", 1)[0].strip()
+    return first or direct_host
+
+
 class DashboardAuth:
     """Per-process bearer-token gate for the FastAPI dashboard.
 
@@ -93,10 +131,11 @@ class DashboardAuth:
         if not self.enabled:
             return True
 
-        client_host = ""
-        client = getattr(request, "client", None)
-        if client is not None:
-            client_host = getattr(client, "host", "") or ""
+        # Use the resolved effective client (honours X-Forwarded-For only
+        # when the immediate peer is loopback). Without this, a reverse
+        # proxy on the same host turns every remote request into a fake
+        # "localhost" call and silently bypasses auth.
+        client_host = resolve_effective_client_host(request)
 
         if self.allow_unauth_localhost and client_host in _LOCAL_HOSTS:
             return True

--- a/src/storage/database.py
+++ b/src/storage/database.py
@@ -1335,14 +1335,56 @@ class Database:
         # the last in-flight value but updated_at moves so dashboard stops
         # polling.
         final_phase = "completed" if status == "completed" else status
-        with self.get_cursor() as cur:
-            cur.execute("""
+
+        # Issue #194 Wave 6 — cross-check the caller's in-memory counter
+        # against SELECT COUNT(*). The caller (file_scanner.scan_source)
+        # increments file_count per record yielded by the walker; if the
+        # stager or bulk_insert_scanned_files lost rows (silent retry
+        # exhaustion, executemany partial failure), counter > rows. In
+        # the reverse direction, if a second scan interleaves on the
+        # same scan_id (shouldn't happen, but the schema allows it),
+        # counter < rows. Either way the SELECT is the source of truth
+        # for what the dashboard will subsequently render.
+        try:
+            with self.get_read_cursor() as cur:
+                row = cur.execute(
+                    "SELECT COUNT(*) AS c, COALESCE(SUM(file_size),0) AS s "
+                    "FROM scanned_files WHERE scan_id=?",
+                    (scan_id,),
+                ).fetchone()
+            actual_files = int(row["c"]) if row else 0
+            actual_size = int(row["s"]) if row else 0
+        except Exception as e:  # pragma: no cover - defensive
+            logger.debug("complete_scan_run COUNT cross-check failed: %s", e)
+            actual_files = total_files
+            actual_size = total_size
+
+        if actual_files != int(total_files):
+            logger.warning(
+                "complete_scan_run scan_id=%d: in-memory counter=%d but "
+                "SELECT COUNT(*) returned %d — using SELECT value",
+                scan_id, int(total_files), actual_files,
+            )
+            total_files = actual_files
+        if actual_size != int(total_size):
+            logger.warning(
+                "complete_scan_run scan_id=%d: in-memory size=%d but "
+                "SELECT SUM(file_size) returned %d — using SELECT value",
+                scan_id, int(total_size), actual_size,
+            )
+            total_size = actual_size
+
+        self._execute_write_with_retry(
+            "complete_scan_run",
+            """
                 UPDATE scan_runs
                 SET completed_at = datetime('now','localtime'), total_files = ?,
                     total_size = ?, errors = ?, status = ?,
                     current_phase = ?, updated_at = datetime('now','localtime')
                 WHERE id = ?
-            """, (total_files, total_size, errors, status, final_phase, scan_id))
+            """,
+            (total_files, total_size, errors, status, final_phase, scan_id),
+        )
 
     def get_scan_runs(self, source_id: Optional[int] = None, limit: int = 20) -> list:
         with self.get_cursor() as cur:
@@ -1451,6 +1493,43 @@ class Database:
         logger.error(
             "bulk_insert_scanned_files exhausted retries (5x): %s", last_err,
         )
+        if last_err is not None:
+            raise last_err
+
+    def _execute_write_with_retry(
+        self, label: str, sql: str, params: tuple
+    ) -> None:
+        """Issue #194 Wave 6 — run a single write statement with the same
+        5x exponential backoff that bulk_insert_scanned_files uses. Used
+        by compute_scan_summary's UPDATE and complete_scan_run's UPDATE
+        so a transient writer-lock contention doesn't lose the summary
+        row or leave scan_runs in a dangling state.
+        """
+        backoff = 1.0
+        last_err: Optional[Exception] = None
+        for attempt in range(1, 6):
+            try:
+                with self.get_cursor() as cur:
+                    cur.execute(sql, params)
+                if attempt > 1:
+                    logger.info(
+                        "%s succeeded on attempt %d (after %d retries)",
+                        label, attempt, attempt - 1,
+                    )
+                return
+            except sqlite3.OperationalError as e:
+                msg = str(e).lower()
+                if "database is locked" not in msg and "busy" not in msg:
+                    raise
+                last_err = e
+                if attempt < 5:
+                    logger.warning(
+                        "%s locked (attempt %d/5), retry in %.1fs: %s",
+                        label, attempt, backoff, e,
+                    )
+                    time.sleep(backoff)
+                    backoff *= 2
+        logger.error("%s exhausted retries (5x): %s", label, last_err)
         if last_err is not None:
             raise last_err
 
@@ -3139,7 +3218,17 @@ class Database:
         # En ustu "huge" acik ust sinir
         size_bucket_defs.append(("huge", prev_max, None))
 
-        with self.get_cursor() as cur:
+        # Issue #194 Wave 6 — read all 10 aggregates against a single
+        # consistent snapshot via the read-only pool with an explicit
+        # BEGIN. Two wins: (1) the writer pool slot is not held for the
+        # full read sequence, so a concurrent scanner's bulk inserts
+        # proceed in parallel; (2) the SELECTs all see the same point-
+        # in-time row set — without BEGIN, sqlite3's default deferred
+        # isolation means each statement opens its own implicit
+        # transaction and the 10 reads can see different snapshots
+        # (audit C1-2 root cause for "total_files=0 with risky_count>0").
+        with self.get_read_cursor() as cur:
+            cur.execute("BEGIN")
             # Temel sayim
             row = cur.execute(
                 "SELECT COUNT(*) c, COALESCE(SUM(file_size),0) s, "
@@ -3373,12 +3462,17 @@ class Database:
             # Versiyon isareti — backfill bu anahtara bakar
             summary["summary_json_version"] = 2
 
-            # Kaydet (kompakt JSON, ensure_ascii=False)
-            now = now_dt.strftime("%Y-%m-%d %H:%M:%S")
-            cur.execute(
-                "UPDATE scan_runs SET summary_json=?, summary_computed_at=? WHERE id=?",
-                (json.dumps(summary, ensure_ascii=False, separators=(",", ":")), now, scan_id),
-            )
+        # Persist via the writer pool with the same 5x backoff retry as
+        # bulk_insert_scanned_files. The previous in-block UPDATE had no
+        # retry — a transient "database is locked" during a heavy scan
+        # would silently lose summary_json for that scan (audit C1-3).
+        now = now_dt.strftime("%Y-%m-%d %H:%M:%S")
+        payload = json.dumps(summary, ensure_ascii=False, separators=(",", ":"))
+        self._execute_write_with_retry(
+            "compute_scan_summary.UPDATE",
+            "UPDATE scan_runs SET summary_json=?, summary_computed_at=? WHERE id=?",
+            (payload, now, scan_id),
+        )
 
         summary["scan_id"] = scan_id
         summary["computed_at"] = now

--- a/src/storage/database.py
+++ b/src/storage/database.py
@@ -612,6 +612,12 @@ class Database:
         cur.execute("CREATE INDEX IF NOT EXISTS idx_sf_src_scan_ext ON scanned_files(source_id, scan_id, extension)")
         cur.execute("CREATE INDEX IF NOT EXISTS idx_sf_src_scan_size ON scanned_files(source_id, scan_id, file_size)")
         cur.execute("CREATE INDEX IF NOT EXISTS idx_sf_src_scan_owner ON scanned_files(source_id, scan_id, owner)")
+        # Issue #194 Wave 6 — composite (scan_id, file_path) supports the
+        # size-enrich UPDATE WHERE clause. Without it each of the 600+
+        # chunks per 3M-file scan does a partial scan within idx_sf_scan
+        # → O(N) per row → 30+ minute enrich pass. With this index the
+        # UPDATE is O(log N) and enrich completes in seconds.
+        cur.execute("CREATE INDEX IF NOT EXISTS idx_sf_scan_path ON scanned_files(scan_id, file_path)")
 
         # Arsivlenmis dosyalar
         cur.execute("""

--- a/tests/test_config_migrator.py
+++ b/tests/test_config_migrator.py
@@ -1,0 +1,365 @@
+"""Tests for scripts/migrate_config.py (issue #194 Wave 8 / D7).
+
+Covers the customer-facing safety guarantees:
+  * old_default → new_default flip happens
+  * operator customisations (any value != old_default) preserved
+  * comments + formatting around the migrated line preserved
+  * backup written before modification
+  * post-edit YAML must parse and contain the expected new value
+  * missing keys and absent files don't crash
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+# Import the migrator script as a module (not a package).
+SCRIPT = Path(__file__).resolve().parent.parent / "scripts" / "migrate_config.py"
+sys.path.insert(0, str(SCRIPT.parent))
+import migrate_config  # noqa: E402
+
+
+@pytest.fixture
+def rules_flip_parquet():
+    return [
+        {
+            "path": "scanner.parquet_staging.enabled",
+            "old_default": True,
+            "new_default": False,
+            "reason": "test",
+            "pr": "#174",
+        }
+    ]
+
+
+@pytest.fixture
+def rules_flip_host():
+    return [
+        {
+            "path": "dashboard.host",
+            "old_default": "0.0.0.0",
+            "new_default": "127.0.0.1",
+            "reason": "test",
+            "pr": "#158",
+        }
+    ]
+
+
+def _write(path: Path, body: str) -> Path:
+    path.write_text(body, encoding="utf-8")
+    return path
+
+
+# ---------------------------------------------------------------------------
+# Happy path — value matches old_default → flip applied
+# ---------------------------------------------------------------------------
+
+
+def test_flip_applied_when_value_matches_old_default(tmp_path, rules_flip_parquet):
+    cfg = _write(tmp_path / "config.yaml", """\
+scanner:
+  parquet_staging:
+    # operator's comment about parquet
+    enabled: true
+    flush_rows: 50000
+""")
+    results = migrate_config.migrate(cfg, rules_flip_parquet)
+    assert [r.action for r in results] == ["applied"]
+    new = cfg.read_text(encoding="utf-8")
+    assert "enabled: false" in new
+    # Comment preserved
+    assert "operator's comment about parquet" in new
+    # flush_rows untouched
+    assert "flush_rows: 50000" in new
+    # Backup created next to the file
+    backups = list(tmp_path.glob("config.yaml.bak-*"))
+    assert len(backups) == 1
+    assert "enabled: true" in backups[0].read_text(encoding="utf-8")
+
+
+def test_string_value_flip(tmp_path, rules_flip_host):
+    cfg = _write(tmp_path / "config.yaml", """\
+dashboard:
+  host: "0.0.0.0"
+  port: 8085
+""")
+    results = migrate_config.migrate(cfg, rules_flip_host)
+    assert results[0].action == "applied"
+    new = cfg.read_text(encoding="utf-8")
+    parsed = yaml.safe_load(new)
+    assert parsed["dashboard"]["host"] == "127.0.0.1"
+    assert parsed["dashboard"]["port"] == 8085
+    # Quote style preserved: operator wrote "0.0.0.0", we write "127.0.0.1".
+    assert 'host: "127.0.0.1"' in new
+
+
+def test_quote_style_preserved_single_quotes(tmp_path, rules_flip_host):
+    cfg = _write(tmp_path / "config.yaml", """\
+dashboard:
+  host: '0.0.0.0'
+""")
+    results = migrate_config.migrate(cfg, rules_flip_host)
+    assert results[0].action == "applied"
+    new = cfg.read_text(encoding="utf-8")
+    assert "host: '127.0.0.1'" in new
+
+
+def test_quote_style_preserved_bare(tmp_path, rules_flip_host):
+    cfg = _write(tmp_path / "config.yaml", """\
+dashboard:
+  host: 0.0.0.0
+""")
+    results = migrate_config.migrate(cfg, rules_flip_host)
+    assert results[0].action == "applied"
+    new = cfg.read_text(encoding="utf-8")
+    assert "host: 127.0.0.1" in new
+    assert 'host: "127.0.0.1"' not in new
+
+
+# ---------------------------------------------------------------------------
+# Operator customisation — value differs from old_default → DO NOT TOUCH
+# ---------------------------------------------------------------------------
+
+
+def test_operator_value_preserved(tmp_path, rules_flip_parquet):
+    cfg = _write(tmp_path / "config.yaml", """\
+scanner:
+  parquet_staging:
+    enabled: false
+""")
+    results = migrate_config.migrate(cfg, rules_flip_parquet)
+    assert results[0].action == "skipped"
+    # File unchanged
+    assert cfg.read_text(encoding="utf-8") == """\
+scanner:
+  parquet_staging:
+    enabled: false
+"""
+    # No backup written when nothing applied
+    assert not list(tmp_path.glob("config.yaml.bak-*"))
+
+
+def test_operator_value_arbitrary_preserved(tmp_path, rules_flip_host):
+    """Customer with LAN bind (operator set 0.0.0.0 deliberately AFTER
+    we shipped 127.0.0.1 default) — value happens to equal old_default
+    again. This is the migration-rule's blind spot, accepted: we flip
+    it back. Cover with a different non-default value to confirm
+    skipping logic."""
+    cfg = _write(tmp_path / "config.yaml", """\
+dashboard:
+  host: "192.168.1.10"
+""")
+    results = migrate_config.migrate(cfg, rules_flip_host)
+    assert results[0].action == "skipped"
+    assert cfg.read_text(encoding="utf-8").count("192.168.1.10") == 1
+
+
+# ---------------------------------------------------------------------------
+# Comment + formatting preservation
+# ---------------------------------------------------------------------------
+
+
+def test_inline_comment_preserved(tmp_path, rules_flip_parquet):
+    cfg = _write(tmp_path / "config.yaml", """\
+scanner:
+  parquet_staging:
+    enabled: true     # PR #174 — was unsafe pre-2026-03
+    flush_rows: 50000
+""")
+    results = migrate_config.migrate(cfg, rules_flip_parquet)
+    assert results[0].action == "applied"
+    new = cfg.read_text(encoding="utf-8")
+    assert "# PR #174 — was unsafe pre-2026-03" in new
+    assert "enabled: false" in new
+
+
+def test_long_comment_block_preserved(tmp_path, rules_flip_parquet):
+    cfg = _write(tmp_path / "config.yaml", """\
+scanner:
+  parquet_staging:
+    # Tarama sirasinda satirlari Parquet dosyasina biriktirir, sonra DuckDB
+    # uzerinden tek INSERT ile SQLite'a ingest eder. 100k+ satirli scan'lerde
+    # row-by-row INSERT'e gore 10-50x hizli; pyarrow yoksa otomatik olarak
+    # klasik bulk_insert_scanned_files yoluna dusulur.
+    #
+    # Issue #174 — varsayilan KAPALI. Manuel acmak icin: enabled: true.
+    enabled: true
+    flush_rows: 50000
+""")
+    results = migrate_config.migrate(cfg, rules_flip_parquet)
+    assert results[0].action == "applied"
+    new = cfg.read_text(encoding="utf-8")
+    # Every original comment line is still in the file
+    assert "Tarama sirasinda satirlari Parquet dosyasina biriktirir" in new
+    assert "Issue #174 — varsayilan KAPALI" in new
+    assert "row-by-row INSERT'e gore 10-50x hizli" in new
+
+
+# ---------------------------------------------------------------------------
+# Safety — dry-run, missing keys, broken YAML
+# ---------------------------------------------------------------------------
+
+
+def test_dry_run_does_not_modify(tmp_path, rules_flip_parquet):
+    original = """\
+scanner:
+  parquet_staging:
+    enabled: true
+"""
+    cfg = _write(tmp_path / "config.yaml", original)
+    results = migrate_config.migrate(cfg, rules_flip_parquet, dry_run=True)
+    assert results[0].action == "applied"  # would-apply
+    assert cfg.read_text(encoding="utf-8") == original
+    assert not list(tmp_path.glob("config.yaml.bak-*"))
+
+
+def test_missing_key_does_not_crash(tmp_path, rules_flip_parquet):
+    cfg = _write(tmp_path / "config.yaml", """\
+scanner:
+  # parquet_staging block absent entirely
+  enrich_sizes: true
+""")
+    results = migrate_config.migrate(cfg, rules_flip_parquet)
+    assert results[0].action == "missing"
+    # File unchanged: the key isn't present as a real assignment
+    parsed = yaml.safe_load(cfg.read_text(encoding="utf-8"))
+    assert "parquet_staging" not in parsed["scanner"]
+    assert not list(tmp_path.glob("config.yaml.bak-*"))
+
+
+def test_missing_file_records_error(tmp_path, rules_flip_parquet):
+    cfg = tmp_path / "nonexistent.yaml"
+    results = migrate_config.migrate(cfg, rules_flip_parquet)
+    assert results[0].action == "error"
+
+
+def test_broken_yaml_is_not_modified(tmp_path, rules_flip_parquet):
+    cfg = _write(tmp_path / "config.yaml", """\
+scanner:
+  parquet_staging:
+    enabled: true
+this is not: valid: yaml: here
+""")
+    results = migrate_config.migrate(cfg, rules_flip_parquet)
+    assert results[0].action == "error"
+    # Original preserved
+    assert "this is not: valid: yaml: here" in cfg.read_text(encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# Multi-rule end-to-end
+# ---------------------------------------------------------------------------
+
+
+def test_multiple_rules_applied_in_one_pass(tmp_path):
+    rules = [
+        {
+            "path": "scanner.parquet_staging.enabled",
+            "old_default": True,
+            "new_default": False,
+            "reason": "x",
+            "pr": "#174",
+        },
+        {
+            "path": "dashboard.host",
+            "old_default": "0.0.0.0",
+            "new_default": "127.0.0.1",
+            "reason": "y",
+            "pr": "#158",
+        },
+        {
+            "path": "backup.corruption_check_mode",
+            "old_default": "quick",
+            "new_default": "skip",
+            "reason": "z",
+            "pr": "#131",
+        },
+    ]
+    cfg = _write(tmp_path / "config.yaml", """\
+scanner:
+  parquet_staging:
+    enabled: true
+dashboard:
+  host: "0.0.0.0"
+  port: 8085
+backup:
+  corruption_check_mode: "quick"
+  enabled: true
+""")
+    results = migrate_config.migrate(cfg, rules)
+    actions = sorted(r.action for r in results)
+    assert actions == ["applied", "applied", "applied"]
+    parsed = yaml.safe_load(cfg.read_text(encoding="utf-8"))
+    assert parsed["scanner"]["parquet_staging"]["enabled"] is False
+    assert parsed["dashboard"]["host"] == "127.0.0.1"
+    assert parsed["dashboard"]["port"] == 8085  # untouched
+    assert parsed["backup"]["corruption_check_mode"] == "skip"
+    assert parsed["backup"]["enabled"] is True  # untouched
+
+
+def test_partial_rule_set_only_flips_matching(tmp_path):
+    rules = [
+        {
+            "path": "scanner.parquet_staging.enabled",
+            "old_default": True,
+            "new_default": False,
+            "reason": "x",
+            "pr": "#174",
+        },
+        {
+            "path": "watcher.backend",
+            "old_default": "polling",
+            "new_default": "watchdog",
+            "reason": "y",
+            "pr": "#14",
+        },
+    ]
+    cfg = _write(tmp_path / "config.yaml", """\
+scanner:
+  parquet_staging:
+    enabled: true
+watcher:
+  backend: "watchdog"
+""")
+    results = migrate_config.migrate(cfg, rules)
+    by_path = {r.path: r for r in results}
+    assert by_path["scanner.parquet_staging.enabled"].action == "applied"
+    assert by_path["watcher.backend"].action == "skipped"
+    parsed = yaml.safe_load(cfg.read_text(encoding="utf-8"))
+    assert parsed["scanner"]["parquet_staging"]["enabled"] is False
+    assert parsed["watcher"]["backend"] == "watchdog"
+
+
+# ---------------------------------------------------------------------------
+# Shipped rules file loads cleanly
+# ---------------------------------------------------------------------------
+
+
+def test_shipped_rules_file_parses():
+    rules = migrate_config.load_rules()
+    assert len(rules) >= 1, "no migration rules shipped"
+    for r in rules:
+        assert "path" in r
+        assert "old_default" in r
+        assert "new_default" in r
+        assert "." in r["path"], f"rule path must be dotted: {r['path']!r}"
+
+
+def test_shipped_rules_applied_against_shipped_config_is_noop(tmp_path):
+    """The shipped config.yaml is the post-migration state by definition.
+    Running the migrator against a copy of the shipped config must
+    produce ZERO 'applied' results."""
+    import shutil as _shutil
+    shipped = Path(__file__).resolve().parent.parent / "config.yaml"
+    cfg = tmp_path / "config.yaml"
+    _shutil.copy(shipped, cfg)
+    rules = migrate_config.load_rules()
+    results = migrate_config.migrate(cfg, rules)
+    applied = [r for r in results if r.action == "applied"]
+    assert applied == [], (
+        f"shipped config.yaml triggers migrations against shipped rules: {applied}"
+    )

--- a/tests/test_dashboard_auth.py
+++ b/tests/test_dashboard_auth.py
@@ -204,3 +204,66 @@ def test_custom_token_env_name(monkeypatch):
         "/api/ping", headers={"Authorization": "Bearer custom-tok"}
     )
     assert resp.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# Reverse-proxy unmasking (backend audit Class 10 / issue #194).
+#
+# When the dashboard sits behind a reverse proxy on the same host, the
+# TCP peer is always 127.0.0.1 (the proxy). Without XFF awareness the
+# allow_unauth_localhost branch silently fires for every remote request
+# and turns the dashboard into an unauthenticated service.
+# ---------------------------------------------------------------------------
+
+
+def test_proxy_with_remote_xff_does_not_bypass_auth(monkeypatch):
+    """Proxy IP is loopback (127.0.0.1) BUT X-Forwarded-For carries a
+    real remote IP — auth must still be enforced."""
+    monkeypatch.setenv("FILEACTIVITY_DASHBOARD_TOKEN", "s3cret")
+    app = _build_app(_default_cfg(), force_client_host="127.0.0.1")
+    client = TestClient(app)
+    resp = client.get(
+        "/api/ping",
+        headers={"X-Forwarded-For": "203.0.113.42"},
+    )
+    assert resp.status_code == 401
+
+
+def test_proxy_with_loopback_xff_still_bypasses(monkeypatch):
+    """Proxy IP is loopback AND XFF says loopback — caller is genuinely
+    on the same host as the proxy → bypass should still fire."""
+    monkeypatch.delenv("FILEACTIVITY_DASHBOARD_TOKEN", raising=False)
+    app = _build_app(_default_cfg(), force_client_host="127.0.0.1")
+    client = TestClient(app)
+    resp = client.get(
+        "/api/ping",
+        headers={"X-Forwarded-For": "127.0.0.1"},
+    )
+    assert resp.status_code == 200
+
+
+def test_direct_remote_cannot_spoof_xff(monkeypatch):
+    """Defense: a direct LAN client sets XFF to 127.0.0.1 hoping to
+    impersonate localhost. Because their immediate peer is NOT loopback,
+    XFF is ignored entirely."""
+    monkeypatch.setenv("FILEACTIVITY_DASHBOARD_TOKEN", "s3cret")
+    app = _build_app(_default_cfg(), force_client_host="10.0.0.5")
+    client = TestClient(app)
+    resp = client.get(
+        "/api/ping",
+        headers={"X-Forwarded-For": "127.0.0.1"},
+    )
+    assert resp.status_code == 401
+
+
+def test_xff_first_entry_used_for_chain(monkeypatch):
+    """XFF chain "real-client, proxy1, proxy2" — only the leftmost
+    entry (the original client) is consulted."""
+    monkeypatch.setenv("FILEACTIVITY_DASHBOARD_TOKEN", "s3cret")
+    app = _build_app(_default_cfg(), force_client_host="127.0.0.1")
+    client = TestClient(app)
+    resp = client.get(
+        "/api/ping",
+        headers={"X-Forwarded-For": "203.0.113.42, 127.0.0.1, 127.0.0.1"},
+    )
+    assert resp.status_code == 401


### PR DESCRIPTION
Close-out of the stabilization-week plan tracked in issue #194. 12 atomic commits, ordered by audit blast radius. Customer is currently on master tip `43fa84e` (PR #202, 2026-04-29) and reported "many pages do not load" — that report is against a deploy that doesn't have ANY of these fixes yet.

## What's in this PR

| Wave | Commit | Concern |
|---|---|---|
| 1 | `ecc21c1` | scanner: size-enrich BEFORE compute_scan_summary + AI insights |
| 1 | `cc0dee5` | api: normalize /api/risk-score shape + extend self-heal to /api/overview + /api/dashboard/init |
| 2 | `24b81b7` | config: merge duplicate `compliance:` top-level key (PII + retention configs were silently dropped) |
| 0 | `1addb07` | auth: honour X-Forwarded-For so a reverse proxy doesn't bypass auth |
| 3 | `cee8558` | dashboard: null-guard 12 unguarded innerHTML/textContent hot spots |
| 5 | `9f23e20` | ci: 5 deterministic guards (D-YAML / S-YAML / LOADERS / HTML-BUDGET / SVC-PARITY) + `node --check` on extracted dashboard script |
| 6 | `be638ac` | storage: `idx_sf_scan_path` index — size-enrich O(N) → O(log N) on 3M-row scans |
| 6 | `813540e` | storage: BEGIN-snapshot compute_scan_summary + UPDATE retry + complete_scan_run SELECT COUNT(*) cross-check |
| 7 | `2ada63c` | version: align setup.py / main.py / README with VERSION file |
| 4 | `9d87eae` | api: emit audit events on 11 writer endpoints (closes CLAUDE.md hard-rule violation) |
| 3+ | `bbafaec` | dashboard: null-guard the 6 remaining "Yukleme basarisiz" loaders (Kaynaklar, Dosya Türleri, Boyutlar, Erişim Sıklığı, Kullanıcılar, Anomaliler, Arşiv) |
| 8 | `b1bb98d` | deploy: config flag-rot migrator (D7) — `parquet_staging.enabled: true` etc. auto-flip on update with backup |

## What the customer gets after `update.cmd`

Direct prod-blockers closed:
- ✅ "Genel Bakış TOPLAM=0" — both write-side (scanner ordering) and read-side (self-heal at every cached endpoint)
- ✅ "Yukleme basarisiz: Cannot set properties of null" on Kaynaklar / Frequency / Types / Sizes / Users / Anomalies / Archive
- ✅ WAL pressure + 79× "DuckDB ingest basarisiz (database is locked)" — D7 migrator auto-flips `parquet_staging.enabled: true → false` with backup
- ✅ Service-name drift — `update.bat` + `auto-update.ps1` now stop the right service
- ✅ PII + retention engine configs reach prod for the first time

Defense-in-depth (no current customer impact but ships now):
- Reverse-proxy auth bypass (Wave 0)
- 11 writer endpoints now emit audit events (Wave 4)
- 5 CI guards + `node --check` would have caught #193/#197/#200/#202 in seconds (Wave 5)
- Version drift cleanup (Wave 7)

## Test posture

- 649 passed, 15 skipped, 0 regressions on Linux pytest
- 5/5 CI guards green
- `node --check` on extracted dashboard script clean
- 16 new tests covering the config migrator
- 4 new tests covering the X-Forwarded-For auth fix

## Risk

- Migrator is text-level edit (preserves comments + quote style); backup-then-write is mandatory; post-edit verify re-parses and aborts on mismatch. Contract test asserts shipped config + shipped rules = noop.
- compute_scan_summary BEGIN snapshot reads no longer hold a writer-pool slot for the full read sequence — scanner inserts proceed in parallel.
- Customer's existing summary_json values from pre-fix scans may still be stale; `_is_summary_stale` self-heal at every cached-read site catches this and falls through to live SQL.

## After merge — customer flow

```
.\update.cmd
# update.cmd → setup-source.ps1 →
#   1. pull master ZIP (now contains Wave 0-8)
#   2. blow away src/, recopy
#   3. preserve config\config.yaml
#   4. NEW: run scripts/migrate_config.py against config\config.yaml
#      → parquet_staging.enabled: true → false (with backup)
#   5. service stop/start
# tarayıcıda Ctrl+Shift+R
```

Next session test on the customer's 3.1M-file E:\ should: WAL stay <500 MB, BOYUT show real TB, every sidebar page render without console errors.

Refs: issue #194 stabilization-week tracker, `docs/architecture/audit-2026-04-28.md` debts D2/D3/D5/D6/D7 closed-in-this-PR.

https://claude.ai/code/session_01A1UzS1A4DZNk1akoP4uhZ7

---
_Generated by [Claude Code](https://claude.ai/code/session_01A1UzS1A4DZNk1akoP4uhZ7)_