### PR TITLE
perf(scanner): pre-warm analyzer_cache at scan complete — first click instant

### DIFF
--- a/src/scanner/file_scanner.py
+++ b/src/scanner/file_scanner.py
@@ -1099,6 +1099,50 @@ class FileScanner:
             except Exception as e:
                 logger.warning("AI insights hesaplanamadi (scan_id=%d): %s", scan_id, e)
 
+            # Pre-warm the analyzer_cache for hot dashboard endpoints.
+            #
+            # Customer 2026-05-22: even after PR #224/#227/#228 caching the
+            # heavy reports, the **first** click after a scan completes still
+            # paid the compute cost (3-30 sec per report on a 2.89M-row
+            # scan, even with PR #230 indexes). Customer perception: "scan
+            # finished but dashboard still slow on first click". The work
+            # is identical either way — running it here, after scan
+            # completion but before the user's first click, shifts the
+            # wait into the scan timeline (which the customer already
+            # accepts as "wait") and out of the dashboard navigation
+            # timeline (which the customer expects to be snappy).
+            #
+            # Each pre-warm is best-effort: a failure is logged but does
+            # NOT block the scan from being marked complete. The dashboard
+            # endpoint will recompute on demand if any individual cache
+            # entry is missing.
+            try:
+                from src.analyzer.report_generator import ReportGenerator
+                from src.analyzer import cache as analyzer_cache
+                gen = ReportGenerator(self.db, self.config)
+                prewarm_specs = [
+                    ("frequency", lambda: gen.generate_frequency_report(source_id, None)),
+                    ("types", lambda: gen.generate_type_report(source_id)),
+                    ("sizes", lambda: gen.generate_size_report(source_id)),
+                    ("status", lambda: gen.generate_status_report(source_id)),
+                    ("full", lambda: gen.generate_full_report(source_id)),
+                ]
+                for name, fn in prewarm_specs:
+                    try:
+                        t0 = time.time()
+                        analyzer_cache.get_or_compute(self.db, name, scan_id, fn)
+                        logger.info(
+                            "Pre-warmed cache: %s (scan_id=%d, %.1f sn)",
+                            name, scan_id, time.time() - t0,
+                        )
+                    except Exception as e:  # pragma: no cover - defensive
+                        logger.warning(
+                            "Pre-warm failed for %s (scan_id=%d): %s",
+                            name, scan_id, e,
+                        )
+            except Exception as e:  # pragma: no cover - defensive
+                logger.warning("Cache pre-warm phase skipped (scan_id=%d): %s", scan_id, e)
+
         # Issue #181 Track B1 — final flush at scan completion. Always
         # runs (even on failure / cancel) so the dashboard's last
         # snapshot reflects the actual end state and scan_state moves


### PR DESCRIPTION
## Why

Customer 2026-05-22: **"her zaman ilk tıklamada yavaş"**. Even after PR #224/#227/#228 (caching) and PR #230 (composite indexes), the FIRST click on any heavy report after a scan completes still paid the compute cost (3-30 sec on 2.89M-row DB).

Customer perception: "scan bitti ama dashboard hâlâ yavaş açılıyor". This kills the "snappy navigation" feel.

## Fix

After `compute_scan_summary` + AI insights complete, scanner now pre-warms `analyzer_cache` for the 5 hot report endpoints:

```python
for name, fn in [
    ("frequency", lambda: gen.generate_frequency_report(...)),
    ("types",     lambda: gen.generate_type_report(...)),
    ("sizes",     lambda: gen.generate_size_report(...)),
    ("status",    lambda: gen.generate_status_report(...)),
    ("full",      lambda: gen.generate_full_report(...)),
]:
    analyzer_cache.get_or_compute(self.db, name, scan_id, fn)
```

## Before / after

| | Before | After |
|---|---|---|
| Scan finishes | Banner clears | Pre-warm runs (3-30 sec) — appears in "Tam rapor: e" badge |
| First dashboard click | **3-30 sec wait** | **Instant** (cache hit, sub-ms) |
| Second click | Instant | Instant |
| Total compute work | Same | Same |

UX win at zero compute cost. The wait is now inside the "scan is finishing" timeline (which the customer already accepts as wait) instead of the navigation timeline (which the customer expects to be snappy).

## Risk

Low. Each pre-warm is best-effort — wrapped in try/except, so a single failure (e.g. cache write error) does NOT block scan completion. The dashboard endpoint will recompute on demand if any cache entry is missing.

## Verification

- `python -m py_compile src/scanner/file_scanner.py`: clean
- `pytest -k "scan or scanner or cache or analyzer"`: 80 passed, 6 skipped
- `python scripts/ci_guards.py`: 6/6 green

## Customer test path

After `update.cmd` + fresh scan:
1. Wait for scan to fully complete (banner clears + "Tam rapor: e" badge clears)
2. Navigate to Treemap, Erişim Sıklığı, Dosya Türleri, Adlandırma Uyumu
3. Each page should open **instantly** on the very first click — no 3-30 sec wait


---
_Generated by [Claude Code](https://claude.ai/code/session_01TamPK8xuAaSWtmapjyuSXs)_