### PR TITLE
docs: refresh CLAUDE.md + ROADMAP.md for post-stabilization state

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,26 +6,44 @@
 
 ---
 
-## 🛑 ACTIVE: Stabilization week (2026-04-28 → 2026-05-05)
+## ✅ Stabilization week (2026-04-28 → 2026-05-05) — CLOSED
 
-**Read [issue #194](https://github.com/deepdarbe/file_activity/issues/194) FIRST**.
-It's the running log: every customer test, every fix, every regression posts there
-as a comment. Mermaid status diagram, 7-day plan, open architectural debts list.
+[Issue #194](https://github.com/deepdarbe/file_activity/issues/194) closed
+2026-05-20. The 7-day plan executed; the four-times-recurring WAL leak
+chapter (#132/#174/#181/#185) is sealed by the per-query DuckDB conn
+contract and the read-only pool. The followup audit lives in
+[#29 comment 2026-05-22](https://github.com/deepdarbe/file_activity/issues/29) — read that first when resuming.
 
-### Hard rules during this week
-- **NO new features.** Bug fixes for prod-blockers only.
+### Discipline retained from stabilization (now permanent)
 - **`node --check` is mandatory** for any `index.html` edit (PR #193 regression
-  was a JS parse error — would have been caught in 1 second).
+  was a JS parse error — would have been caught in 1 second). Wired via
+  `.github/workflows/ci.yml` and `scripts/ci_guards.py`.
 - **No parallel agents on the same file.** Wave-of-agents on `index.html` produced
   the JS regression. One agent per file per PR.
-- **Every customer interaction → post a comment to #194** with format:
-  `Customer msg / What tested / Outcome ✅⏳❌ / Action / Next`.
-- **Every PR this week MUST cite a prod-blocker** in #194 comments, otherwise close it.
+- **`scripts/ci_guards.py` (D-YAML / S-YAML / LOADERS / HTML-BUDGET / D-CHAIN /
+  SVC-PARITY)** runs on every PR. Adds belong here, not in ad-hoc PR diffs.
+- **Customer interactions still benefit from the #194 log format** even though
+  the week is over: `Customer msg / What tested / Outcome ✅⏳❌ / Action / Next`.
 
 The stabilization decision came after an honest assessment: 35 PRs in one session
 included **4 separate fixes for the same WAL leak root cause** (#132, #174, #181,
-#185) and a JS regression that broke every menu (#193). The working pattern was
-producing whack-a-mole, not stability. Plan A is "stop, audit, harden, then resume".
+#185) and a JS regression that broke every menu (#193). The pattern of
+"customer reports → emergency hotfix → next regression" was structural, not
+incidental. Plan A worked — the codebase is in a more honest state now than
+when the week began.
+
+### Post-stabilization wave (2026-05-22)
+- **PR #215** — event-loop starvation root-cause fix. 166 dashboard endpoints
+  were `async def` calling sync DB code, blocking the FastAPI loop. Converted
+  to plain `def` so Starlette dispatches to anyio worker threads. Customer's
+  "every page is waiting" symptom maps to this.
+- **PR #216** — `D-CHAIN` ci-guard plus 18 `document.getElementById(...).innerHTML =`
+  call-sites migrated to `_setHtmlSafe`. Prevents the #200/#201/#202 null-deref
+  class permanently. `INNERHTML_BUDGET` tightened 180 → 140.
+- **PR #217** — `scripts/bench_storage.py` harness. Customer can run on their
+  real 3.1M-row DB to settle "is DuckDB actually faster than SQLite?" — 10k
+  synthetic rows already shows DuckDB 9–37× slower because ATTACH overhead
+  (~50 ms/call) dominates.
 
 ---
 
@@ -64,12 +82,14 @@ to a real architectural issue (long-lived DuckDB ATTACH blocking WAL truncation)
 
 | Symptom | Likely file | Why |
 |---------|-------------|-----|
+| Every dashboard page "waiting" / loading | `src/dashboard/api.py` (sync def, ~160 endpoints) | FastAPI event-loop starvation if a new endpoint is added as `async def` while making sync DB calls — see #215. Default to plain `def`. |
 | Scan emits 0 files on real NTFS | `src/scanner/backends/_ntfs_records.py` | FRN sequence-number masking (lower 48 bits) — see #164/#165 |
 | Scan aborts mid-run with `database is locked` | `src/storage/database.py::bulk_insert_scanned_files` | 5× retry with 1/2/4/8/16s backoff (#176) |
 | WAL stuck at 13+ GB, won't truncate | `src/storage/analytics.py::AnalyticsEngine` | Per-query DuckDB conn (#185/#186) — long-lived ATTACH was the leak |
 | Dashboard menus empty during scan | `src/storage/database.py::get_read_cursor` + `partial_summary_v2` | Read-only pool (#184) + v2 schema (#183) + frontend partial-data (#182) |
 | `BOYUT: 0 B` on every file | `src/scanner/size_enricher.py` | MFT enum is path-only by design; size enrich pass runs after walk (#179) |
 | `update.cmd` fails on locked `bin\nssm.exe` | `deploy/setup-source.ps1` | Service-aware Stop/Start wrapper (#172/#173) |
+| Dashboard menu disappears / `TypeError: null.innerHTML` | `src/dashboard/static/index.html` | Use `_setHtmlSafe(id, html)` helper, never `document.getElementById(...).innerHTML =`. Enforced by `D-CHAIN` (#216). |
 
 ---
 
@@ -95,11 +115,12 @@ DuckDB analytics (AnalyticsEngine._cursor):
   - Pinned by tests/test_analytics_per_query.py
 ```
 
-**The trap that bit this codebase three times** (#132 / #174 / #185):
+**The trap that bit this codebase four times** (#132 / #174 / #181 / #185):
 A long-lived reader (any kind — dashboard handle, DuckDB ATTACH, scheduler probe)
 prevents `wal_checkpoint(TRUNCATE)` from shrinking the WAL. Symptom is always
 "WAL grows to N GB and never shrinks". Fix is always "make the reader short-lived".
 If you see that symptom in a future session, look for the new long-lived reader.
+Background read on the failure mode: https://loke.dev/blog/sqlite-checkpoint-starvation-wal-growth
 
 ---
 
@@ -152,25 +173,41 @@ subagent today opens against an older base because they take 5-30 min and master
 
 ## CI flake reality (don't chase ghosts)
 
-`Python syntax check` and `Pytest (Linux, Docker)` flake on PRs even when master is green.
-Diagnosis is in #91's body: pip-install timeouts on the GHA runner before pytest collects.
-Docker test infra (#188) addresses the chronic part. Until 3 master runs are green back-to-back,
-**`continue-on-error: true` stays on**. **Don't keep diagnosing the same flake every PR**;
-verify locally and merge if local + master are green.
+Two checks flake on PRs even when master is green:
+
+- **`Pytest (Linux, Docker)`** — pip-install timeouts on the GHA runner before pytest
+  collects. Diagnosis in #91. Docker test infra (#188) addresses the chronic part.
+  Job has `continue-on-error: true` until 3 master runs are green back-to-back.
+- **`CodeQL` (umbrella)** — distinct from `Analyze (python)` / `Analyze (javascript)`
+  which actually scan. The umbrella check inherits master-side Dependabot advisories;
+  it can fail on a PR while the analysis jobs pass. Same advisory has been on master
+  through #214/#215/#216/#217. Don't re-diagnose per PR.
+
+**Don't keep diagnosing the same flake every PR**; verify locally and merge if
+local + master are green.
 
 ---
 
-## What's open (as of 2026-04-28 end of wave)
+## What's open (as of 2026-05-22 post-stabilization audit)
 
-Only **2 open issues**:
+Code-tracking issues:
+- **#29** — EPIC roadmap tracker (pinned, never closed). 2026-05-22 audit comment
+  is the latest punch list — read it before starting any architectural work.
+- **#114** — Pluggable storage Phase 3-5. Deliberately deferred. Phase 1+2 shipped
+  (#121, #167); Phase 3 = dashboard query layer rewrite (~30 endpoints).
+  Architecturally significant — wait for the #217 bench result before committing.
 
-- **#29** — EPIC roadmap tracker (pinned, never closed)
-- **#114** — Pluggable storage Phase 3-5. Deliberately deferred. Phase 1+2 shipped (#121, #167);
-  Phase 3 = dashboard query layer rewrite (~30 endpoints). Architecturally significant —
-  needs a fresh head, NOT a tired evening session.
+Dependabot queue (10 PRs open, none merged yet — handle in this order):
+- **Patch / minor (safe, batch-merge)**: #209 pyyaml 6.0.1→6.0.3, #208 duckdb 1.0→1.5,
+  #211 apscheduler 3.10→3.11
+- **CI actions (review, then merge)**: #205 actions/checkout v4→v6, #206 codeql-action v3→v4,
+  #204 docker/build-push-action v5→v7
+- **Majors (need code audit before merging)**: #210 pillow 10→12 (touches `src/scanner/image_hash.py`),
+  #207 elasticsearch 8→9 (touches `src/storage/backends/elasticsearch_backend.py`)
 
 Closed-this-wave issues whose context might still be referenced: #14, #20, #80, #81, #83,
-#91, #112, #132, #165, #166, #172, #174, #175, #177, #181, #185.
+#91, #112, #132, #165, #166, #172, #174, #175, #177, #181, #185, #193–#202, #212, #213,
+#194 (stabilization tracker).
 
 ---
 
@@ -197,6 +234,13 @@ grep -rn "_FRN_SEGMENT_MASK" src/ tests/
 # Inspect WAL pressure live during a customer scan:
 ls -la C:\FileActivity\data\file_activity.db-wal
 # (>500 MB during scan = normal; >5 GB sustained after scan = leak; investigate readers)
+
+# Run the SQLite-vs-DuckDB benchmark on the customer's real DB (#217):
+python scripts/bench_storage.py --db C:\FileActivity\data\file_activity.db
+# Settles "is DuckDB worth it?" empirically. Tested 10k synthetic rows → DuckDB 9-37x slower.
+
+# Run every CI guard locally before pushing (D-YAML / S-YAML / LOADERS / HTML-BUDGET / D-CHAIN / SVC-PARITY):
+python scripts/ci_guards.py
 
 # After a customer reports a problem, ALWAYS get:
 #   1. The version from the dashboard footer (e.g. v1.9.0-rc1+30fd8a9)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -4,8 +4,93 @@
 > is, where it's going, and how the work is organised. Mirrored by a pinned
 > GitHub issue that tracks the live backlog.
 
-**Last updated**: 2026-04-28 — post customer prod-test wave, v1.9.0 (post-rc1).
-See "Recent wave (2026-04-28)" below for what shipped this round.
+**Last updated**: 2026-05-22 — post-stabilization audit + 3 PRs merged.
+See "Recent wave (2026-05-22)" for what shipped this round; older waves below it.
+
+---
+
+## Recent wave (2026-05-22) — post-stabilization hardening
+
+Stabilization week (issue #194) closed 2026-05-20. This wave is the
+honest-state audit that followed it: lessons-from-issues retrospective,
+architecture contract audit, external-research pass, and three PRs that
+landed concrete improvements. No new features — the line from stabilization
+holds.
+
+### Shipped
+- **PR #215** (`master 4cbef2c`) — **event-loop starvation fix**. The
+  customer's "every page is waiting" symptom traced to **165 of 182**
+  dashboard endpoints declared `async def` while only doing sync DB
+  calls. FastAPI runs `async def` on the event loop; a sync DB call
+  inside blocks the whole loop. Mechanical AST-driven conversion of
+  166 endpoints to plain `def` so Starlette dispatches them to anyio
+  worker threads. 17 endpoints kept async (middlewares + handlers that
+  `await request.json()`).
+- **PR #216** (`master bcac79b`) — **`D-CHAIN` ci-guard + 18-site
+  migration**. The `document.getElementById('id').innerHTML = ...`
+  pattern null-derefs whenever the element isn't in the DOM (the
+  #200/#201/#202 class). Migrated all 18 existing instances to the
+  `_setHtmlSafe(id, html)` helper, then added a CI guard that bans the
+  chained shape going forward. Self-tests at `tests/test_ci_guards.py`.
+  `INNERHTML_BUDGET` tightened 180 → 140.
+- **PR #217** (`master 277471f`) — **`scripts/bench_storage.py`**.
+  Single-file harness that times the 8 hot dashboard queries through
+  direct SQLite vs DuckDB `:memory:` + ATTACH (matching
+  `AnalyticsEngine._cursor`). Self-test on 10k synthetic rows shows
+  DuckDB **9–37× slower** because ATTACH overhead (~50 ms/call)
+  dominates query time on small tables. Customer runs this on the real
+  3.1M-row DB to settle "should we drop DuckDB?" empirically before
+  Phase 3 of #114 is scheduled.
+
+### Audit findings (full punch-list in [#29 comment 2026-05-22](https://github.com/deepdarbe/file_activity/issues/29))
+1. **Frontend monolith** — `index.html` is 9,475 lines of inline JS with
+   ~131 `innerHTML =` writes (down from 149 after #216). Root cause of
+   the #193/#197/#200/#202 regression cluster. Candidate fix: incremental
+   HTMX + Alpine + esbuild migration.
+2. **`parquet_staging.enabled` default-true** — the implementation is
+   sound (per-flush ATTACH, fallback), but the foot-gun from #174 is
+   still loaded. Worth flipping to false by default in a future PR.
+3. **No customer-shape integration test** — local pytest passes, prod
+   breaks. Most of the recent regressions lived in this gap (#165 FRN,
+   #175 size-zero, #193 JS).
+4. **Open question — DuckDB worth keeping?** — answered by running #217
+   on real DB.
+
+### Dependabot queue (open, not merged this wave)
+- **Safe (patch/minor)**: #209 pyyaml 6.0.1→6.0.3, #208 duckdb 1.0→1.5,
+  #211 apscheduler 3.10→3.11
+- **CI actions**: #205 actions/checkout v6, #206 codeql-action v4,
+  #204 docker/build-push-action v7
+- **Majors (need code audit)**: #210 pillow 10→12 (perceptual hash),
+  #207 elasticsearch 8→9 (backend module)
+
+### Status diagram
+
+```mermaid
+graph TD
+    A[master @ 277471f<br/>post #215 #216 #217] --> B[customer test client-side]
+    B --> C{Event-loop fix landed?}
+    C -->|p95 dashboard load < 2s| D[Close 'every page waiting' chapter ✅]
+    C -->|still slow| E[Profile individual slow queries<br/>indexes / precompute]
+
+    A --> F[Run #217 bench on real 3.1M-row DB]
+    F -->|DuckDB > SQLite| G[Keep, pin in docs]
+    F -->|SQLite competitive| H[Schedule #114 Phase 3<br/>drop DuckDB]
+
+    A --> I[Dependabot triage]
+    I --> J[Batch merge safe minors:<br/>#208 #209 #211]
+    I --> K[CI action bumps:<br/>#204 #205 #206]
+    I --> L[Major audit:<br/>#207 #210]
+
+    A --> M[#29 audit punch-list]
+    M --> N[Punch-list 1: HTMX pilot on 1 page]
+    M --> O[Punch-list 2: parquet_staging default-off]
+    M --> P[Punch-list 3: integration-test corpus]
+
+    style D fill:#90EE90
+    style H fill:#90EE90
+    style J fill:#90EE90
+```
 
 ---
 


### PR DESCRIPTION
## Why

Stabilization week (#194) closed 2026-05-20 but the memory files still showed it as `🛑 ACTIVE`. This PR captures the honest-state audit run on 2026-05-22 and reflects what landed since (#215/#216/#217).

Memory file scope: **project-only** (`/CLAUDE.md` in this repo, not `~/.claude/CLAUDE.md` global). The two never overlap.

## CLAUDE.md
- Stabilization header: `🛑 ACTIVE` → `✅ CLOSED`, with the discipline items that stay permanent (`node --check`, no-parallel-agents-on-same-file, `ci_guards.py` on every PR).
- Architecture map: new rows for the two newest failure modes — event-loop starvation (#215) and `TypeError: null.innerHTML` from chained `getElementById` (#216).
- The trap section: `bit this codebase three times` → `four times` (added #181). Pinned the Loke.dev background article as the canonical reference.
- CI flake reality: added the CodeQL umbrella check separately from the `Analyze (python/javascript)` jobs that actually scan. Both flake on PRs while master is green.
- What's open: refreshed for 2026-05-22 — 2 code-tracking issues plus the **10-PR Dependabot queue grouped by risk tier**.
- Useful incantations: added one-liners for `bench_storage.py` and `ci_guards.py`.

## ROADMAP.md
- New `Recent wave (2026-05-22)` section above the existing 2026-04-28 block (preserved verbatim).
- Audit findings inline with pointer to the #29 comment for full punch list.
- Dependabot queue with explicit risk tiers (safe / CI actions / majors).
- Mermaid status diagram showing the three live decision threads:
  1. Customer test of #215 (event-loop fix)
  2. #217 bench result (DuckDB-vs-SQLite verdict)
  3. Dependabot triage

## Verification

- `python scripts/ci_guards.py`: all 6 checks green
- No code changes; only `CLAUDE.md` and `ROADMAP.md`

## Risk

None — documentation-only update.


---
_Generated by [Claude Code](https://claude.ai/code/session_01TamPK8xuAaSWtmapjyuSXs)_