### PR TITLE
feat(config): enable orphaned-SID report by default (domain fleets)

### DIFF
--- a/scripts/config_migrations.yaml
+++ b/scripts/config_migrations.yaml
@@ -52,3 +52,15 @@ migrations:
     new_default: "watchdog"
     reason: "PR #14 — watchdog backend supersedes polling for local NTFS"
     pr: "#14"
+
+  # Operator decision 2026-05-24 — enable the orphaned-SID report by default.
+  # The fleet is domain-joined, so SIDs resolve via Windows LookupAccountSid
+  # (pywin32) WITHOUT the optional active_directory LDAP config; the report is
+  # read-only + cached, so default-on is low cost. The shipped config.yaml
+  # already ships ``true`` (so this is a no-op there) — the rule only flips
+  # preserved customer configs still carrying the old ``false``.
+  - path: "security.orphan_sid.enabled"
+    old_default: false
+    new_default: true
+    reason: "operator decision — orphaned-SID report on by default for domain-joined fleets (resolves via Windows LookupAccountSid; no LDAP config needed)"
+    pr: "#56"

--- a/tests/test_config_migrator.py
+++ b/tests/test_config_migrator.py
@@ -349,6 +349,24 @@ def test_shipped_rules_file_parses():
         assert "." in r["path"], f"rule path must be dotted: {r['path']!r}"
 
 
+def test_orphan_sid_rule_flips_preserved_false(tmp_path):
+    """2026-05-24 operator rule: a preserved config with the orphaned-SID
+    report disabled is flipped on (domain-joined fleets), siblings intact."""
+    cfg = _write(tmp_path / "config.yaml", """\
+security:
+  orphan_sid:
+    enabled: false
+    cache_ttl_minutes: 1440
+""")
+    rules = migrate_config.load_rules()
+    results = migrate_config.migrate(cfg, rules)
+    by_path = {r.path: r for r in results}
+    assert by_path["security.orphan_sid.enabled"].action == "applied"
+    parsed = yaml.safe_load(cfg.read_text(encoding="utf-8"))
+    assert parsed["security"]["orphan_sid"]["enabled"] is True
+    assert parsed["security"]["orphan_sid"]["cache_ttl_minutes"] == 1440
+
+
 def test_shipped_rules_applied_against_shipped_config_is_noop(tmp_path):
     """The shipped config.yaml is the post-migration state by definition.
     Running the migrator against a copy of the shipped config must


### PR DESCRIPTION
## Summary

Makes the **orphaned-SID report on by default** for the (domain-joined) fleet, per operator request — without anyone hand-editing the preserved `config.yaml`.

## How

Adds one rule to `scripts/config_migrations.yaml`:
```yaml
- path: "security.orphan_sid.enabled"
  old_default: false
  new_default: true
```
The migrator (`scripts/migrate_config.py`, already wired into `setup-source.ps1`) runs on `update.cmd` and flips `security.orphan_sid.enabled` to `true` **only** where the customer's value is still `false`, backing up `config.yaml` first and leaving any other (operator-chosen) value alone.

## Why this is safe / coherent
- **Shipped `config.yaml` already ships `true`** → the rule is a **no-op** against the shipped config (the existing `test_shipped_rules_applied_against_shipped_config_is_noop` still passes). It only touches preserved customer configs carrying the old `false`.
- **No LDAP needed:** on domain-joined Windows hosts, SIDs resolve via `LookupAccountSid` (pywin32). The optional `active_directory.enabled` (LDAP) is only for richer email/displayName enrichment, not for the report itself.
- The report is read-only + cached (`cache_ttl_minutes: 1440`), so default-on is low cost.

## Test plan
- [x] `test_orphan_sid_rule_flips_preserved_false` (new): preserved `false` → flipped `true`, sibling keys intact.
- [x] Full migrator suite: **17 passed**; `py_compile` ✓; 9/9 `ci_guards` ✓.
- [x] Confirmed shipped `config.yaml` has `orphan_sid.enabled: true` (noop guarantee).
- [ ] On-box after merge: `update.cmd` → migrator logs the flip → SID page no longer shows the "disabled" banner.

## Operator note
After merge + `update.cmd`, the SID page activates. For it to show **data** (orphaned SIDs) it still needs scan data with owners (`scanner.read_owner: true`, already the default) — so run a scan if owners aren't populated yet. Richer name/email resolution is the separate, optional `active_directory` LDAP config.

https://claude.ai/code/session_012n24XMRY5sdH9SyCq2Mo6c

---
_Generated by [Claude Code](https://claude.ai/code/session_012n24XMRY5sdH9SyCq2Mo6c)_