### PR TITLE
feat(search): embedded FTS5 trigram file search across scanned_files

### DIFF
--- a/src/dashboard/api.py
+++ b/src/dashboard/api.py
@@ -15,11 +15,17 @@ import threading
 import uuid
 from datetime import datetime, timedelta
 
-from fastapi import FastAPI, HTTPException, Query, Request
+from fastapi import Depends, FastAPI, HTTPException, Query, Request
 from fastapi.staticfiles import StaticFiles
 from fastapi.responses import HTMLResponse, FileResponse, JSONResponse
 from pydantic import BaseModel, Field, field_validator
 from typing import Optional, List
+
+# PaginationParams is used as a FastAPI ``Depends()`` default in route
+# signatures, so it must be importable at module scope (the decorator
+# evaluates the signature when create_app runs). cached_report_endpoint
+# stays a lazy import inside each handler per the existing convention.
+from src.dashboard._endpoint_helpers import PaginationParams
 
 # ── Arka plan export kuyrugu ──
 _export_jobs = {}  # job_id -> {status, progress, file_path, error, created_at, ...}
@@ -1590,6 +1596,35 @@ def create_app(db, config, analytics=None, ad_lookup=None, email_notifier=None,
     def archive_search(q: str, extension: Optional[str] = None,
                               page: int = Query(1, ge=1, le=10000)):
         return db.search_archived_files(q, extension=extension, page=page)
+
+    @app.get("/api/files/search")
+    def search_files(q: str, source_id: Optional[int] = None,
+                            p: PaginationParams = Depends()):
+        """Embedded full-text substring search over scanned files.
+
+        Path / file-name / owner substring search backed by the
+        ``scanned_files_fts`` trigram index (issue: embedded SEARCH). Plain
+        ``def`` so FastAPI dispatches the sync DB work to the thread pool
+        (Rule 5). ``db.search_files`` reads via ``get_read_cursor()``
+        internally (Rule 6) so this never contends with a running scan.
+
+        ``source_id`` is optional: when given, results are scoped to that
+        source's latest scan; when omitted, the whole index is searched
+        (handy for "where is this file across all shares?"). Pagination is
+        the canonical ``PaginationParams`` (Rule 2).
+        """
+        scan_id = None
+        if source_id is not None:
+            src = _get_source(db, source_id)
+            scan_id = db.get_latest_scan_id(src.id, include_running=True)
+            if not scan_id:
+                # Source exists but has no scan yet — empty page, not 400,
+                # so the search box renders "0 sonuc" cleanly.
+                return p.response(total=0, items=[])
+        result = db.search_files(
+            q, scan_id=scan_id, limit=p.page_size, offset=p.offset,
+        )
+        return p.response(total=result["total"], items=result["files"])
 
     @app.get("/api/archive/stats")
     def archive_stats():

--- a/src/dashboard/static/index.html
+++ b/src/dashboard/static/index.html
@@ -620,6 +620,7 @@ body.sidebar-open { overflow: hidden; }
         <div class="nav-label">Genel <span class="chev">&#9660;</span></div>
         <div class="nav-item active" onclick="showPage('overview')" title="Genel Bakis"><span class="icon">📈</span> <span>Genel Bakis</span></div>
         <div class="nav-item" onclick="showPage('sources')" title="Kaynaklar"><span class="icon">📁</span> <span>Kaynaklar</span></div>
+        <div class="nav-item" onclick="showPage('search')" title="Dosya Arama"><span class="icon">🔎</span> <span>Dosya Arama</span></div>
     </div>
     <div class="nav-section" data-group="Analiz">
         <div class="nav-label">Analiz <span class="chev">&#9660;</span></div>
@@ -788,6 +789,28 @@ body.sidebar-open { overflow: hidden; }
             <button class="btn btn-outline" onclick="optimizeDb()" style="font-size:12px;border-color:var(--info);color:var(--info)">Optimize Et</button>
         </div>
     </div>
+</div>
+
+<!-- ============ FILE SEARCH (FTS5 trigram) ============ -->
+<div class="page" id="page-search">
+    <div class="page-header">
+        <div><h2>Dosya Arama</h2><div class="desc">Yol / dosya adi / sahip icinde hizli alt-dize arama (FTS5 trigram)</div></div>
+    </div>
+    <div class="form-row" style="margin-bottom:16px">
+        <div class="form-group" style="flex:2">
+            <label>Arama (en az 3 karakter)</label>
+            <input id="file-search-q" placeholder="rapor, .xlsx, CORP\\ahmet, \\Finans\\ ..." onkeyup="if(event.key==='Enter')runFileSearch()">
+        </div>
+        <div class="form-group">
+            <label>Kaynak</label>
+            <select id="file-search-source"></select>
+        </div>
+        <div class="form-group" style="flex:0 0 auto;align-self:flex-end">
+            <button class="btn btn-primary" onclick="runFileSearch()">Ara</button>
+        </div>
+    </div>
+    <div id="file-search-meta" style="font-size:12px;color:var(--text-secondary);margin-bottom:8px"></div>
+    <div class="table-wrap"><table id="file-search-table"></table></div>
 </div>
 
 <!-- ============ TREEMAP ============ -->
@@ -2728,7 +2751,7 @@ function showPage(name) {
     // Find and activate nav item
     document.querySelectorAll('.nav-item').forEach(n => { if (n.getAttribute('onclick')?.includes(name)) n.classList.add('active'); });
     // Auto-load data
-    const loaders = { overview: loadOverview, sources: loadSources, frequency: loadFrequency, types: loadTypes, sizes: loadSizes, users: loadUsers, anomalies: loadAnomalies, archive: loadArchive, 'archive-history': loadArchiveHistory, duplicates: loadDuplicates, growth: loadGrowth, naming: loadNaming, policies: loadPolicies, schedules: loadSchedules, treemap: loadTreemap, insights: loadInsights, sqlquery: sqlqInit, 'legal-holds': loadLegalHolds, standards: loadStandards, 'orphan-sids': loadOrphanSids, ransomware: loadRansomwareAlerts, acl: loadAclAnalyzer, 'extension-anomalies': loadExtensionAnomalies, 'image-duplicates': loadImageDuplicates, pii: loadPii, retention: loadRetention, syslog: loadSyslog, mcp: loadMcp, backups: loadBackups, operations: loadOperations, approvals: loadApprovalsAll, chargeback: loadChargeback, quarantine: loadQuarantine, forecast: loadForecast };
+    const loaders = { overview: loadOverview, sources: loadSources, search: loadFileSearch, frequency: loadFrequency, types: loadTypes, sizes: loadSizes, users: loadUsers, anomalies: loadAnomalies, archive: loadArchive, 'archive-history': loadArchiveHistory, duplicates: loadDuplicates, growth: loadGrowth, naming: loadNaming, policies: loadPolicies, schedules: loadSchedules, treemap: loadTreemap, insights: loadInsights, sqlquery: sqlqInit, 'legal-holds': loadLegalHolds, standards: loadStandards, 'orphan-sids': loadOrphanSids, ransomware: loadRansomwareAlerts, acl: loadAclAnalyzer, 'extension-anomalies': loadExtensionAnomalies, 'image-duplicates': loadImageDuplicates, pii: loadPii, retention: loadRetention, syslog: loadSyslog, mcp: loadMcp, backups: loadBackups, operations: loadOperations, approvals: loadApprovalsAll, chargeback: loadChargeback, quarantine: loadQuarantine, forecast: loadForecast };
     // Issue #79: route through loadWithProgress so slow pages get a top
     // progress bar, ETA from p50 history, and a retry path on failure.
     if (loaders[name]) loadWithProgress(name, loaders[name]).catch(() => { /* widget surfaces error */ });
@@ -9512,6 +9535,71 @@ function _fmtSize(bytes) {
     if (bytes < 1048576) return (bytes / 1024).toFixed(1) + ' KB';
     if (bytes < 1073741824) return (bytes / 1048576).toFixed(1) + ' MB';
     return (bytes / 1073741824).toFixed(1) + ' GB';
+}
+
+// ═══════════════════════════════════════════════════
+// FILE SEARCH (FTS5 trigram) — page-search
+//
+// Substring search over file_path / file_name / owner via the
+// /api/files/search endpoint (backed by scanned_files_fts). Renders into
+// #file-search-table exclusively through _setHtmlSafe (D-CHAIN / Rule 7).
+// ═══════════════════════════════════════════════════
+function loadFileSearch() {
+    // Reuse the standard source selector; an empty option = "all sources".
+    populateSourceSelect('file-search-source');
+    const sel = document.getElementById('file-search-source');
+    // Default to "all sources" so the box works before picking a source.
+    if (sel) sel.value = '';
+    _setHtmlSafe('file-search-table', '');
+    _setHtmlSafe('file-search-meta', 'Aramak icin en az 3 karakter girin ve Enter\'a basin.');
+}
+
+async function runFileSearch() {
+    const qEl = document.getElementById('file-search-q');
+    const srcEl = document.getElementById('file-search-source');
+    const q = qEl ? qEl.value.trim() : '';
+    const sourceId = srcEl ? srcEl.value : '';
+    if (q.length < 3) {
+        _setHtmlSafe('file-search-meta', 'En az 3 karakter gerekli (trigram arama).');
+        _setHtmlSafe('file-search-table', '');
+        return;
+    }
+    _setHtmlSafe('file-search-meta', 'Araniyor...');
+    let url = '/files/search?q=' + encodeURIComponent(q) + '&page_size=100';
+    if (sourceId) url += '&source_id=' + encodeURIComponent(sourceId);
+    let data;
+    try {
+        data = await api(url);
+    } catch (e) {
+        _setHtmlSafe('file-search-meta', 'Arama hatasi: ' + escapeHtml(e.message || String(e)));
+        _setHtmlSafe('file-search-table', '');
+        return;
+    }
+    const items = (data && data.items) || [];
+    const total = (data && data.total) || 0;
+    if (!items.length) {
+        _setHtmlSafe('file-search-meta', '"' + escapeHtml(q) + '" icin sonuc bulunamadi.');
+        _setHtmlSafe('file-search-table', '<div class="empty-state"><div class="icon">🔎</div><h3>Sonuc Yok</h3><p>Farkli bir terim deneyin. Tarama tamamlandiktan sonra arama indeksi guncellenir.</p></div>');
+        return;
+    }
+    const shown = items.length;
+    _setHtmlSafe('file-search-meta',
+        'Toplam ' + formatNum(total) + ' eslesme' +
+        (total > shown ? (' (ilk ' + shown + ' gosteriliyor)') : ''));
+    const rows = items.map(f => {
+        const folderAttr = escapeHtml(((f.directory || _extractFolder(f.file_path)) || '').replace(/\\/g, '\\\\\\\\'));
+        return '<tr>' +
+            '<td style="word-break:break-all">' + escapeHtml(f.file_name || '') + '</td>' +
+            '<td style="word-break:break-all;color:var(--text-secondary);font-size:12px">' + escapeHtml(f.file_path || '') + '</td>' +
+            '<td style="white-space:nowrap">' + escapeHtml(f.owner || 'Bilinmiyor') + '</td>' +
+            '<td style="white-space:nowrap;text-align:right">' + _fmtSize(f.file_size || 0) + '</td>' +
+            '<td style="white-space:nowrap"><button class="btn btn-sm btn-outline" onclick="openFolder(\'' + folderAttr + '\')">Konuma Git</button></td>' +
+            '</tr>';
+    }).join('');
+    const html =
+        '<thead><tr><th>Dosya Adi</th><th>Yol</th><th>Sahip</th><th style="text-align:right">Boyut</th><th></th></tr></thead>' +
+        '<tbody>' + rows + '</tbody>';
+    _setHtmlSafe('file-search-table', html);
 }
 
 

--- a/src/scanner/file_scanner.py
+++ b/src/scanner/file_scanner.py
@@ -1143,6 +1143,22 @@ class FileScanner:
             except Exception as e:  # pragma: no cover - defensive
                 logger.warning("Cache pre-warm phase skipped (scan_id=%d): %s", scan_id, e)
 
+            # Rebuild the FTS5 trigram search index now that scanned_files
+            # is fully populated + size-enriched. Lives alongside the cache
+            # pre-warm for the same reason: do the one-shot index build
+            # inside the scan timeline (which the operator already accepts
+            # as "wait") so the search box is instant on first use. The
+            # scanner does NOT keep the index live via per-row triggers —
+            # that would tax every one of the millions of bulk inserts —
+            # so this rebuild is what makes a fresh scan searchable.
+            # Best-effort: rebuild_fts swallows + logs its own errors.
+            try:
+                self.db.rebuild_fts(scan_id)
+            except Exception as e:  # pragma: no cover - defensive
+                logger.warning(
+                    "FTS rebuild skipped (scan_id=%d): %s", scan_id, e,
+                )
+
         # Issue #181 Track B1 — final flush at scan completion. Always
         # runs (even on failure / cancel) so the dashboard's last
         # snapshot reflects the actual end state and scan_state moves

--- a/src/storage/database.py
+++ b/src/storage/database.py
@@ -1232,6 +1232,42 @@ class Database:
             "ON image_hashes(dhash)"
         )
 
+        # ──────────────────────────────────────────────
+        # Embedded SEARCH (FTS5 + trigram) over scanned_files.
+        #
+        # Fast path/name/owner *substring* search across multi-million-row
+        # scans, in-process, with zero new infrastructure (SQLite ships
+        # with the FTS5 + trigram tokenizer in Python 3.11's bundled
+        # sqlite3). The trigram tokenizer is what makes ``LIKE '%foo%'``-
+        # style substring matching index-backed instead of a full table
+        # scan — a plain unicode61 tokenizer would only match whole tokens,
+        # not the "any 3+ char fragment of the path" the operator wants.
+        #
+        # External-content table (content='scanned_files',
+        # content_rowid='id'): the FTS index stores only the tokens, not a
+        # second copy of the text columns, so the on-disk cost is far
+        # smaller than a standalone contentless+stored table. ``scanned_files``
+        # has a stable INTEGER PRIMARY KEY (``id``) which is exactly what
+        # content_rowid needs.
+        #
+        # IMPORTANT — no per-row INSERT/UPDATE/DELETE sync triggers here
+        # (unlike ``archived_files_fts`` above). The scanner bulk-inserts
+        # millions of rows per scan; firing an FTS trigger per row would
+        # multiply the insert cost and re-introduce write-lock pressure the
+        # stabilization week worked to remove. Instead the index is
+        # (re)built in one shot at scan-complete via ``rebuild_fts()`` —
+        # see ``FileScanner._finalize`` cache pre-warm block.
+        cur.execute("""
+            CREATE VIRTUAL TABLE IF NOT EXISTS scanned_files_fts USING fts5(
+                file_path,
+                file_name,
+                owner,
+                content='scanned_files',
+                content_rowid='id',
+                tokenize='trigram'
+            )
+        """)
+
         conn.commit()
         cur.close()
         logger.info("Veritabani tablolari olusturuldu")
@@ -1884,6 +1920,125 @@ class Database:
             rows = cur.fetchall()
 
         return {"total": total, "page": page, "page_size": page_size, "results": rows}
+
+    # ──────────────────────────────────────────────
+    # Embedded SEARCH (FTS5 + trigram) over scanned_files
+    #
+    # See the ``scanned_files_fts`` CREATE in ``_create_tables`` for the
+    # design rationale (external-content trigram index, rebuilt in one
+    # shot at scan-complete rather than via per-row triggers).
+    # ──────────────────────────────────────────────
+
+    # Trigram tokenizer indexes overlapping 3-character windows, so any
+    # MATCH term must be at least 3 characters or FTS5 returns nothing.
+    # We surface that as an explicit, friendly empty result instead of a
+    # confusing "no rows" with a 1-2 char query.
+    _FTS_MIN_QUERY_LEN = 3
+
+    @staticmethod
+    def _fts_phrase(query: str) -> str:
+        """Wrap raw user input as a single FTS5 phrase token.
+
+        The whole query becomes one double-quoted phrase so path search
+        is *substring* search (trigram), not a boolean expression. Any
+        embedded double-quote is escaped by doubling it (FTS5 string
+        literal escaping), which also neutralises FTS5 operator syntax
+        (NEAR/AND/OR/``*``/``:``) that would otherwise let a query string
+        change the query semantics.
+        """
+        return '"' + query.replace('"', '""') + '"'
+
+    def rebuild_fts(self, scan_id: Optional[int] = None) -> None:
+        """(Re)build the ``scanned_files_fts`` trigram index in one shot.
+
+        Called at scan-complete (alongside the #232 cache pre-warm) so the
+        search box reflects the freshly-scanned data without paying a
+        per-row trigger cost during the bulk insert.
+
+        ``scan_id`` is accepted for call-site symmetry and logging, but an
+        external-content FTS5 index can only be rebuilt *wholesale* from
+        its content table — there is no per-partition rebuild. That is the
+        correct behaviour here: the index mirrors all of ``scanned_files``,
+        and retention pruning keeps that to the last N scans, so a full
+        rebuild stays cheap relative to the scan that just ran. Idempotent
+        and best-effort: a failure is logged, never raised, so it can
+        never block a scan from completing.
+        """
+        try:
+            with self.get_cursor() as cur:
+                t0 = time.time()
+                # 'rebuild' wipes and repopulates the index from the
+                # external content table. The CREATE in _create_tables is
+                # IF NOT EXISTS, so this is safe on a fresh or existing DB.
+                cur.execute(
+                    "INSERT INTO scanned_files_fts(scanned_files_fts) "
+                    "VALUES('rebuild')"
+                )
+                logger.info(
+                    "FTS5 search index rebuilt (scan_id=%s, %.1f sn)",
+                    scan_id, time.time() - t0,
+                )
+        except sqlite3.DatabaseError as e:  # pragma: no cover - defensive
+            logger.warning(
+                "FTS5 rebuild_fts basarisiz (kritik degil, scan_id=%s): %s",
+                scan_id, e,
+            )
+
+    def search_files(self, query: str, scan_id: Optional[int] = None,
+                     limit: int = 100, offset: int = 0) -> dict:
+        """Substring search over file_path / file_name / owner via FTS5.
+
+        Returns ``{"total": int, "files": [<scanned_files row dict>, ...],
+        "query": str}``. ``total`` is the full match count (for pagination);
+        ``files`` is the ``limit``/``offset`` page, ordered by file_size
+        DESC so the biggest hits surface first (mirrors the drilldown
+        endpoints).
+
+        A query shorter than the trigram minimum (3 chars) returns an empty
+        result rather than scanning — trigram MATCH can't satisfy it anyway.
+        Reads run on the read-only connection pool so this never contends
+        with a running scan's writer lock (issue #132 contract).
+        """
+        q = (query or "").strip()
+        if len(q) < self._FTS_MIN_QUERY_LEN:
+            return {"total": 0, "files": [], "query": q}
+
+        phrase = self._fts_phrase(q)
+        limit = max(1, min(int(limit), 500))
+        offset = max(0, int(offset))
+
+        where = "scanned_files_fts MATCH ?"
+        count_params: list = [phrase]
+        page_params: list = [phrase]
+        if scan_id is not None:
+            where += " AND sf.scan_id = ?"
+            count_params.append(scan_id)
+            page_params.append(scan_id)
+
+        # get_read_cursor: short-lived read-only connection — independent
+        # of the scanner's writer pool, never blocks WAL checkpoint.
+        with self.get_read_cursor() as cur:
+            cur.execute(
+                "SELECT COUNT(*) AS cnt "
+                "FROM scanned_files_fts f "
+                "JOIN scanned_files sf ON sf.id = f.rowid "
+                f"WHERE {where}",  # noqa: S608 - where is built from literals only
+                count_params,
+            )
+            row = cur.fetchone()
+            total = (row["cnt"] if row else 0) or 0
+
+            cur.execute(
+                "SELECT sf.* "
+                "FROM scanned_files_fts f "
+                "JOIN scanned_files sf ON sf.id = f.rowid "
+                f"WHERE {where} "  # noqa: S608 - where is built from literals only
+                "ORDER BY sf.file_size DESC "
+                "LIMIT ? OFFSET ?",
+                page_params + [limit, offset],
+            )
+            files = [dict(r) for r in cur.fetchall()]
+        return {"total": total, "files": files, "query": q}
 
     def get_archive_stats(self) -> dict:
         """Arsiv genel istatistikleri."""

--- a/tests/test_fts_search.py
+++ b/tests/test_fts_search.py
@@ -1,0 +1,253 @@
+"""Tests for the embedded FTS5 (trigram) file search.
+
+Covers the database layer (``rebuild_fts`` / ``search_files``) and the
+``GET /api/files/search`` endpoint.
+
+Acceptance criteria from the agent instructions:
+
+* A substring query finds the right rows (path / name / owner).
+* A non-matching query returns ``[]``.
+* ``scan_id`` scoping works.
+* A too-short (< 3 char trigram) query returns empty cleanly.
+* The HTTP endpoint follows PaginationParams (page / page_size / items).
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+import pytest
+
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if REPO_ROOT not in sys.path:
+    sys.path.insert(0, REPO_ROOT)
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+from src.dashboard.api import create_app  # noqa: E402
+from src.storage.database import Database  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Stubs for create_app
+# ---------------------------------------------------------------------------
+
+
+class _StubAnalytics:
+    available = False
+
+
+def _make_config() -> dict:
+    return {
+        "dashboard": {"host": "127.0.0.1", "port": 8085, "auth": {"enabled": False}},
+        "archiving": {"enabled": False, "dry_run": True},
+        "audit": {"chain_enabled": False},
+        "database": {},
+    }
+
+
+# A small, deterministic corpus exercising path / name / owner matches and
+# two distinct scan_ids for the scoping test.
+#  (source_id, scan_id, file_path, relative_path, file_name, extension,
+#   file_size, owner)
+_ROWS = [
+    (1, 1, r"E:\Finans\rapor_2024.xlsx", r"Finans\rapor_2024.xlsx",
+     "rapor_2024.xlsx", "xlsx", 4096, r"CORP\ahmet"),
+    (1, 1, r"E:\HR\maaslar.docx", r"HR\maaslar.docx",
+     "maaslar.docx", "docx", 2048, r"CORP\zeynep"),
+    (1, 1, r"E:\Finans\butce_taslak.pdf", r"Finans\butce_taslak.pdf",
+     "butce_taslak.pdf", "pdf", 8192, r"CORP\ahmet"),
+    (1, 2, r"E:\Arsiv\eski_rapor.xlsx", r"Arsiv\eski_rapor.xlsx",
+     "eski_rapor.xlsx", "xlsx", 1024, r"CORP\mehmet"),
+]
+
+
+def _seed(database, source_id):
+    with database.get_cursor() as cur:
+        # scanned_files.scan_id FK-references scan_runs(id); seed the two
+        # scan runs (ids 1 and 2) first so the inserts satisfy the FK.
+        # Distinct started_at so get_latest_scan_id() resolves scan 2 as
+        # "latest" deterministically (same-timestamp inserts would tie).
+        for ts in ("2026-01-01 10:00:00", "2026-01-02 10:00:00"):
+            cur.execute(
+                "INSERT INTO scan_runs(source_id, status, started_at) "
+                "VALUES(?, 'completed', ?)",
+                (source_id, ts),
+            )
+        for r in _ROWS:
+            cur.execute(
+                "INSERT INTO scanned_files("
+                "source_id, scan_id, file_path, relative_path, file_name, "
+                "extension, file_size, owner) VALUES (?,?,?,?,?,?,?,?)",
+                (source_id,) + r[1:],
+            )
+
+
+@pytest.fixture
+def db(tmp_path):
+    """On-disk SQLite with one source + seeded scanned_files + built FTS."""
+    db_path = tmp_path / "fts_test.db"
+    database = Database({"path": str(db_path)})
+    database.connect()
+    with database.get_cursor() as cur:
+        cur.execute(
+            "INSERT INTO sources(name, unc_path) VALUES(?, ?)",
+            ("share1", r"\\fs\share1"),
+        )
+        source_id = cur.lastrowid
+    _seed(database, source_id)
+    database.rebuild_fts()
+    yield database, source_id
+    database.close()
+
+
+# ---------------------------------------------------------------------------
+# Database layer
+# ---------------------------------------------------------------------------
+
+
+def test_substring_matches_filename(db):
+    """A name fragment finds the matching files (trigram substring)."""
+    database, _ = db
+    res = database.search_files("rapor")
+    names = {f["file_name"] for f in res["files"]}
+    assert "rapor_2024.xlsx" in names
+    assert "eski_rapor.xlsx" in names
+    assert res["total"] == 2
+    # Non-matching file is absent.
+    assert "maaslar.docx" not in names
+
+
+def test_substring_matches_partial_token(db):
+    """Trigram matches a 4-char fragment inside a longer token."""
+    database, _ = db
+    res = database.search_files("maas")
+    assert [f["file_name"] for f in res["files"]] == ["maaslar.docx"]
+
+
+def test_substring_matches_owner(db):
+    """Owner substring search returns every file owned by that principal."""
+    database, _ = db
+    res = database.search_files("ahmet")
+    assert res["total"] == 2
+    assert all("ahmet" in f["owner"] for f in res["files"])
+
+
+def test_substring_matches_path_component(db):
+    """A path-fragment search hits files anywhere under that folder."""
+    database, _ = db
+    res = database.search_files("Finans")
+    names = {f["file_name"] for f in res["files"]}
+    assert names == {"rapor_2024.xlsx", "butce_taslak.pdf"}
+
+
+def test_non_match_returns_empty(db):
+    """A query matching nothing returns total=0 and an empty list."""
+    database, _ = db
+    res = database.search_files("zzzznotpresent")
+    assert res["total"] == 0
+    assert res["files"] == []
+
+
+def test_scan_id_scoping(db):
+    """scan_id filter restricts results to that scan only."""
+    database, _ = db
+    # "rapor" matches in both scans; scoping to scan 2 keeps only the
+    # archived one.
+    res_all = database.search_files("rapor")
+    assert res_all["total"] == 2
+    res_scan2 = database.search_files("rapor", scan_id=2)
+    assert res_scan2["total"] == 1
+    assert res_scan2["files"][0]["file_name"] == "eski_rapor.xlsx"
+
+
+def test_short_query_returns_empty(db):
+    """A query shorter than the trigram minimum returns empty, not error."""
+    database, _ = db
+    assert database.search_files("ra")["files"] == []
+    assert database.search_files("")["total"] == 0
+
+
+def test_rebuild_is_idempotent(db):
+    """rebuild_fts can run repeatedly without changing results."""
+    database, _ = db
+    database.rebuild_fts()
+    database.rebuild_fts(scan_id=1)
+    res = database.search_files("rapor")
+    assert res["total"] == 2
+
+
+def test_pagination_offset(db):
+    """limit/offset paginate the ordered (file_size DESC) result set."""
+    database, _ = db
+    page1 = database.search_files("xlsx", limit=1, offset=0)
+    page2 = database.search_files("xlsx", limit=1, offset=1)
+    assert len(page1["files"]) == 1
+    assert len(page2["files"]) == 1
+    # Ordered by file_size DESC: rapor_2024 (4096) before eski_rapor (1024).
+    assert page1["files"][0]["file_name"] == "rapor_2024.xlsx"
+    assert page2["files"][0]["file_name"] == "eski_rapor.xlsx"
+
+
+# ---------------------------------------------------------------------------
+# HTTP endpoint
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def client(db):
+    database, source_id = db
+    app = create_app(
+        db=database,
+        config=_make_config(),
+        analytics=_StubAnalytics(),
+        ad_lookup=None,
+        email_notifier=None,
+    )
+    return TestClient(app), source_id
+
+
+def test_endpoint_returns_pagination_envelope(client):
+    tc, _ = client
+    resp = tc.get("/api/files/search", params={"q": "rapor"})
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    # PaginationParams envelope shape.
+    assert body["page"] == 1
+    assert body["page_size"] == 100
+    assert body["total"] == 2
+    assert len(body["items"]) == 2
+    names = {f["file_name"] for f in body["items"]}
+    assert names == {"rapor_2024.xlsx", "eski_rapor.xlsx"}
+
+
+def test_endpoint_scoped_by_source(client):
+    tc, source_id = client
+    resp = tc.get(
+        "/api/files/search",
+        params={"q": "rapor", "source_id": source_id},
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    # source_id resolves to the latest scan (scan 2) → only eski_rapor.
+    assert body["total"] == 1
+    assert body["items"][0]["file_name"] == "eski_rapor.xlsx"
+
+
+def test_endpoint_non_match_empty(client):
+    tc, _ = client
+    resp = tc.get("/api/files/search", params={"q": "zzzznotpresent"})
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["total"] == 0
+    assert body["items"] == []
+
+
+def test_endpoint_unknown_source_404(client):
+    tc, _ = client
+    resp = tc.get(
+        "/api/files/search",
+        params={"q": "rapor", "source_id": 999999},
+    )
+    assert resp.status_code == 404


### PR DESCRIPTION
## Summary

Fast path / name / owner **substring** search across multi-million-row scans, in-process, with **zero new dependencies** — SQLite's FTS5 + `trigram` tokenizer ships with Python 3.11's bundled `sqlite3`. The trigram tokenizer is what makes `%foo%`-style substring matching index-backed instead of a full table scan.

- **`src/storage/database.py`** — idempotent external-content FTS5 virtual table `scanned_files_fts` (`tokenize='trigram'`) over `file_path` / `file_name` / `owner`, keyed on the existing `scanned_files.id` PK (`content='scanned_files'`, `content_rowid='id'`). **No per-row sync triggers** (unlike `archived_files_fts`): the scanner bulk-inserts millions of rows, so the index is built in **one shot at scan-complete** via the new `rebuild_fts(scan_id=None)`. Also adds `search_files(query, scan_id=None, limit=100, offset=0)` which reads via `get_read_cursor()` (Rule 6) and guards trigram's 3-char minimum.
- **`src/scanner/file_scanner.py`** — fires `rebuild_fts()` alongside the #232 cache pre-warm (single additive try/except, post size-enrich) so the search box is instant on first use. Best-effort: never blocks scan completion.
- **`src/dashboard/api.py`** — `GET /api/files/search` (`q`, optional `source_id`, pagination). Plain `def` (Rule 5), `PaginationParams = Depends()` (Rule 2), read-only pool, optional latest-scan scoping by source. `PaginationParams` promoted to a module-level import so the `Depends()` default resolves at decoration time.
- **`src/dashboard/static/index.html`** — "Dosya Arama" nav item + page with a search box; results render exclusively through `_setHtmlSafe` (Rule 7 / D-CHAIN), with a "Konuma Git" button via the existing `openFolder` + `_extractFolder` pattern.

## Design notes

- External-content keeps on-disk cost low (index stores tokens, not a 2nd copy of the text). `'rebuild'` reindexes the whole content table — correct here, since retention pruning keeps `scanned_files` to the last N scans.
- `scan_id` on `rebuild_fts` is for call-site symmetry/logging; external-content FTS5 only rebuilds wholesale (no per-partition rebuild).

## Test plan

- [x] `python -m pytest tests/test_fts_search.py -q` → **13 passed** (substring on name/owner/path, partial-token, scan-id scoping, non-match → `[]`, short-query guard, pagination, HTTP endpoint envelope + 404).
- [x] `python -m pytest tests/ -k database -q` → 4 passed, no regressions (3 collection errors are the pre-existing `openpyxl`-missing container gap, unrelated).
- [x] `python scripts/ci_guards.py` → **all 9 green** (D-YAML / S-YAML / LOADERS / HTML-BUDGET 128/140 / D-CHAIN / SVC-PARITY / R-CACHE / A-AWAIT / C-CURSOR).
- [x] `node --check` on the extracted inline `<script>` (CI extraction regex replicated) → passes.
- [x] `python -m py_compile` on all four touched `.py` files → passes.
- [x] Broad suite: 681 passed; the 26 failures are the documented pre-existing container baseline (watchdog / imagehash / mft / uvicorn / libmagic), identical with my changes stashed.

Draft pending the customer's real-DB smoke (run a scan, then hit "Dosya Arama") and review of the `src/scanner/file_scanner.py` hook touch given the concurrent scanner-backends work.

https://claude.ai/code/session_012n24XMRY5sdH9SyCq2Mo6c

---
_Generated by [Claude Code](https://claude.ai/code/session_012n24XMRY5sdH9SyCq2Mo6c)_