### PR TITLE
perf: HTTP-level bench + EXPLAIN QUERY PLAN audit (Aşama 0 diagnostics)

### DIFF
--- a/scripts/bench_api.py
+++ b/scripts/bench_api.py
@@ -1,0 +1,243 @@
+"""HTTP-level latency benchmark for the dashboard's hot endpoints.
+
+Why this exists
+---------------
+``scripts/bench_storage.py`` (PR #217) measures SQL-level latency
+(SQLite vs DuckDB) but says nothing about the **end-to-end HTTP path** —
+FastAPI dispatch, anyio threadpool overhead, JSON serialisation, response
+size. The customer's "every page is waiting" symptom (PR #215) and the
+"Treemap empty waiting" symptom (PR #227) both lived at this layer, not
+the SQL layer.
+
+This script runs against the dashboard running on the customer machine
+(or a copy of it) and reports p50/p95/p99 + cache hit ratio per
+endpoint, for both **cold** (cache miss) and **warm** (cache hit)
+states.
+
+Usage
+-----
+On the customer machine, with the FileActivity service running::
+
+    python scripts/bench_api.py --base http://localhost:8085 \\
+        --source-id 1 --repeats 20
+
+Outputs a table + JSON sidecar ``bench_api_<ts>.json`` for diffing
+across runs (before/after an index migration, before/after a code
+fix).
+
+Endpoint set (5 critical reads, the ones the dashboard hits on every
+load):
+
+  /api/dashboard/init                       - overview KPIs
+  /api/reports/frequency/{source_id}        - Erisim Sikligi page
+  /api/reports/types/{source_id}            - Dosya Turleri page
+  /api/reports/sizes/{source_id}            - Boyut Dagilimi page
+  /api/reports/duplicates/{source_id}       - Kopya Dosyalar page
+
+Cold vs warm:
+  - Cold: hit each endpoint once *before* it's been called this session.
+    The analyzer_cache LRU is empty, the DB-tier cache may or may not
+    be hot (depends on prior session). First-call latency dominates.
+  - Warm: hit each endpoint --repeats more times. The analyzer_cache
+    LRU is now hot; latency is just the response-serialise path.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import statistics
+import sys
+import time
+import urllib.error
+import urllib.request
+from typing import Iterable
+
+ENDPOINTS = [
+    ("dashboard_init", "/api/dashboard/init"),
+    ("frequency", "/api/reports/frequency/{source_id}"),
+    ("types", "/api/reports/types/{source_id}"),
+    ("sizes", "/api/reports/sizes/{source_id}"),
+    ("duplicates", "/api/reports/duplicates/{source_id}"),
+]
+
+
+def _http_get(url: str, timeout: float = 120.0) -> tuple[int, float, dict]:
+    """Return (status_code, elapsed_seconds, parsed_json_or_empty)."""
+    t0 = time.perf_counter()
+    try:
+        req = urllib.request.Request(url, headers={"Accept": "application/json"})
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            elapsed = time.perf_counter() - t0
+            body = resp.read()
+            try:
+                parsed = json.loads(body.decode("utf-8")) if body else {}
+            except Exception:
+                parsed = {}
+            return resp.status, elapsed, parsed
+    except urllib.error.HTTPError as e:
+        elapsed = time.perf_counter() - t0
+        return e.code, elapsed, {}
+    except Exception as e:
+        elapsed = time.perf_counter() - t0
+        print(f"  HTTP error: {e}", file=sys.stderr)
+        return -1, elapsed, {}
+
+
+def _bench_one(
+    name: str, url: str, repeats: int
+) -> dict:
+    """Hit ``url`` ``repeats`` times. First call is the cold sample;
+    the rest are warm. Both are reported separately."""
+    samples = []
+    status_codes = []
+    cache_hits = 0
+    cache_misses = 0
+    response_sizes: list[int] = []
+    for i in range(repeats):
+        status, elapsed, body = _http_get(url)
+        samples.append(elapsed)
+        status_codes.append(status)
+        cache = body.get("cache", {}) if isinstance(body, dict) else {}
+        if isinstance(cache, dict):
+            if cache.get("hit"):
+                cache_hits += 1
+            else:
+                cache_misses += 1
+        response_sizes.append(len(json.dumps(body).encode("utf-8")))
+    cold = samples[0] if samples else float("nan")
+    warm = samples[1:] if len(samples) > 1 else []
+    return {
+        "name": name,
+        "url": url,
+        "status_codes": status_codes,
+        "cache_hits": cache_hits,
+        "cache_misses": cache_misses,
+        "response_size_bytes_p50": int(statistics.median(response_sizes)) if response_sizes else 0,
+        "cold_seconds": cold,
+        "warm_count": len(warm),
+        "warm_min": min(warm) if warm else float("nan"),
+        "warm_p50": statistics.median(warm) if warm else float("nan"),
+        "warm_p95": _percentile(warm, 0.95),
+        "warm_p99": _percentile(warm, 0.99),
+        "warm_max": max(warm) if warm else float("nan"),
+        "samples": samples,
+    }
+
+
+def _percentile(values: list[float], p: float) -> float:
+    if not values:
+        return float("nan")
+    s = sorted(values)
+    k = (len(s) - 1) * p
+    f = int(k)
+    c = min(f + 1, len(s) - 1)
+    if f == c:
+        return s[f]
+    return s[f] + (s[c] - s[f]) * (k - f)
+
+
+def _fmt_t(seconds: float) -> str:
+    if seconds != seconds:  # NaN
+        return "      n/a"
+    if seconds < 0.001:
+        return f"{seconds * 1e6:7.0f} us"
+    if seconds < 1.0:
+        return f"{seconds * 1000:7.1f} ms"
+    return f"{seconds:7.2f} s "
+
+
+def _print_table(results: list[dict]) -> None:
+    print()
+    print(f"{'Endpoint':<16} {'cold':>10} {'warm p50':>10} {'warm p95':>10} "
+          f"{'warm p99':>10} {'cache':>8} {'bytes':>10}")
+    print("-" * 84)
+    for r in results:
+        cache_total = r["cache_hits"] + r["cache_misses"]
+        cache_ratio = (
+            f"{r['cache_hits']}/{cache_total}" if cache_total else "  —"
+        )
+        # Flag bad status codes
+        bad_status = [c for c in r["status_codes"] if c < 200 or c >= 300]
+        status_marker = f" ⚠ {bad_status[0]}" if bad_status else ""
+        print(
+            f"{r['name']:<16} "
+            f"{_fmt_t(r['cold_seconds']):>10} "
+            f"{_fmt_t(r['warm_p50']):>10} "
+            f"{_fmt_t(r['warm_p95']):>10} "
+            f"{_fmt_t(r['warm_p99']):>10} "
+            f"{cache_ratio:>8} "
+            f"{r['response_size_bytes_p50']:>9,d}B"
+            f"{status_marker}"
+        )
+    print()
+    print("Cold = first call (cache cold). Warm = subsequent calls (cache warm).")
+    print("cache column shows analyzer_cache hits / total calls.")
+
+
+def main(argv: Iterable[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument(
+        "--base",
+        default="http://localhost:8085",
+        help="Base URL of the running FileActivity dashboard (default: http://localhost:8085).",
+    )
+    ap.add_argument(
+        "--source-id",
+        type=int,
+        required=True,
+        help="Source ID to bench against. See /api/sources for the list.",
+    )
+    ap.add_argument(
+        "--repeats",
+        type=int,
+        default=10,
+        help="Calls per endpoint. First is cold; rest are warm (default: 10).",
+    )
+    ap.add_argument(
+        "--endpoints",
+        nargs="*",
+        choices=[name for name, _ in ENDPOINTS] + ["all"],
+        default=["all"],
+        help="Subset of endpoints to bench (default: all).",
+    )
+    args = ap.parse_args(list(argv) if argv else None)
+
+    base = args.base.rstrip("/")
+    sid = args.source_id
+
+    selected = args.endpoints
+    if "all" in selected:
+        names = [n for n, _ in ENDPOINTS]
+    else:
+        names = list(selected)
+
+    print(f"Bench target: {base}")
+    print(f"source_id={sid}, repeats={args.repeats}")
+    print()
+
+    results = []
+    for name, template in ENDPOINTS:
+        if name not in names:
+            continue
+        url = base + template.replace("{source_id}", str(sid))
+        print(f"  benching {name:<16} {url}")
+        r = _bench_one(name, url, args.repeats)
+        results.append(r)
+
+    _print_table(results)
+
+    ts = time.strftime("%Y%m%d-%H%M%S")
+    out_path = f"bench_api_{ts}.json"
+    with open(out_path, "w") as f:
+        json.dump({
+            "base": base,
+            "source_id": sid,
+            "repeats": args.repeats,
+            "results": results,
+        }, f, indent=2)
+    print(f"JSON sidecar: {out_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/explain_audit.py
+++ b/scripts/explain_audit.py
@@ -1,0 +1,293 @@
+"""EXPLAIN QUERY PLAN audit for the dashboard's hot SQL paths.
+
+Why this exists
+---------------
+``scripts/bench_api.py`` measures *latency*. This script tells you *why*
+a query is slow — index hit vs full table scan, B-tree vs sequential
+scan, temp B-tree for sorting, etc. Together they pinpoint which
+endpoints need a new index.
+
+The query set mirrors the SQL that the dashboard's hot endpoints run
+(via ``ReportGenerator`` / ``Database.compute_scan_summary`` /
+``MITNamingAnalyzer``). Each query is run under ``EXPLAIN QUERY PLAN``
+on the customer's real DB and the resulting plan is parsed for
+red-flag patterns:
+
+  - ``SCAN TABLE scanned_files``   ← full table scan, bad on 2.9M rows
+  - ``USE TEMP B-TREE FOR ORDER``  ← unindexed ORDER BY, expensive sort
+  - ``USE TEMP B-TREE FOR GROUP``  ← unindexed GROUP BY, expensive sort
+
+Usage
+-----
+On the customer machine (or a copy of the DB)::
+
+    python scripts/explain_audit.py \\
+        --db C:\\FileActivity\\data\\file_activity.db
+
+Outputs a per-query verdict and a summary of which composite indexes
+*would* help (e.g. ``(scan_id, file_size)`` to remove a temp B-tree).
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sqlite3
+import sys
+import time
+from pathlib import Path
+from typing import Iterable
+
+# Query set. Each entry: (name, sql, params_template).
+# ``params_template`` is a dict that uses placeholder values; the real
+# values come from the DB at audit time (largest scan_id by default).
+QUERIES: list[tuple[str, str, dict]] = [
+    (
+        "compute_scan_summary.total_size",
+        "SELECT COUNT(*) c, COALESCE(SUM(file_size),0) s, "
+        "COUNT(DISTINCT owner) o FROM scanned_files WHERE scan_id=?",
+        {"scan_id": 1},
+    ),
+    (
+        "compute_scan_summary.stale_count",
+        "SELECT COUNT(*) c, COALESCE(SUM(file_size),0) s FROM scanned_files "
+        "WHERE scan_id=? AND COALESCE(last_access_time, last_modify_time) < ?",
+        {"scan_id": 1, "cutoff": "2025-01-01"},
+    ),
+    (
+        "compute_scan_summary.risky_count",
+        "SELECT COUNT(*) c FROM scanned_files "
+        "WHERE scan_id=? AND LOWER(extension) IN "
+        "('exe','bat','ps1','vbs','cmd','com','scr','msi','js','wsf')",
+        {"scan_id": 1},
+    ),
+    (
+        "compute_scan_summary.top_extensions",
+        "SELECT extension, COUNT(*) c, COALESCE(SUM(file_size),0) s "
+        "FROM scanned_files WHERE scan_id=? "
+        "GROUP BY extension ORDER BY c DESC LIMIT 10",
+        {"scan_id": 1},
+    ),
+    (
+        "compute_scan_summary.top_owners",
+        "SELECT owner, COUNT(*) c, COALESCE(SUM(file_size),0) s "
+        "FROM scanned_files WHERE scan_id=? AND owner IS NOT NULL "
+        "GROUP BY owner ORDER BY s DESC LIMIT 10",
+        {"scan_id": 1},
+    ),
+    (
+        "compute_scan_summary.top_large_files",
+        "SELECT file_name, file_path, file_size FROM scanned_files "
+        "WHERE scan_id=? ORDER BY file_size DESC LIMIT 50",
+        {"scan_id": 1},
+    ),
+    (
+        "type_analyzer.analyze",
+        "SELECT extension, COUNT(*) file_count, "
+        "COALESCE(SUM(file_size),0) total_size, "
+        "COALESCE(AVG(file_size),0) avg_size, "
+        "COALESCE(MIN(file_size),0) min_size, "
+        "COALESCE(MAX(file_size),0) max_size "
+        "FROM scanned_files WHERE scan_id=? GROUP BY extension",
+        {"scan_id": 1},
+    ),
+    (
+        "mit_naming_files.scan",
+        "SELECT id, file_path, file_name, file_size, owner, last_modify_time "
+        "FROM scanned_files WHERE scan_id=?",
+        {"scan_id": 1},
+    ),
+    (
+        "duplicates.group_by_hash",
+        "SELECT content_hash, COUNT(*) c, COALESCE(SUM(file_size),0) s "
+        "FROM scanned_files "
+        "WHERE scan_id=? AND content_hash IS NOT NULL "
+        "GROUP BY content_hash HAVING c > 1 ORDER BY s DESC LIMIT 50",
+        {"scan_id": 1},
+    ),
+]
+
+
+RED_FLAGS = [
+    ("SCAN TABLE scanned_files", "full_table_scan"),
+    ("USE TEMP B-TREE FOR ORDER BY", "temp_btree_order"),
+    ("USE TEMP B-TREE FOR GROUP BY", "temp_btree_group"),
+    ("USE TEMP B-TREE FOR DISTINCT", "temp_btree_distinct"),
+]
+
+
+def _explain(conn: sqlite3.Connection, sql: str, params: tuple) -> list[dict]:
+    """Return list of {id, parent, notused, detail} rows from EXPLAIN QUERY PLAN."""
+    cur = conn.execute("EXPLAIN QUERY PLAN " + sql, params)
+    cols = [d[0] for d in cur.description]
+    return [dict(zip(cols, row)) for row in cur.fetchall()]
+
+
+def _list_indexes(conn: sqlite3.Connection) -> list[dict]:
+    cur = conn.execute(
+        "SELECT name, sql FROM sqlite_master "
+        "WHERE type='index' AND tbl_name='scanned_files' "
+        "ORDER BY name"
+    )
+    return [{"name": r[0], "sql": r[1] or ""} for r in cur.fetchall()]
+
+
+def _resolve_scan_id(conn: sqlite3.Connection, override: int | None) -> int:
+    if override is not None:
+        return override
+    row = conn.execute(
+        "SELECT scan_id, COUNT(*) c FROM scanned_files "
+        "GROUP BY scan_id ORDER BY c DESC LIMIT 1"
+    ).fetchone()
+    return int(row[0]) if row else 1
+
+
+def _classify(plan_rows: list[dict]) -> list[str]:
+    """Walk the plan, return list of red-flag tags found."""
+    flags = []
+    for row in plan_rows:
+        detail = row.get("detail", "") or ""
+        for needle, tag in RED_FLAGS:
+            if needle in detail:
+                flags.append(tag)
+    return flags
+
+
+def _suggest_indexes(name: str, sql: str, flags: list[str]) -> list[str]:
+    """Heuristic: based on WHERE + ORDER BY of the query, suggest indexes."""
+    suggestions = []
+    sql_upper = sql.upper()
+    if "temp_btree_order" in flags and "ORDER BY FILE_SIZE" in sql_upper:
+        suggestions.append("CREATE INDEX idx_scan_size ON scanned_files(scan_id, file_size DESC);")
+    if "temp_btree_group" in flags and "GROUP BY EXTENSION" in sql_upper:
+        suggestions.append("CREATE INDEX idx_scan_ext ON scanned_files(scan_id, extension);")
+    if "temp_btree_group" in flags and "GROUP BY OWNER" in sql_upper:
+        suggestions.append("CREATE INDEX idx_scan_owner ON scanned_files(scan_id, owner);")
+    if "temp_btree_group" in flags and "GROUP BY CONTENT_HASH" in sql_upper:
+        suggestions.append("CREATE INDEX idx_scan_hash ON scanned_files(scan_id, content_hash);")
+    if "full_table_scan" in flags and "WHERE SCAN_ID=" in sql_upper.replace(" ", ""):
+        suggestions.append("CREATE INDEX idx_scan_id ON scanned_files(scan_id);  -- if not present")
+    return suggestions
+
+
+def _run(conn: sqlite3.Connection, scan_id: int) -> dict:
+    by_query = []
+    all_suggestions: set[str] = set()
+    for name, sql, params_template in QUERIES:
+        # Fill in placeholders
+        params = []
+        if "scan_id" in params_template:
+            params.append(scan_id)
+        if "cutoff" in params_template:
+            params.append("2025-01-01")
+        try:
+            t0 = time.perf_counter()
+            plan = _explain(conn, sql, tuple(params))
+            explain_time = time.perf_counter() - t0
+        except sqlite3.OperationalError as e:
+            by_query.append({
+                "name": name,
+                "error": str(e),
+                "plan": [],
+                "red_flags": [],
+                "suggested_indexes": [],
+            })
+            continue
+        flags = _classify(plan)
+        sugg = _suggest_indexes(name, sql, flags)
+        all_suggestions.update(sugg)
+        by_query.append({
+            "name": name,
+            "sql": sql,
+            "plan": [r.get("detail", "") for r in plan],
+            "red_flags": flags,
+            "suggested_indexes": sugg,
+            "explain_time_ms": round(explain_time * 1000, 2),
+        })
+    return {"queries": by_query, "all_suggestions": sorted(all_suggestions)}
+
+
+def _print_report(result: dict, indexes: list[dict]) -> None:
+    print()
+    print("=" * 80)
+    print("EXISTING INDEXES ON scanned_files")
+    print("=" * 80)
+    if not indexes:
+        print("  (none)")
+    for idx in indexes:
+        print(f"  {idx['name']}: {idx['sql']}")
+    print()
+    print("=" * 80)
+    print("QUERY PLANS")
+    print("=" * 80)
+    for q in result["queries"]:
+        print()
+        print(f"## {q['name']}")
+        if "error" in q:
+            print(f"   ⚠ error: {q['error']}")
+            continue
+        flag_str = ", ".join(q["red_flags"]) if q["red_flags"] else "OK"
+        print(f"   flags: {flag_str}")
+        for line in q["plan"]:
+            marker = "  ⚠ " if any(r[0] in line for r in RED_FLAGS) else "    "
+            print(f"  {marker}{line}")
+        if q["suggested_indexes"]:
+            print("   Suggested:")
+            for s in q["suggested_indexes"]:
+                print(f"     {s}")
+    print()
+    print("=" * 80)
+    print("CONSOLIDATED SUGGESTIONS (deduplicated)")
+    print("=" * 80)
+    if not result["all_suggestions"]:
+        print("  No new indexes suggested — existing indexes cover the hot queries.")
+    else:
+        for s in result["all_suggestions"]:
+            print(f"  {s}")
+    print()
+
+
+def main(argv: Iterable[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument(
+        "--db",
+        required=True,
+        help="Path to the SQLite DB to audit.",
+    )
+    ap.add_argument(
+        "--scan-id",
+        type=int,
+        help="scan_id to plan against (default: largest in DB).",
+    )
+    args = ap.parse_args(list(argv) if argv else None)
+
+    if not Path(args.db).exists():
+        print(f"DB not found: {args.db}", file=sys.stderr)
+        return 2
+
+    uri = f"file:{args.db}?mode=ro&cache=shared"
+    conn = sqlite3.connect(uri, uri=True)
+    try:
+        scan_id = _resolve_scan_id(conn, args.scan_id)
+        print(f"DB: {args.db}")
+        print(f"scan_id: {scan_id}")
+        indexes = _list_indexes(conn)
+        result = _run(conn, scan_id)
+        _print_report(result, indexes)
+
+        ts = time.strftime("%Y%m%d-%H%M%S")
+        out_path = f"explain_audit_{ts}.json"
+        with open(out_path, "w") as f:
+            json.dump({
+                "db": args.db,
+                "scan_id": scan_id,
+                "existing_indexes": indexes,
+                **result,
+            }, f, indent=2)
+        print(f"JSON sidecar: {out_path}")
+        return 0
+    finally:
+        conn.close()
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Why

Customer 2026-05-22 advisor sub-agent flagged **"ölçmeden optimize etme"** as the missing Aşama 0. We had SQL-level measurement (PR #217 `bench_storage`) but **nothing at the HTTP layer**. This pair of read-only diagnostic scripts closes that gap.

## What

### 1. `scripts/bench_api.py` — HTTP-level latency
- 5 hot endpoints: `dashboard_init`, `frequency`, `types`, `sizes`, `duplicates`
- Reports: cold (first call) + warm p50/p95/p99/max + cache hit ratio + response size
- stdlib only (`urllib`), zero deps
- JSON sidecar for before/after diff

```
python scripts/bench_api.py --base http://localhost:8085 --source-id 1 --repeats 20
```

### 2. `scripts/explain_audit.py` — SQL plan audit
- `EXPLAIN QUERY PLAN` on 9 hot SQL paths (compute_scan_summary's GROUP BY + ORDER BY, TypeAnalyzer, mit_naming_files, duplicates)
- Red flag detection: `SCAN TABLE`, `USE TEMP B-TREE FOR {GROUP,ORDER,DISTINCT}`
- Per-query suggested CREATE INDEX statements

```
python scripts/explain_audit.py --db C:\FileActivity\data\file_activity.db
```

## Self-test result (on synthetic 5k-row DB)

Even on a synthetic with only `idx_scan_id`, the audit correctly surfaces **4 missing composite indexes**:

```
CREATE INDEX idx_scan_ext   ON scanned_files(scan_id, extension);
CREATE INDEX idx_scan_hash  ON scanned_files(scan_id, content_hash);
CREATE INDEX idx_scan_owner ON scanned_files(scan_id, owner);
CREATE INDEX idx_scan_size  ON scanned_files(scan_id, file_size DESC);
```

These are exactly the indexes that would remove the temp B-tree sort on GROUP BY extension / GROUP BY owner / ORDER BY file_size on the real 2.89M-row DB.

## How they fit together

1. **bench_api** → which endpoint is actually slow? what's its tail latency? does the cache hit reliably?
2. **explain_audit** → for the slow ones, is the SQL plan the cause? is there a missing index?
3. If yes → ship `CREATE INDEX` migration, re-run bench, confirm tail dropped.

## Risk

None — both scripts are read-only against the customer's DB / API. No production code touched.

## Next step

Customer runs both on production. Shares JSON sidecars. Then we ship a targeted index migration based on real evidence — no guessing.


---
_Generated by [Claude Code](https://claude.ai/code/session_01TamPK8xuAaSWtmapjyuSXs)_