### PR TITLE
perf(dashboard): cache report_full + report_status (closes Treemap empty/waiting)

### DIFF
--- a/src/dashboard/api.py
+++ b/src/dashboard/api.py
@@ -1301,10 +1301,25 @@ def create_app(db, config, analytics=None, ad_lookup=None, email_notifier=None,
 
     @app.get("/api/reports/status/{source_id}")
     def report_status(source_id: int):
+        """Same pattern as report_frequency/types/sizes — cached per scan_id.
+
+        Previously this endpoint re-ran generate_status_report (a GROUP BY
+        over all of scanned_files) on every call. On a 2.89M-file scan that
+        is 10–30 sec per click. Now cached via ``analyzer_cache`` and
+        invalidated automatically on a new scan.
+        """
         from src.analyzer.report_generator import ReportGenerator
+        from src.analyzer import cache as analyzer_cache
         src = _get_source(db, source_id)
         gen = ReportGenerator(db, config)
-        return gen.generate_status_report(src.id)
+        scan_id = db.get_latest_scan_id(src.id, include_running=True)
+        if scan_id is None:
+            return gen.generate_status_report(src.id)
+        envelope = analyzer_cache.get_or_compute(
+            db, "status", scan_id,
+            lambda: gen.generate_status_report(src.id),
+        )
+        return _attach_cache_envelope(envelope)
 
     # Issue #125 — context manager that wraps a block in start/finish on
     # the operations registry. Tracker outage MUST NOT break the work,
@@ -1490,8 +1505,19 @@ def create_app(db, config, analytics=None, ad_lookup=None, email_notifier=None,
         snapshot is available, return it (with ``is_partial: True``) so
         the Reports page renders rolling KPIs instead of the empty
         placeholder.
+
+        Customer 2026-05-22: Treemap Harita page (the only caller of
+        this endpoint) was empty because ``generate_full_report``
+        re-ran three separate GROUP BY queries (freq + types + sizes)
+        over 2.89M scanned_files on every page open — 30-90 sec per
+        click, often timed out before the SVG rendered. Now cached
+        via ``analyzer_cache.get_or_compute(db, "full", scan_id, ...)``
+        so the first click pays the compute and every subsequent
+        click is sub-ms. Same pattern as report_frequency / report_types
+        / report_sizes / mit_naming_report (PR #224).
         """
         from src.analyzer.report_generator import ReportGenerator
+        from src.analyzer import cache as analyzer_cache
         src = _get_source(db, source_id)
         completed_scan_id = db.get_latest_scan_id(src.id, include_running=False)
         if completed_scan_id is None:
@@ -1508,7 +1534,11 @@ def create_app(db, config, analytics=None, ad_lookup=None, email_notifier=None,
             metadata={"source_id": src.id},
         ):
             gen = ReportGenerator(db, config)
-            return gen.generate_full_report(src.id)
+            envelope = analyzer_cache.get_or_compute(
+                db, "full", completed_scan_id,
+                lambda: gen.generate_full_report(src.id),
+            )
+            return _attach_cache_envelope(envelope)
 
     # --- ARCHIVE API ---
 


### PR DESCRIPTION
## Why

Customer 2026-05-22 (post-#224 update): **Treemap Harita sayfası boş geliyor**, "yukleniyor 0/1 endpoint" sürekli yazıyor. Aynı sınıf bug #224 mit_naming ile — endpoint cache'siz, her tıklamada 2.89M satır üzerinde heavy GROUP BY.

## Root cause

`/api/reports/full` ve `/api/reports/status` `analyzer_cache.get_or_compute` sarmalı kullanmıyordu. `report_full` özellikle kötü: `generate_full_report` içinde **3 ayrı analyzer** çağırıyor (freq + types + sizes), her biri kendi GROUP BY'ını çalıştırıyor — yani 30-90 sn/tıklama. Browser çoğu zaman vazgeçiyor, SVG render olmuyor.

İronik: `/reports/frequency`, `/reports/types`, `/reports/sizes` zaten **tek tek cache'li**. Ama `report_full` üçünü ayrıca yeniden hesaplıyordu.

## Fix

İkisini de `analyzer_cache.get_or_compute(db, name, scan_id, ...)` ile sarmaladım — Rule 1 (`docs/standards/endpoint-conventions.md`) ile uyumlu. İlk tıklama yine compute eder; sonraki tıklamalar sub-ms.

```diff
+from src.analyzer import cache as analyzer_cache
...
-return gen.generate_full_report(src.id)
+envelope = analyzer_cache.get_or_compute(
+    db, "full", completed_scan_id,
+    lambda: gen.generate_full_report(src.id),
+)
+return _attach_cache_envelope(envelope)
```

## Sistematik audit sonucu

`R-CACHE` rule (henüz CI guard değil, manuel uyguladım) ile tüm endpoint'leri taradım. **5 ihlal**:

| Endpoint | Bu PR | Sonraki |
|---|---|---|
| `report_status` (1303) | ✅ | — |
| `report_full` (1484) | ✅ | — |
| `report_export` (1728) | — | #225 R-2 (parent cache okusun) |
| `mit_naming_files` (2279) | — | #225 R-2 (shape farklı, ayrı cache key) |
| `mit_naming_export` (2336) | — | #225 R-2 (drilldown export) |

Bu PR müşterinin **şu an ekranını etkileyen 2'sini** kapatıyor (Treemap + Status). Diğer 3 export-yolu (`report_export`, `mit_naming_files`, `mit_naming_export`) EPIC #225 R-2 içinde — küçük bir refactor ile parent cache'i okuyup yeniden compute etmemeleri gerekiyor.

## Verification

- `python -m py_compile src/dashboard/api.py`: clean
- `pytest -k "dashboard or report"`: 67 passed, 5 skipped
- `python scripts/ci_guards.py`: 6/6 green

## Customer test path

1. Update + hard refresh
2. Treemap Harita → ilk açılışta 30-90 sn bekle (cold cache), sonra **anlık yenilenir**
3. Genel Bakış sayfasındaki "Tam rapor: e" badge'i de artık 1 dakikada bitmesi gerek (ilk compute), sonra hiç çıkmaz


---
_Generated by [Claude Code](https://claude.ai/code/session_01TamPK8xuAaSWtmapjyuSXs)_