### PR TITLE
feat(security): USN encryption/truncation burst detection + blocking tail (#33)

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -160,6 +160,15 @@ scanner:
   # volume / izin yetersizse otomatik olarak polling'e duser.
   usn_tail_enabled: false
   usn_poll_interval_seconds: 1.0
+  # Issue #33: dusuk-gecikme bloklayan USN okuma. true ise FSCTL_READ_USN_JOURNAL
+  # cagrisi surucu icinde yeni kayit gelene (veya timeout dolana) kadar bloklar;
+  # tespit gecikmesi ~1sn -> ~0'a duser. usn_poll_interval_seconds bu modda
+  # atlanir (surucu okumasi kadansi kendisi saglar). Yalnizca usn_tail_enabled:
+  # true iken etkilidir. Varsayilan false = mevcut davranis (BytesToWaitFor=0 ile
+  # non-blocking polling). Gap-handling, state persist ve polling fallback her
+  # iki modda da korunur.
+  usn_blocking: false
+  usn_blocking_timeout_seconds: 1.0  # bloklayan okumanin surucu bekleme suresi (sn)
   batch_size: 1000            # DB batch insert boyutu
   skip_hidden: true           # Hidden attribute'lu dosyaları atla
   skip_system: true           # System attribute'lu dosyaları atla
@@ -325,6 +334,15 @@ security:
     rename_velocity_window: 60         # saniye
     deletion_velocity_threshold: 100   # > M delete / dakika -> alert
     deletion_velocity_window: 60       # saniye
+    # Issue #33: USN-tabanli yerinde-sifreleme tespiti. USN_REASON_ENCRYPTION_CHANGE
+    # ve USN_REASON_DATA_TRUNCATION patlamalari rename-velocity'nin kacirdigi
+    # yeniden-adlandirmayan (in-place) sifrelemeyi yakalar. Yalnizca USN tail
+    # akisinda anlamli (scanner.usn_tail_enabled). Esikler rename/delete'ten
+    # dusuk cunku bu olaylar normal kullanimda nadir + yuksek-sinyal.
+    encryption_velocity_threshold: 30    # > N ENCRYPTION_CHANGE / dakika -> alert
+    encryption_velocity_window: 60       # saniye
+    truncation_velocity_threshold: 40    # > N DATA_TRUNCATION / dakika -> alert
+    truncation_velocity_window: 60       # saniye
     risky_new_extensions:
       - encrypted
       - locked

--- a/src/scanner/backends/ntfs_usn_tail.py
+++ b/src/scanner/backends/ntfs_usn_tail.py
@@ -168,6 +168,23 @@ class NtfsUsnTailer:
         self._journal_id = None
         self._last_seen_usn = None
         self._gap_detected = False
+
+        # Lower-latency blocking read (config-gated). When True, the FIRST
+        # FSCTL_READ_USN_JOURNAL of each poll passes a nonzero BytesToWaitFor +
+        # Timeout so DeviceIoControl blocks in the driver until new records
+        # arrive (near-zero detection latency on local volumes) instead of
+        # returning immediately and sleeping ~1s in the loop. On timeout the
+        # call returns just the 8-byte next-USN header, which poll_once already
+        # treats as "no records" -- so gap-handling, state persistence and the
+        # polling fallback are all preserved. Default False = current behavior.
+        scanner_cfg = self.config.get("scanner", {}) or {}
+        self.usn_blocking = bool(scanner_cfg.get("usn_blocking", False))
+        # Driver wait timeout in seconds for the blocking read. Bounded so a
+        # stop_event can still be honored within roughly this interval.
+        self.usn_blocking_timeout_seconds = float(
+            scanner_cfg.get("usn_blocking_timeout_seconds", 1.0)
+        )
+
         ensure_state_table(self.db)
 
     # ── Detection ──────────────────────────────────────────────────────
@@ -311,11 +328,39 @@ class NtfsUsnTailer:
 
     # ── Polling ────────────────────────────────────────────────────────
 
+    @staticmethod
+    def _blocking_read_params(blocking: bool, timeout_seconds: float) -> tuple:
+        """Compute (bytes_to_wait_for, timeout_100ns) for the read struct.
+
+        Pure / platform-independent so it can be unit-tested on Linux.
+
+        * Non-blocking (default): ``(0, 0)`` -- DeviceIoControl returns
+          immediately with whatever is pending.
+        * Blocking: ``BytesToWaitFor`` is set to 1 byte so the driver blocks
+          until *any* new record is journaled, and ``Timeout`` is a relative
+          NT time (negative count of 100-ns intervals) so the call still
+          returns periodically -- letting the run loop check ``stop_event``
+          and persist state. A non-positive timeout collapses to the
+          non-blocking behavior to avoid an unbounded driver wait.
+        """
+        if not blocking:
+            return 0, 0
+        if timeout_seconds <= 0:
+            return 0, 0
+        # Relative wait times are passed as negative 100-ns intervals.
+        timeout_100ns = -int(timeout_seconds * 10_000_000)
+        return 1, timeout_100ns
+
     def poll_once(self, callback: Callable[[dict], None]) -> int:
         """Read all pending USN entries, invoke callback per record.
 
-        Returns the number of records dispatched. Non-blocking
-        (BytesToWaitFor=0). Safe to call repeatedly.
+        Returns the number of records dispatched. The first read of each
+        round honors the ``scanner.usn_blocking`` gate: when off (default) the
+        call is non-blocking (``BytesToWaitFor=0``); when on it blocks in the
+        driver until a record arrives or the configured timeout elapses,
+        cutting detection latency from ~1s to near-zero. Subsequent reads in
+        the same round (draining a backlog) are always non-blocking. Safe to
+        call repeatedly either way.
         """
         if self._handle is None or self._journal_id is None:
             raise RuntimeError("NtfsUsnTailer: initialize() once before poll_once()")
@@ -331,19 +376,22 @@ class NtfsUsnTailer:
                 ("StartUsn", ctypes.c_int64),
                 ("ReasonMask", ctypes.c_uint32),
                 ("ReturnOnlyOnClose", ctypes.c_uint32),
-                ("Timeout", ctypes.c_uint64),
+                ("Timeout", ctypes.c_int64),
                 ("BytesToWaitFor", ctypes.c_uint64),
                 ("UsnJournalID", ctypes.c_uint64),
                 ("MinMajorVersion", ctypes.c_uint16),
                 ("MaxMajorVersion", ctypes.c_uint16),
             ]
 
+        bytes_to_wait, timeout_100ns = self._blocking_read_params(
+            self.usn_blocking, self.usn_blocking_timeout_seconds
+        )
         in_struct = READ_USN_JOURNAL_DATA_V1(
             StartUsn=self._last_seen_usn,
             ReasonMask=0xFFFFFFFF,
             ReturnOnlyOnClose=0,
-            Timeout=0,
-            BytesToWaitFor=0,
+            Timeout=timeout_100ns,
+            BytesToWaitFor=bytes_to_wait,
             UsnJournalID=self._journal_id,
             MinMajorVersion=2,
             MaxMajorVersion=3,
@@ -394,6 +442,11 @@ class NtfsUsnTailer:
 
             self._last_seen_usn = next_usn
             in_struct.StartUsn = next_usn
+            # Only the FIRST read of a round may block. Once we've started
+            # draining, switch to non-blocking so an empty backlog returns
+            # immediately instead of waiting for the next write.
+            in_struct.BytesToWaitFor = 0
+            in_struct.Timeout = 0
 
             # If buffer wasn't full, no more pending entries this round.
             if n < USN_BUFFER_SIZE - 1024:
@@ -414,17 +467,27 @@ class NtfsUsnTailer:
     def run_loop(self, callback: Callable[[dict], None],
                   poll_interval_seconds: float = 1.0,
                   stop_event: Optional[threading.Event] = None) -> None:
-        """Continuous tail loop. Blocks until ``stop_event`` is set."""
+        """Continuous tail loop. Blocks until ``stop_event`` is set.
+
+        In non-blocking mode the loop polls then sleeps ``poll_interval_seconds``
+        between rounds. In blocking mode (``scanner.usn_blocking: true``) the
+        driver read itself supplies both the cadence and stop-responsiveness
+        (it returns at most every ``usn_blocking_timeout_seconds``), so the
+        inter-round sleep is skipped to keep detection latency near-zero.
+        """
         if stop_event is None:
             stop_event = threading.Event()
-        logger.info("USN tail dongu baslatildi (kaynak %d, interval=%.1fs)",
-                    self.source_id, poll_interval_seconds)
+        logger.info(
+            "USN tail dongu baslatildi (kaynak %d, interval=%.1fs, blocking=%s)",
+            self.source_id, poll_interval_seconds, self.usn_blocking,
+        )
         while not stop_event.is_set():
             try:
                 self.poll_once(callback)
             except Exception as e:
                 logger.error("USN poll hatasi: %s", e)
-            stop_event.wait(timeout=poll_interval_seconds)
+            if not self.usn_blocking:
+                stop_event.wait(timeout=poll_interval_seconds)
         logger.info("USN tail dongu durduruldu (kaynak %d)", self.source_id)
 
 

--- a/src/scanner/file_watcher.py
+++ b/src/scanner/file_watcher.py
@@ -151,6 +151,20 @@ class FileWatcher:
     def _on_usn_event(self, event: dict) -> None:
         """Bridge USN reasons to existing _record_audit semantics."""
         reasons = set(event.get("reason") or [])
+        fname = event.get("file_name", "")
+
+        # -- Security-only signals ----------------------------------------
+        # ENCRYPTION_CHANGE / DATA_TRUNCATION are routed to the ransomware
+        # detector as DISTINCT event types so the in-place-encryption
+        # velocity rules (issue #33) can fire. These run independently of
+        # the single audit etype chosen below, because a USN record can
+        # carry an encryption flag alongside a data-overwrite flag, and
+        # the velocity counter must see every encryption / truncation event.
+        if "ENCRYPTION_CHANGE" in reasons:
+            self._feed_detector("encryption_change", fname)
+        if "DATA_TRUNCATION" in reasons:
+            self._feed_detector("data_truncation", fname)
+
         # Choose ONE event_type per record (ordered by priority)
         if "FILE_DELETE" in reasons:
             etype = "delete"
@@ -158,7 +172,8 @@ class FileWatcher:
             etype = "create"
         elif "RENAME_NEW_NAME" in reasons:
             etype = "rename"
-        elif reasons & {"DATA_OVERWRITE", "DATA_EXTEND", "DATA_TRUNCATION"}:
+        elif reasons & {"DATA_OVERWRITE", "DATA_EXTEND", "DATA_TRUNCATION",
+                        "ENCRYPTION_CHANGE"}:
             etype = "modify"
         else:
             # Skip BASIC_INFO_CHANGE / SECURITY_CHANGE / CLOSE noise
@@ -166,7 +181,6 @@ class FileWatcher:
         # USN gives us the file name, not full path. Best effort path is
         # the volume root + name; the watcher doesn't reconstruct full
         # parent path here (would require an MFT lookup).
-        fname = event.get("file_name", "")
         with self._stats_lock:
             if etype == "create":
                 self.stats["new_files"] += 1
@@ -180,6 +194,27 @@ class FileWatcher:
             self._record_audit(etype, fname, owner=None)
         except Exception as e:
             logger.debug("USN _on_usn_event audit hata: %s", e)
+
+    def _feed_detector(self, event_type: str, fname: str) -> None:
+        """Forward a USN-derived security signal to the ransomware detector.
+
+        Best-effort: a detector failure must never break USN tailing. This
+        does NOT write an audit row (the audit path is handled separately in
+        :meth:`_on_usn_event`); it only drives the velocity counters.
+        """
+        det = self.ransomware_detector
+        if det is None:
+            return
+        try:
+            det.consume_event({
+                "timestamp": datetime.now(),
+                "source_id": self.source_id,
+                "username": None,
+                "file_path": fname,
+                "event_type": event_type,
+            })
+        except Exception as e:
+            logger.debug("USN detector fan-out error (%s): %s", event_type, e)
 
     def get_status(self):
         with self._stats_lock:

--- a/src/security/ransomware_detector.py
+++ b/src/security/ransomware_detector.py
@@ -1,8 +1,8 @@
 """Ransomware canary + rename-velocity detector (issue #37).
 
-Consumes file events from the existing watcher (later from a USN-tail feed
-once issue #33 lands) and triggers alerts when ransomware-style behaviour is
-detected. The four rules implemented today are:
+Consumes file events from the existing watcher (and from the USN-tail feed,
+issue #33) and triggers alerts when ransomware-style behaviour is detected.
+The six rules implemented today are:
 
 1. ``rename_velocity``  -- > N renames per minute by a single user on a
    single source. Defaults: 50/min.
@@ -12,6 +12,13 @@ detected. The four rules implemented today are:
    Defaults: 100/min.
 4. ``canary_access``    -- ANY access to a designated canary file fires an
    immediate critical alert.
+5. ``encryption_burst`` -- > N USN_REASON_ENCRYPTION_CHANGE events per
+   minute by a single user. Catches in-place EFS-style encryption that
+   does NOT rename the file, which rename-velocity would miss entirely.
+   Defaults: 30/min.
+6. ``truncation_burst`` -- > N USN_REASON_DATA_TRUNCATION events per minute
+   by a single user. A mass-shrink/overwrite pattern (ransomware that
+   rewrites file contents in place) without a rename. Defaults: 40/min.
 
 Persistence
 -----------
@@ -53,6 +60,14 @@ DEFAULT_RENAME_THRESHOLD = 50
 DEFAULT_RENAME_WINDOW = 60
 DEFAULT_DELETE_THRESHOLD = 100
 DEFAULT_DELETE_WINDOW = 60
+# In-place encryption / truncation bursts (USN signals, issue #33). These
+# thresholds are lower than rename/delete because in-place encryption is a
+# rarer, higher-signal event during normal operation -- a burst of them is a
+# strong ransomware indicator on its own.
+DEFAULT_ENCRYPTION_THRESHOLD = 30
+DEFAULT_ENCRYPTION_WINDOW = 60
+DEFAULT_TRUNCATION_THRESHOLD = 40
+DEFAULT_TRUNCATION_WINDOW = 60
 DEFAULT_RISKY_EXTENSIONS = [
     "encrypted", "locked", "crypto", "crypt", "wcry", "wnry",
     "ryk", "lockbit", "conti", "cuba",
@@ -68,7 +83,10 @@ _MAX_SAMPLE_PATHS = 20
 # deliberately do NOT auto-kill on plain rename velocity from a single user
 # (could be a legitimate batch job); the operator opts in by toggling
 # ``auto_kill_session``.
-_KILL_RULES = {"canary_access", "risky_extension", "mass_deletion", "rename_velocity"}
+_KILL_RULES = {
+    "canary_access", "risky_extension", "mass_deletion", "rename_velocity",
+    "encryption_burst", "truncation_burst",
+}
 
 
 def _parse_event_time(raw) -> datetime:
@@ -115,6 +133,15 @@ class RansomwareDetector:
                                              DEFAULT_DELETE_THRESHOLD))
         self.delete_window = int(cfg.get("deletion_velocity_window",
                                           DEFAULT_DELETE_WINDOW))
+        # USN-derived in-place encryption / truncation bursts (issue #33).
+        self.encryption_threshold = int(cfg.get("encryption_velocity_threshold",
+                                                 DEFAULT_ENCRYPTION_THRESHOLD))
+        self.encryption_window = int(cfg.get("encryption_velocity_window",
+                                             DEFAULT_ENCRYPTION_WINDOW))
+        self.truncation_threshold = int(cfg.get("truncation_velocity_threshold",
+                                                 DEFAULT_TRUNCATION_THRESHOLD))
+        self.truncation_window = int(cfg.get("truncation_velocity_window",
+                                             DEFAULT_TRUNCATION_WINDOW))
 
         risky = cfg.get("risky_new_extensions") or DEFAULT_RISKY_EXTENSIONS
         self.risky_extensions = {str(e).strip().lower().lstrip(".") for e in risky if e}
@@ -138,6 +165,8 @@ class RansomwareDetector:
         # Rolling event buffers: (source_id, username) -> deque[(timestamp, path)]
         self._renames: dict = defaultdict(deque)
         self._deletes: dict = defaultdict(deque)
+        self._encryptions: dict = defaultdict(deque)
+        self._truncations: dict = defaultdict(deque)
         self._lock = threading.Lock()
 
         # De-dupe key per (source_id, username, rule) -> last_triggered datetime.
@@ -145,7 +174,10 @@ class RansomwareDetector:
         self._last_alert: dict = {}
         # Cooldown roughly equal to the analysis window so the same burst
         # doesn't keep retriggering.
-        self._cooldown_seconds = max(self.rename_window, self.delete_window, 60)
+        self._cooldown_seconds = max(
+            self.rename_window, self.delete_window,
+            self.encryption_window, self.truncation_window, 60,
+        )
 
     # ------------------------------------------------------------------
     # Public API
@@ -169,9 +201,15 @@ class RansomwareDetector:
               "source_id":  int,
               "username":   str,
               "file_path":  str,
-              "event_type": "create" | "modify" | "delete" | "rename" | "access",
+              "event_type": "create" | "modify" | "delete" | "rename" |
+                            "access" | "encryption_change" | "data_truncation",
               "old_path":   str (optional, for rename),
             }
+
+        ``encryption_change`` / ``data_truncation`` come from the USN tail
+        (``USN_REASON_ENCRYPTION_CHANGE`` / ``USN_REASON_DATA_TRUNCATION``)
+        and feed their own velocity counters -- these catch in-place
+        encryption that never renames the file, which rename-velocity misses.
         """
         if not self.enabled or not event:
             return None
@@ -241,6 +279,27 @@ class RansomwareDetector:
             alert = self._track_velocity(
                 self._deletes, "mass_deletion", source_id, username,
                 file_path, ts, self.delete_threshold, self.delete_window,
+                severity="critical",
+            )
+            if alert:
+                return alert
+
+        # USN_REASON_ENCRYPTION_CHANGE burst -- in-place encryption that does
+        # not rename the file. Rename-velocity is blind to this pattern.
+        if ev_type == "encryption_change":
+            alert = self._track_velocity(
+                self._encryptions, "encryption_burst", source_id, username,
+                file_path, ts, self.encryption_threshold, self.encryption_window,
+                severity="critical",
+            )
+            if alert:
+                return alert
+
+        # USN_REASON_DATA_TRUNCATION burst -- mass in-place overwrite/shrink.
+        if ev_type == "data_truncation":
+            alert = self._track_velocity(
+                self._truncations, "truncation_burst", source_id, username,
+                file_path, ts, self.truncation_threshold, self.truncation_window,
                 severity="critical",
             )
             if alert:

--- a/tests/test_ntfs_usn_tail.py
+++ b/tests/test_ntfs_usn_tail.py
@@ -215,6 +215,65 @@ class GapDetectionLogicTests(unittest.TestCase):
 # Real DeviceIoControl tests — Windows-only, skipped on Linux
 # ─────────────────────────────────────────────────────────────────────
 
+# ─────────────────────────────────────────────────────────────────────
+# Blocking-read parameter computation (issue #33) — pure, Linux-safe.
+# Validates the config-gated low-latency knob without touching ctypes.
+# ─────────────────────────────────────────────────────────────────────
+
+class BlockingReadParamsTests(unittest.TestCase):
+    def test_non_blocking_default_is_zero_zero(self):
+        # Default path: BytesToWaitFor=0, Timeout=0 -> immediate return.
+        self.assertEqual(NtfsUsnTailer._blocking_read_params(False, 1.0), (0, 0))
+
+    def test_blocking_sets_one_byte_wait_and_negative_timeout(self):
+        bytes_to_wait, timeout_100ns = NtfsUsnTailer._blocking_read_params(True, 1.0)
+        self.assertEqual(bytes_to_wait, 1)
+        # Relative NT time -> negative 100-ns intervals. 1s == 10,000,000.
+        self.assertEqual(timeout_100ns, -10_000_000)
+
+    def test_blocking_scales_timeout(self):
+        _, t = NtfsUsnTailer._blocking_read_params(True, 0.5)
+        self.assertEqual(t, -5_000_000)
+
+    def test_blocking_with_nonpositive_timeout_collapses_to_nonblocking(self):
+        # Guards against an unbounded driver wait.
+        self.assertEqual(NtfsUsnTailer._blocking_read_params(True, 0), (0, 0))
+        self.assertEqual(NtfsUsnTailer._blocking_read_params(True, -3), (0, 0))
+
+
+class BlockingConfigGateTests(unittest.TestCase):
+    """The usn_blocking config flag is parsed on construction and defaults
+    to the legacy non-blocking behavior. Construction works on Linux because
+    only the SQLite state table is touched."""
+
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp(prefix="usn_cfg_")
+        self.dbpath = os.path.join(self.tmpdir, "cfg.db")
+        self.db = FakeDB(self.dbpath)
+
+    def tearDown(self):
+        for p in (self.dbpath,):
+            try:
+                os.remove(p)
+            except OSError:
+                pass
+        try:
+            os.rmdir(self.tmpdir)
+        except OSError:
+            pass
+
+    def test_default_is_non_blocking(self):
+        t = NtfsUsnTailer(self.db, {}, source_id=1, volume_letter="C")
+        self.assertFalse(t.usn_blocking)
+        self.assertEqual(t.usn_blocking_timeout_seconds, 1.0)
+
+    def test_blocking_enabled_via_config(self):
+        cfg = {"scanner": {"usn_blocking": True, "usn_blocking_timeout_seconds": 2.5}}
+        t = NtfsUsnTailer(self.db, cfg, source_id=1, volume_letter="C")
+        self.assertTrue(t.usn_blocking)
+        self.assertEqual(t.usn_blocking_timeout_seconds, 2.5)
+
+
 @unittest.skipIf(sys.platform != "win32", "Requires Windows + admin")
 class WindowsIntegrationTests(unittest.TestCase):
     def test_initialize_on_c_volume(self):

--- a/tests/test_ransomware_detector.py
+++ b/tests/test_ransomware_detector.py
@@ -221,3 +221,133 @@ def test_smb_kill_is_safe_on_linux():
         # the documented keys.
         assert "killed_session_ids" in out
         assert "dry_run" in out
+
+
+# ---------------------------------------------------------------------------
+# Issue #33: USN-derived in-place encryption / truncation burst detection.
+# These feed consume_event() with the distinct 'encryption_change' /
+# 'data_truncation' event types emitted by the USN tail. No real USN /
+# pywin32 is needed -- we drive consume_event() directly, so these run on
+# Linux CI exactly like the rename/delete velocity tests above.
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def usn_detector(tmp_path):
+    """Detector with small, explicit encryption/truncation thresholds so the
+    burst boundary is cheap to exercise deterministically."""
+    db_path = tmp_path / "usn_ransom.db"
+    db = Database({"path": str(db_path)})
+    db.connect()
+    cfg = {
+        "security": {
+            "ransomware": {
+                "enabled": True,
+                # Keep the rename/delete rules out of the way; we only test
+                # the two new USN signals here.
+                "rename_velocity_threshold": 100000,
+                "deletion_velocity_threshold": 100000,
+                "encryption_velocity_threshold": 10,
+                "encryption_velocity_window": 60,
+                "truncation_velocity_threshold": 15,
+                "truncation_velocity_window": 60,
+                # Avoid the canary / risky-extension fast-paths firing first.
+                "risky_new_extensions": ["zzz_never_match"],
+                "canary_file_names": ["zzz_never_match_canary"],
+                "auto_kill_session": False,
+                "notification_email": "",
+            }
+        }
+    }
+    return RansomwareDetector(db, cfg), db
+
+
+def _fire_events(det, event_type, n, *, user="mallory", source=5, base_ts=None):
+    """Inject n events of one type spaced 100ms apart inside the window."""
+    base_ts = base_ts or datetime.now()
+    last = None
+    for i in range(n):
+        ts = base_ts + timedelta(milliseconds=i * 100)
+        last = det.consume_event({
+            "timestamp": ts,
+            "source_id": source,
+            "username": user,
+            # In-place encryption keeps the SAME name (no rename) -- this is
+            # exactly the pattern rename-velocity cannot see.
+            "file_path": f"/share/data/doc_{i}.docx",
+            "event_type": event_type,
+        }) or last
+    return last
+
+
+def test_encryption_burst_does_not_fire_below_threshold(usn_detector):
+    det, _db = usn_detector
+    # threshold is 10, exclusive (> N). Exactly 10 must NOT fire.
+    alert = _fire_events(det, "encryption_change", 10)
+    assert alert is None
+
+
+def test_encryption_burst_fires_at_threshold(usn_detector):
+    det, _db = usn_detector
+    # The 11th encryption_change crosses the > 10 boundary.
+    alert = _fire_events(det, "encryption_change", 11)
+    assert alert is not None
+    assert alert["rule_name"] == "encryption_burst"
+    assert alert["severity"] == "critical"
+    assert alert["file_count"] >= 11
+    assert alert["username"] == "mallory"
+    assert alert["sample_paths"], "should carry sample paths"
+    assert len(alert["sample_paths"]) <= 20
+
+
+def test_truncation_burst_does_not_fire_below_threshold(usn_detector):
+    det, _db = usn_detector
+    # threshold is 15, exclusive. Exactly 15 must NOT fire.
+    alert = _fire_events(det, "data_truncation", 15)
+    assert alert is None
+
+
+def test_truncation_burst_fires_at_threshold(usn_detector):
+    det, _db = usn_detector
+    alert = _fire_events(det, "data_truncation", 16)
+    assert alert is not None
+    assert alert["rule_name"] == "truncation_burst"
+    assert alert["severity"] == "critical"
+    assert alert["file_count"] >= 16
+
+
+def test_encryption_and_truncation_counters_are_independent(usn_detector):
+    det, _db = usn_detector
+    # 10 encryption + 15 truncation: neither crosses its own threshold, so
+    # the two counters must not bleed into each other.
+    enc = _fire_events(det, "encryption_change", 10, user="eve", source=6)
+    trunc = _fire_events(det, "data_truncation", 15, user="eve", source=6)
+    assert enc is None
+    assert trunc is None
+
+
+def test_encryption_burst_persists_to_db(usn_detector):
+    det, db = usn_detector
+    alert = _fire_events(det, "encryption_change", 11)
+    assert alert is not None
+    rows = det.get_active_alerts(since_minutes=60)
+    assert any(r["rule_name"] == "encryption_burst" for r in rows)
+    with db.get_cursor() as cur:
+        cur.execute(
+            "SELECT rule_name, severity FROM ransomware_alerts "
+            "WHERE rule_name = 'encryption_burst'"
+        )
+        raw = cur.fetchall()
+    assert raw, "encryption_burst alert should be persisted"
+
+
+def test_default_usn_thresholds_when_unconfigured(tmp_path):
+    """When the new keys are absent the detector still loads with the safe
+    documented defaults (30 / 40) -- no KeyError, no crash."""
+    db = Database({"path": str(tmp_path / "def.db")})
+    db.connect()
+    det = RansomwareDetector(db, {"security": {"ransomware": {"enabled": True}}})
+    assert det.encryption_threshold == 30
+    assert det.truncation_threshold == 40
+    # A modest burst below the default must stay silent.
+    alert = _fire_events(det, "encryption_change", 25, user="frank", source=9)
+    assert alert is None


### PR DESCRIPTION
## Summary

Enhances NTFS USN-journal ransomware/anomaly detection. No new dependency; both touched modules stay importable on Linux (the Windows-only `ctypes` paths remain behind the existing `sys.platform` / lazy-import guards).

### 1. New detection signals (the core win)
In-place encryption (e.g. EFS / ransomware that rewrites file bytes without renaming) is invisible to the existing rename-velocity rule. This wires the two USN reason flags that *do* see it into the detector as **distinct event types** with their own velocity counters + thresholds, mirroring the rename/delete logic:

- `USN_REASON_ENCRYPTION_CHANGE` -> `encryption_change` -> **`encryption_burst`** rule (default `> 30/min`)
- `USN_REASON_DATA_TRUNCATION` -> `data_truncation` -> **`truncation_burst`** rule (default `> 40/min`)

`FileWatcher._on_usn_event` now fans these out to `RansomwareDetector.consume_event(...)` independently of the single audit `etype` (a USN record can carry an encryption flag *alongside* a data-overwrite flag, so the velocity counter must see every one). New config keys under `security.ransomware`: `encryption_velocity_threshold/window`, `truncation_velocity_threshold/window` — safe defaults, absence falls back to the documented values, existing keys untouched.

### 2. Lower-latency blocking USN tail (config-gated, default OFF)
`scanner.usn_blocking: false` (+ `usn_blocking_timeout_seconds: 1.0`). When enabled, the first `FSCTL_READ_USN_JOURNAL` of each round passes a nonzero `BytesToWaitFor` + relative NT `Timeout`, so `DeviceIoControl` blocks in the driver until a record arrives — cutting detection latency from ~1s to near-zero on local volumes. The driver read supplies the loop cadence so the inter-round sleep is skipped in this mode. Gap-handling, state persistence and the polling fallback are **all preserved**; only the first read of a round may block (backlog drain stays non-blocking). The `Timeout` struct field type was widened to a signed `c_int64` to hold the negative relative-time value. Logic is factored into a pure `_blocking_read_params(...)` static method so it is unit-tested on Linux.

## Test plan
- [x] `python scripts/ci_guards.py` — all 9 guards green
- [x] `python -m pytest tests/test_ransomware_detector.py tests/test_ntfs_usn_tail.py -q` — 38 passed, 1 skipped (Windows-only)
- [x] New tests assert `encryption_burst` / `truncation_burst` fire at threshold and NOT below, counters are independent, alert persists to `ransomware_alerts`, and unconfigured defaults (30/40) load
- [x] New tests cover `_blocking_read_params` (non-blocking default, negative-timeout scaling, non-positive-timeout collapse) and the `usn_blocking` config gate — all Linux-safe (no real USN / pywin32)
- [x] `python -m py_compile` on all touched files
- [x] `python -c "import src.scanner.backends.ntfs_usn_tail, src.security.ransomware_detector"` works on Linux
- [ ] Windows admin smoke test of blocking mode on a real NTFS volume (manual, not runnable in CI)

Scope note: did not touch `src/storage/*` or `src/dashboard/*`.

https://claude.ai/code/session_012n24XMRY5sdH9SyCq2Mo6c

---
_Generated by [Claude Code](https://claude.ai/code/session_012n24XMRY5sdH9SyCq2Mo6c)_