### PR TITLE
fix(dashboard): cache-bust / endpoint + diag for _setTextSafe warnings

### DIFF
--- a/src/dashboard/api.py
+++ b/src/dashboard/api.py
@@ -820,11 +820,41 @@ def create_app(db, config, analytics=None, ad_lookup=None, email_notifier=None,
 
     @app.get("/", response_class=HTMLResponse)
     async def index():
+        # Issue (post-#212) — "_setTextSafe: element not found: ov-*" warnings
+        # in a customer's console with no source-side regression. The HTML and
+        # the inline JS travel together, so a browser cache mismatch shouldn't
+        # be possible in theory, yet aggressive heuristic caching by Chrome
+        # could pin an old HTML body while a later visit revalidates and gets
+        # a different inline script (e.g. through a stale intermediary or a
+        # background sync). Force-revalidate the document on every load and
+        # cache-bust /static/* with the build version so a new app version
+        # always sweeps the browser cache clean.
         html_path = os.path.join(static_dir, "index.html")
+        no_cache_headers = {
+            "Cache-Control": "no-cache, no-store, must-revalidate",
+            "Pragma": "no-cache",
+            "Expires": "0",
+            "X-App-Version": APP_VERSION,
+        }
         if os.path.exists(html_path):
             with open(html_path, "r", encoding="utf-8") as f:
-                return f.read()
-        return "<h1>FILE ACTIVITY Dashboard</h1><p>static/index.html bulunamadi.</p>"
+                html = f.read()
+            # Substitute the build-version meta placeholder + add ?v=<ver>
+            # to internal static script srcs so a deploy invalidates them.
+            html = html.replace("__APP_VERSION__", APP_VERSION)
+            html = html.replace(
+                'src="/static/components/entity-list.js"',
+                f'src="/static/components/entity-list.js?v={APP_VERSION}"',
+            )
+            html = html.replace(
+                'src="/static/components/view-toggle.js"',
+                f'src="/static/components/view-toggle.js?v={APP_VERSION}"',
+            )
+            return HTMLResponse(content=html, headers=no_cache_headers)
+        return HTMLResponse(
+            content="<h1>FILE ACTIVITY Dashboard</h1><p>static/index.html bulunamadi.</p>",
+            headers=no_cache_headers,
+        )
 
     # --- SOURCE API (ID-based) ---
 

--- a/src/dashboard/static/index.html
+++ b/src/dashboard/static/index.html
@@ -3,6 +3,7 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="app-version" content="__APP_VERSION__">
 <title>FILE ACTIVITY - Dashboard</title>
 <script src="https://cdn.jsdelivr.net/npm/d3@7"></script>
 <script src="https://cdn.jsdelivr.net/npm/chart.js@4"></script>
@@ -2653,12 +2654,43 @@ function _setHtmlSafe(id, html) {
     }
 }
 
+// Post-#212 customer report: "_setTextSafe: element not found: ov-*" with
+// no source-side regression. Cache-bust on the / endpoint (api.py) keeps
+// browsers from pinning a stale index.html, but if warnings still fire we
+// want the very first one to dump enough state to triangulate: HTML version
+// the browser actually has, whether the overview wrapper exists, how many
+// `.page` containers got parsed. After that one dump, warnings stay quiet
+// per-id to avoid spamming the console.
+let _missingElDiagShown = false;
+const _missingElSeen = new Set();
+function _logMissingElDiag(id) {
+    if (_missingElSeen.has(id)) return;
+    _missingElSeen.add(id);
+    if (!window.console) return;
+    if (!_missingElDiagShown) {
+        _missingElDiagShown = true;
+        try {
+            const meta = document.querySelector('meta[name="app-version"]');
+            const overview = document.getElementById('page-overview');
+            console.warn('[FA-diag] missing-element first warning — context:', {
+                appVersion: meta ? meta.getAttribute('content') : '(no meta)',
+                pageOverviewExists: !!overview,
+                pageOverviewChildren: overview ? overview.children.length : 0,
+                pageContainerCount: document.querySelectorAll('.page').length,
+                activePage: (document.querySelector('.page.active') || {}).id || '(none)',
+                readyState: document.readyState,
+            });
+        } catch (_) { /* diag is best-effort */ }
+    }
+    console.warn('_setTextSafe: element not found:', id);
+}
+
 function _setTextSafe(id, text) {
     const el = document.getElementById(id);
     if (el) {
         el.textContent = text == null ? '' : String(text);
-    } else if (window && window.console) {
-        console.warn('_setTextSafe: element not found:', id);
+    } else {
+        _logMissingElDiag(id);
     }
 }
 


### PR DESCRIPTION
## Context

Customer console (post-#212) shows recurring warnings while the dashboard
appears to work:

```
_setTextSafe: element not found: ov-risk-text
_setTextSafe: element not found: ov-risk-level
_setTextSafe: element not found: ov-stale-pct
... (all overview KPI ids)
```

PR #212 converted the overview loader's direct `getElementById().textContent`
calls into `_setTextSafe`, so what used to crash now warns. The elements all
still exist in `index.html` (lines 716-725), and HTML + inline JS travel in
the same response — so a true source-side mismatch shouldn't be possible.

Most likely cause: an aggressive browser cache pinning a stale document
body. The `/` endpoint sets no cache headers, so Chrome's heuristic
caching can keep an old HTML alive while a later visit silently picks up
a newer revision of `/static/components/*.js`.

## Fix

1. **`/` endpoint** now returns `Cache-Control: no-cache, no-store,
   must-revalidate` + `Pragma: no-cache` + `Expires: 0` + an
   `X-App-Version` header. Browsers revalidate every page load.

2. **`/static/components/entity-list.js`** and **`view-toggle.js`** srcs
   now carry `?v=<APP_VERSION>` so any deploy invalidates them as well.

3. **`<meta name="app-version">`** is injected via a placeholder swap in
   the endpoint, exposing the served HTML version to the JS at runtime.

4. **`_setTextSafe` diagnostic** — the first missing-element warning now
   also dumps a context object (HTML version from the meta tag, whether
   `#page-overview` exists, child count, `.page` count, `readyState`).
   Subsequent warnings dedupe per-id. This tells us in one round-trip
   whether the customer is on a stale cache (meta version old vs. server)
   or whether the elements really are absent at JS exec time.

## Verification

- `python -m pytest tests/test_dashboard_smoke.py tests/test_csp_headers.py tests/test_dashboard_auth.py tests/test_button_audit.py` — 29/29 ✅
- `python scripts/ci_guards.py` — 5/5 ✅
- `node --check` on the extracted inline script — clean ✅
- Manual `TestClient.get("/")`: returns 200, expected headers, expected
  substitutions, `ov-risk-text` still present in HTML body.

## Customer next step

Hard-refresh (Ctrl+Shift+R) the dashboard once. If warnings persist, the
console will now contain a `[FA-diag]` line revealing the served HTML
version + DOM state so we can tell stale-cache from a real runtime DOM
loss. Post that line to issue #194 and we'll route from there.

🔗 [stabilization tracker #194](https://github.com/deepdarbe/file_activity/issues/194)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TamPK8xuAaSWtmapjyuSXs)_