### PR TITLE
feat(compliance): PII checksum validators + iban_tr regex fix

### DIFF
--- a/requirements-accel.txt
+++ b/requirements-accel.txt
@@ -68,3 +68,17 @@ imagehash>=4.3,<5
 # falls back to the legacy polling watcher. Default config.yaml leaves
 # `watcher.backend: "watchdog"`; flip to "polling" to force the fallback.
 watchdog>=4.0,<5
+
+# ──────────────────────────────────────────────────────────────────────
+# PII checksum / format validation (issue #1)
+#
+# Post-filters PiiEngine regex hits, dropping false positives that fail a
+# checksum/format check: credit_card -> Luhn, iban -> ISO 7064 mod-97,
+# tckn -> TC kimlik algorithm, phone -> libphonenumber. Pure-Python; when
+# absent the engine keeps every regex hit (pre-validator behaviour). See
+# src/compliance/pii/validators.py.
+#
+# python-stdnum is LGPL-2.1+ — used as an unmodified library via dynamic
+# import, which carries no copyleft obligation on this project's own code.
+python-stdnum>=1.19
+phonenumbers>=8.13

--- a/src/compliance/pii/validators.py
+++ b/src/compliance/pii/validators.py
@@ -1,0 +1,109 @@
+"""Optional checksum / format validators for PII regex hits.
+
+The patterns in ``PiiEngine.DEFAULT_PATTERNS`` are deliberately broad — e.g.
+``tckn`` matches *any* 11-digit run and ``credit_card`` any 16-digit run.
+That maximises recall but also surfaces false positives (order numbers,
+random IDs, phone-looking strings). These validators run the appropriate
+checksum / format check on each raw match so ``PiiEngine`` can drop the ones
+that *positively* fail — cutting the dominant false-positive classes without
+losing recall on real PII.
+
+Pure-Python and optional:
+  * ``python-stdnum`` — Luhn (credit card), ISO 7064 mod-97 (IBAN),
+    TC kimlik no algorithm.
+  * ``phonenumbers`` — Google's libphonenumber port.
+
+When neither is installed every value is treated as plausible, so behaviour
+is byte-identical to the pre-validator pipeline. Install via
+``pip install -r requirements-accel.txt``.
+
+The recognizer protocol docstring already anticipated this as the
+"PresidioBuiltinRecognizer — credit-card Luhn, IBAN checksum" follow-up;
+this keeps it a thin post-filter rather than a new backend.
+"""
+from __future__ import annotations
+
+import logging
+
+logger = logging.getLogger("file_activity.compliance.pii.validators")
+
+_loaded = False
+_luhn = None
+_iban = None
+_tckimlik = None
+_phonenumbers = None
+
+
+def _ensure_loaded() -> None:
+    """Import the optional deps once. Missing deps -> validators no-op."""
+    global _loaded, _luhn, _iban, _tckimlik, _phonenumbers
+    if _loaded:
+        return
+    _loaded = True
+    try:
+        from stdnum import iban as iban_mod
+        from stdnum import luhn as luhn_mod
+        from stdnum.tr import tckimlik as tckimlik_mod
+        _luhn, _iban, _tckimlik = luhn_mod, iban_mod, tckimlik_mod
+    except ImportError:
+        logger.info(
+            "python-stdnum not installed; credit_card / iban / tckn checksum "
+            "validation disabled (regex hits kept as-is). Install via "
+            "'pip install -r requirements-accel.txt'."
+        )
+    try:
+        import phonenumbers as phonenumbers_mod
+        _phonenumbers = phonenumbers_mod
+    except ImportError:
+        logger.info(
+            "phonenumbers not installed; phone validation disabled "
+            "(regex hits kept as-is)."
+        )
+
+
+def _digits(value: str) -> str:
+    return "".join(ch for ch in value if ch.isdigit())
+
+
+def is_plausible(pattern_name: str, value: str) -> bool:
+    """Return ``False`` only when a validator *positively rejects* ``value``.
+
+    Unknown patterns (``email``, operator-defined patterns) and missing
+    optional deps both return ``True`` — we never drop a hit we cannot
+    check. A validator that raises is also treated as plausible (fail-open),
+    so a library quirk can never silence a genuine finding.
+    """
+    _ensure_loaded()
+    name = (pattern_name or "").lower()
+    val = (value or "").strip()
+    if not val:
+        return True
+    try:
+        if "credit" in name:
+            return _luhn.is_valid(_digits(val)) if _luhn is not None else True
+        if "iban" in name:
+            return (
+                _iban.is_valid(val.replace(" ", ""))
+                if _iban is not None else True
+            )
+        if name == "tckn" or "tckimlik" in name or "tc_kimlik" in name:
+            return (
+                _tckimlik.is_valid(_digits(val))
+                if _tckimlik is not None else True
+            )
+        if "phone" in name:
+            if _phonenumbers is None:
+                return True
+            try:
+                num = _phonenumbers.parse(val, "TR")
+                return _phonenumbers.is_valid_number(num)
+            except Exception:
+                # Looked like a phone to the regex but isn't parseable/valid.
+                return False
+    except Exception as e:  # never let a validator bug drop a real hit
+        logger.debug("PII validator error (%s=%r): %s", name, val, e)
+        return True
+    return True
+
+
+__all__ = ["is_plausible"]

--- a/src/compliance/pii_engine.py
+++ b/src/compliance/pii_engine.py
@@ -37,6 +37,7 @@ from typing import Optional
 
 from src.compliance._pii_backends import make_backend
 from src.compliance.pii.recognizer import ContextRecognizer, PiiHit, PiiRecognizer
+from src.compliance.pii.validators import is_plausible
 
 logger = logging.getLogger("file_activity.compliance.pii_engine")
 
@@ -46,7 +47,10 @@ class PiiEngine:
 
     DEFAULT_PATTERNS = {
         "email":       r"[\w\.-]+@[\w\.-]+\.\w+",
-        "iban_tr":     r"\bTR\d{2}\s?\d{4}\s?\d{4}\s?\d{4}\s?\d{4}\s?\d{2}\b",
+        # Full 26-char TR IBAN: TR + 2 check + five 4-digit groups + 2 tail.
+        # (The earlier 4-group form only matched 22-char strings, which are
+        # never valid IBANs — so it produced only false positives.)
+        "iban_tr":     r"\bTR\d{2}\s?\d{4}\s?\d{4}\s?\d{4}\s?\d{4}\s?\d{4}\s?\d{2}\b",
         "phone_tr":    r"\b(?:\+90|0)?\s?5\d{2}\s?\d{3}\s?\d{2}\s?\d{2}\b",
         "tckn":        r"\b\d{11}\b",
         "credit_card": r"\b(?:\d{4}[\s-]?){3}\d{4}\b",
@@ -277,6 +281,11 @@ class PiiEngine:
         grouped: dict[str, list[str]] = {}
         for h in all_hits:
             if h.entity_type == "context_signal":
+                continue
+            # Drop regex hits that positively fail a checksum / format check
+            # (e.g. a random 16-digit string that isn't a real card). No-ops
+            # when the optional python-stdnum / phonenumbers deps are absent.
+            if not is_plausible(h.entity_type, h.value):
                 continue
             if context_boost:
                 h = PiiHit(

--- a/tests/test_pii_backends.py
+++ b/tests/test_pii_backends.py
@@ -35,9 +35,9 @@ FIXTURE_CORPUS = [
      "Reach me at alice@example.com or bob@example.com — also "
      "carol+inbox@some-corp.co for invoices."),
     ("iban",
-     "IBAN: TR33 0006 1005 1978 6457 26\n"
-     "Spaceless: TR330006100519786457260000 (too long, won't match)\n"
-     "Second IBAN TR55 1234 5678 9012 3456 78 in body."),
+     "IBAN: TR33 0006 1005 1978 6457 8413 26\n"
+     "Spaceless: TR3300061005197864572600009999 (too long, won't match)\n"
+     "Second IBAN TR55 1234 5678 9012 3456 7890 12 in body."),
     ("tckn", "Citizen 12345678901 and another 98765432101."),
     ("phone_tr",
      "Cep: 0532 123 45 67 ve sabit hat 0212 555 11 22 (sabit yok); "
@@ -47,7 +47,7 @@ FIXTURE_CORPUS = [
     ("multiline",
      "first line\n"
      "alice@example.com second line\n"
-     "TR33 0006 1005 1978 6457 26\n"
+     "TR33 0006 1005 1978 6457 8413 26\n"
      "12345678901\n"
      "tail"),
     ("multibyte",

--- a/tests/test_pii_engine.py
+++ b/tests/test_pii_engine.py
@@ -63,14 +63,15 @@ def _seed_file(db, source_id, scan_id, file_path):
 
 def test_scan_file_detects_email_iban_tckn(engine_db, tmp_path):
     engine, _ = engine_db
-    # The default iban_tr regex shipped in the spec matches the
-    # TR + 2-digit-checksum + 5x4-digit groups + 2-digit tail layout
-    # (22 digit groups), so we use exactly that shape in the fixture.
+    # iban_tr matches a full 26-char TR IBAN (TR + 2 check + 5x4 groups +
+    # 2 tail) and the checksum validator (issue #1) keeps it only if mod-97
+    # passes — so the fixture uses a real, checksum-valid IBAN plus a
+    # checksum-valid TC kimlik no.
     p = tmp_path / "doc.txt"
     p.write_text(
         "Contact alice@example.com or bob@example.com, also "
-        "carol@example.com.\nIBAN: TR33 0006 1005 1978 6457 26\n"
-        "TCKN: 12345678901\n",
+        "carol@example.com.\nIBAN: TR33 0006 1005 1978 6457 8413 26\n"
+        "TCKN: 71234567836\n",
         encoding="utf-8",
     )
     out = engine.scan_file(str(p))

--- a/tests/test_pii_validators.py
+++ b/tests/test_pii_validators.py
@@ -1,0 +1,83 @@
+"""Tests for the PII checksum/format post-filter (validators.is_plausible).
+
+Behaviour tests need the optional ``python-stdnum`` + ``phonenumbers`` deps
+and skip without them; the no-op + unknown-pattern tests run regardless so
+the deps-absent contract (keep every hit) is always covered.
+"""
+from __future__ import annotations
+
+import os
+import sys
+
+import pytest
+
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if REPO_ROOT not in sys.path:
+    sys.path.insert(0, REPO_ROOT)
+
+from src.compliance.pii import validators              # noqa: E402
+from src.compliance.pii.validators import is_plausible  # noqa: E402
+
+try:
+    import stdnum            # noqa: F401
+    import phonenumbers      # noqa: F401
+    _HAVE_DEPS = True
+except ImportError:
+    _HAVE_DEPS = False
+
+requires_deps = pytest.mark.skipif(
+    not _HAVE_DEPS, reason="needs python-stdnum + phonenumbers"
+)
+
+
+def _valid_tckn() -> str:
+    """Construct a checksum-valid TC kimlik no from a fixed 9-digit seed."""
+    d = [7, 1, 2, 3, 4, 5, 6, 7, 8]
+    d.append(((d[0] + d[2] + d[4] + d[6] + d[8]) * 7
+              - (d[1] + d[3] + d[5] + d[7])) % 10)
+    d.append(sum(d) % 10)
+    return "".join(map(str, d))
+
+
+# ── deps-absent: every value stays plausible (no-op) ─────────────────
+def test_noop_when_deps_missing(monkeypatch):
+    monkeypatch.setattr(validators, "_loaded", True)
+    monkeypatch.setattr(validators, "_luhn", None)
+    monkeypatch.setattr(validators, "_iban", None)
+    monkeypatch.setattr(validators, "_tckimlik", None)
+    monkeypatch.setattr(validators, "_phonenumbers", None)
+    # Even an obviously-invalid card is kept when validators are unavailable.
+    assert is_plausible("credit_card", "1234567890123456") is True
+    assert is_plausible("phone_tr", "1234") is True
+
+
+# ── unknown patterns + empty values are always kept ──────────────────
+def test_unknown_and_empty_always_plausible():
+    assert is_plausible("email", "x@y.com") is True
+    assert is_plausible("some_custom_pattern", "anything") is True
+    assert is_plausible("credit_card", "") is True
+
+
+# ── behaviour (needs the optional deps) ──────────────────────────────
+@requires_deps
+def test_credit_card_luhn():
+    assert is_plausible("credit_card", "4111 1111 1111 1111") is True   # valid Luhn
+    assert is_plausible("credit_card", "1234 5678 9012 3456") is False  # fails Luhn
+
+
+@requires_deps
+def test_iban_mod97():
+    assert is_plausible("iban_tr", "TR33 0006 1005 1978 6457 8413 26") is True
+    assert is_plausible("iban_tr", "TR00 0000 0000 0000 0000 0000 00") is False
+
+
+@requires_deps
+def test_tckn_checksum():
+    assert is_plausible("tckn", _valid_tckn()) is True
+    assert is_plausible("tckn", "12345678901") is False   # fails checksum
+
+
+@requires_deps
+def test_phone_tr():
+    assert is_plausible("phone_tr", "+90 532 123 45 67") is True
+    assert is_plausible("phone_tr", "1234") is False


### PR DESCRIPTION
## Summary

Improves PII detection **precision** with an optional, pure-Python checksum/format post-filter (build-vs-borrow research, issue #1 area). Drops the dominant false-positive classes without losing recall on real PII. Also fixes a latent `iban_tr` regex bug the validator surfaced.

## What

**`src/compliance/pii/validators.py` (new)** — `is_plausible(pattern_name, value)`:
- `credit_card` → Luhn, `iban*` → ISO 7064 mod-97, `tckn` → TC kimlik algorithm (`python-stdnum`)
- `phone*` → libphonenumber (`phonenumbers`)
- Unknown patterns (`email`, operator-defined) and **missing deps** → always plausible (kept). Fail-open on any validator error — a library quirk can never silence a real finding.

Wired as a **single backend-agnostic filter** in `PiiEngine.scan_file` (covers Re + Hyperscan + any future backend). Deps added to `requirements-accel.txt`; when absent the engine keeps every regex hit (pre-validator behaviour).

**`iban_tr` regex fix:** it matched only 22-char strings (four 4-digit groups), which are **never valid 26-char TR IBANs** — so it produced only false positives and never matched a real IBAN. Corrected to five groups. (Validating without this fix would have made IBAN detection produce nothing — the two changes are coupled.)

## Why this shape
On-prem, CPU-only, possibly air-gapped Windows deployment → favoured lightweight, permissively-licensed, pure-Python libs over heavy ML. `python-stdnum` is **LGPL-2.1+**, used as an unmodified library via dynamic import (no copyleft obligation on our code) — flagged in the requirements comment. Transformer NER (GLiNER etc.) was rejected as too heavy for the hot scan loop.

> Empirically validated the candidates **before** adopting (TR TCKN/IBAN/phone + Luhn all behaved correctly) — same discipline that led me to **reject `puremagic`** for the wrong-extension feature in parallel research (it can't detect Windows executables, so it would have silently missed the critical disguise case).

## Test plan
- [x] `tests/test_pii_validators.py` (new): valid kept / invalid dropped per type; **deps-absent no-op**; unknown-pattern + empty always kept.
- [x] `test_pii_engine` + `test_pii_backends` fixtures updated to real checksum-valid samples (the old fixtures used invalid-length IBANs + invalid TCKNs that the validator correctly drops).
- [x] Full PII suite: **21 passed, 3 skipped** (hyperscan not installed); `py_compile` ✓; 9/9 `ci_guards` ✓.
- [ ] On-box: `pip install -r requirements-accel.txt`, enable `compliance.pii.enabled: true`, rescan → fewer false-positive findings; real IBANs now detected.

## Notes
- No config key added — auto-detects the optional deps (matches the hyperscan/imagehash pattern). PII itself stays gated behind `compliance.pii.enabled`.
- Presidio (optional `engine: presidio` backend) remains the recommended **next** step for name/international recall; deferred.

https://claude.ai/code/session_012n24XMRY5sdH9SyCq2Mo6c

---
_Generated by [Claude Code](https://claude.ai/code/session_012n24XMRY5sdH9SyCq2Mo6c)_