### PR TITLE
fix(dashboard): drilldown XLSX export honours filter (was returning full report)

### DIFF
--- a/src/dashboard/api.py
+++ b/src/dashboard/api.py
@@ -1854,6 +1854,98 @@ def create_app(db, config, analytics=None, ad_lookup=None, email_notifier=None,
         result["limit"] = limit
         return result
 
+    @app.get("/api/drilldown/{filter_type}/{source_id}/export.xlsx")
+    def drilldown_export_xlsx(
+        filter_type: str,
+        source_id: int,
+        min_days: int = 0,
+        max_days: Optional[int] = None,
+        extension: str = "",
+        min_bytes: int = 0,
+        max_bytes: Optional[int] = None,
+        owner: str = "",
+    ):
+        """XLSX export of a drilldown filter result.
+
+        Customer 2026-05-22: clicking ``XLSX İndir`` inside any drilldown
+        modal (Erisim Sikligi/Type/Size/Owner) was hitting
+        ``/api/export/xls/{source_id}`` which exports the **full report**
+        (5-sheet GROUP-BY summary), ignoring the drilldown filter
+        completely AND running 5 separate queries over 2.89M rows on
+        every click. Customer experience: "Rapor almak istiyoruz, sonuc
+        alamiyoruz" — request would either time out or return the wrong
+        file.
+
+        This endpoint mirrors the four drilldown JSON endpoints
+        (frequency/type/size/owner) and emits an XLSX of the matching
+        files via ``XLSExporter.export_drilldown``. Filter params match
+        the JSON endpoint signatures exactly so the frontend can swap
+        ``/drilldown/`` → ``/api/drilldown/.../export.xlsx`` with
+        identical params and Just Work.
+
+        Row cap: 100_000. Beyond that the XLSX is too large to be useful
+        in Excel anyway (and Excel itself caps at 1,048,576 rows). Future
+        work: route oversize exports through ``write_large_workbook``
+        (multi-sheet) or ``stream_csv`` (issue #122 pattern) the same way
+        ``export_mit_naming_xlsx`` does — tracked in #225 R-2.
+        """
+        from fastapi.responses import StreamingResponse
+        from io import BytesIO
+        from src.analyzer.report_exporter_v2 import XLSExporter
+
+        src = _get_source(db, source_id)
+        scan_id = db.get_latest_scan_id(src.id, include_running=True)
+        if not scan_id:
+            raise HTTPException(404, "Tarama verisi bulunamadi")
+
+        MAX_ROWS = 100_000
+
+        if filter_type == "frequency":
+            run = _run_drilldown(analytics.get_files_by_frequency,
+                                 db.get_files_by_frequency)
+            result = run(src.id, scan_id, min_days, max_days, MAX_ROWS, 0)
+            sheet_title = f"freq_{min_days}-{max_days or 'inf'}"
+        elif filter_type == "type":
+            run = _run_drilldown(analytics.get_files_by_extension,
+                                 db.get_files_by_extension)
+            result = run(src.id, scan_id, extension, MAX_ROWS, 0)
+            sheet_title = f"type_{extension}" if extension else "type_all"
+        elif filter_type == "size":
+            run = _run_drilldown(analytics.get_files_by_size_range,
+                                 db.get_files_by_size_range)
+            result = run(src.id, scan_id, min_bytes, max_bytes, MAX_ROWS, 0)
+            sheet_title = f"size_{min_bytes}-{max_bytes or 'inf'}"
+        elif filter_type == "owner":
+            run = _run_drilldown(analytics.get_files_by_owner,
+                                 db.get_files_by_owner)
+            result = run(src.id, scan_id, owner, MAX_ROWS, 0)
+            sheet_title = (f"owner_{owner}" if owner else "owner_all")[:31]
+        else:
+            raise HTTPException(
+                400,
+                f"Gecersiz filter_type: {filter_type}. "
+                "Gecerli: frequency, type, size, owner",
+            )
+
+        files = result.get("files", []) or []
+
+        try:
+            exporter = XLSExporter(db, config)
+            data = exporter.export_drilldown(files, sheet_title)
+        except ImportError:
+            raise HTTPException(501, "openpyxl kurulu degil. pip install openpyxl")
+        except Exception as e:  # pragma: no cover - defensive
+            logger.error("drilldown XLSX export error: %s", e)
+            raise HTTPException(500, str(e))
+
+        ts = datetime.now().strftime("%Y%m%d_%H%M%S")
+        filename = f"drilldown_{filter_type}_{src.name}_{ts}.xlsx"
+        return StreamingResponse(
+            BytesIO(data),
+            media_type="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+            headers={"Content-Disposition": f'attachment; filename="{filename}"'},
+        )
+
     class DrilldownArchiveRequest(BaseModel):
         source_id: int
         filter_type: str  # "frequency", "type", "size", "owner"

--- a/src/dashboard/static/index.html
+++ b/src/dashboard/static/index.html
@@ -5057,13 +5057,26 @@ async function archiveDrilldown() {
 }
 
 async function downloadDrilldownXLS(event) {
-    // Use the URL to determine source_id
-    const parts = ddCurrentUrl.split('/');
-    const sid = parts[parts.length - 1].split('?')[0];
-    if (!sid) { notify('Kaynak bulunamadi', 'warning'); return; }
+    // Customer 2026-05-22: clicking XLSX Indir on a drilldown was hitting
+    // /api/export/xls/{sid} which exports the FULL report (5-sheet
+    // summary), ignoring the drilldown filter completely. Instead, use
+    // the new /api/drilldown/{type}/{sid}/export.xlsx endpoint that
+    // mirrors the JSON drilldown URL (same path + query string) so the
+    // user gets ONLY the filtered rows.
+    //
+    // ddCurrentUrl is something like '/drilldown/frequency/1?min_days=30'.
+    // Convert to '/api/drilldown/frequency/1/export.xlsx?min_days=30'.
+    if (!ddCurrentUrl || !ddCurrentUrl.startsWith('/drilldown/')) {
+        notify('Drilldown URL bulunamadi', 'warning');
+        return;
+    }
+    const qIdx = ddCurrentUrl.indexOf('?');
+    const pathPart = qIdx >= 0 ? ddCurrentUrl.slice(0, qIdx) : ddCurrentUrl;
+    const queryPart = qIdx >= 0 ? ddCurrentUrl.slice(qIdx) : '';
+    const exportUrl = '/api' + pathPart + '/export.xlsx' + queryPart;
     const btn = event?.currentTarget;
     await withButtonLoading(btn, async (signal) => {
-        await fetchAndDownload(`/api/export/xls/${sid}`, signal, `drilldown_${sid}.xlsx`);
+        await fetchAndDownload(exportUrl, signal, 'drilldown.xlsx');
     });
 }
 


### PR DESCRIPTION
## Why

Customer 2026-05-22 complaints:
- **"Rapor almak istediğimizde sonuç alamıyoruz"** — clicking XLSX Indir does nothing useful
- **"AI insight inceleme tarafında halen xlsx döküm göremiyoruz"** — drilldown XLSX broken

## Root cause

`downloadDrilldownXLS` was hitting `/api/export/xls/{sid}` which is `XLSExporter.export_full_report` — the **5-sheet summary**, totally ignoring the drilldown filter. Two failure modes:

1. **Slow**: Full report runs 5 separate GROUP BY queries on 2.89M rows → 15-90 sec → browser timeout
2. **Wrong content**: Even when the download arrived, it was the same workbook regardless of which filter (min_days, extension, owner, size bucket) the user drilled into

## Fix

**Backend** — new endpoint mirroring the 4 drilldown JSON endpoints:
```
GET /api/drilldown/{filter_type}/{source_id}/export.xlsx
   ?min_days=30&max_days=60          # for frequency
   ?extension=pdf                     # for type
   ?min_bytes=1048576&max_bytes=...   # for size
   ?owner=DOMAIN%5Cuser              # for owner
```
Reuses `_run_drilldown` (DuckDB + SQLite fallback) so the row fetch is fast. Uses the existing `XLSExporter.export_drilldown(files, title)` helper — single sheet, **actual filtered rows**.

Row cap 100k (Excel becomes unusable beyond that anyway). Future work tracked in #225 R-2: route oversize exports through `write_large_workbook` / `stream_csv` like `export_mit_naming_xlsx` does.

**Frontend** — `downloadDrilldownXLS` constructs the export URL from the active drilldown's URL:
```
/drilldown/frequency/1?min_days=30
  → /api/drilldown/frequency/1/export.xlsx?min_days=30
```

## Verification

- `python -m py_compile src/dashboard/api.py`: clean
- `node --check` on extracted inline JS: clean
- `python scripts/ci_guards.py`: 6/6 green
- `pytest -k "dashboard or report or drilldown"`: 71 passed, 5 skipped

## Customer test path

After `update.cmd`:
1. Erişim Sıklığı → 365+ gün kartına tıkla → drilldown açılır
2. **XLSX İndir** butonuna bas
3. **Beklenen**: `drilldown_frequency_<source>_<ts>.xlsx` — sadece 365+ gün eski dosyalar (filtre uygulanmış)
4. Aynı şey Dosya Türleri/Boyut Dağılımı/Sahip drilldown'ları için de geçerli


---
_Generated by [Claude Code](https://claude.ai/code/session_01TamPK8xuAaSWtmapjyuSXs)_