### PR TITLE
fix(dashboard): #8/#9 stuck Kopya/Adlandırma reports — lock-resilient reads + surfaced errors

### DIFF
--- a/src/dashboard/static/index.html
+++ b/src/dashboard/static/index.html
@@ -5489,7 +5489,10 @@ async function loadNaming() {
         // Issue #80: reusable entity-list ile ihlal eden dosyalari listele
         renderMitNamingEntityList(sourceId, data);
         _attachNamingViewToggle();
-    } catch(e) { console.error('MIT naming load error:', e); }
+    } catch(e) {
+        console.error('MIT naming load error:', e);
+        _setHtmlSafe('naming-summary-cards', `<div style="padding:20px;color:var(--danger,#dc2626)">Adlandirma raporu yuklenemedi: ${escapeHtml(e.message||'hata')}. Tarama suruyorsa bitince tekrar deneyin.</div>`);
+    }
 }
 
 // Issue #84 — Gorsel ↔ Profesyonel mod toggle for Adlandirma Uyumu.
@@ -6142,7 +6145,11 @@ async function loadDuplicates(page) {
         dupSelectedFiles.clear();
         updateDupSelection();
         _attachDuplicatesViewToggle();
-    } catch(e) { console.error('Duplicates load error:', e); }
+    } catch(e) {
+        console.error('Duplicates load error:', e);
+        _setHtmlSafe('dup-summary-cards', `<div style="padding:20px;color:var(--danger,#dc2626)">Kopya raporu yuklenemedi: ${escapeHtml(e.message||'hata')}. Tarama suruyorsa bitince tekrar deneyin.</div>`);
+        _setHtmlSafe('dup-table', '');
+    }
 }
 
 // Issue #84 — Gorsel ↔ Profesyonel mod toggle for Kopya Dosyalar.

--- a/src/storage/database.py
+++ b/src/storage/database.py
@@ -2270,7 +2270,7 @@ class Database:
             scan_id = self.get_latest_scan_id(source_id)
         if not scan_id:
             return []
-        with self.get_cursor() as cur:
+        with self.get_read_cursor() as cur:
             cur.execute("""
                 SELECT
                     COALESCE(owner, 'Bilinmiyor') as owner,
@@ -2292,7 +2292,7 @@ class Database:
             params_base.append(owner)
         where = f"source_id = ? AND scan_id = ? AND {owner_cond}"
 
-        with self.get_cursor() as cur:
+        with self.get_read_cursor() as cur:
             cur.execute(f"SELECT COUNT(*) as cnt FROM scanned_files WHERE {where}", params_base)  # noqa: S608
             total = cur.fetchone()["cnt"]
             cur.execute(f"""
@@ -3012,7 +3012,7 @@ class Database:
 
         # Son scan_id'yi bul
         if not scan_id:
-            with self.get_cursor() as cur:
+            with self.get_read_cursor() as cur:
                 cur.execute("""
                     SELECT id FROM scan_runs WHERE source_id=? AND status='completed'
                     ORDER BY started_at DESC LIMIT 1
@@ -3023,7 +3023,7 @@ class Database:
                             "groups": [], "page": page, "page_size": page_size, "total_pages": 1}
                 scan_id = row["id"]
 
-        with self.get_cursor() as cur:
+        with self.get_read_cursor() as cur:
             # Tek CTE ile ozetleri (toplam grup, toplam israf, toplam dosya)
             # ve sayfalanmis gruplari iki ayri sorguda tek aggregate uzerinden
             # alir. Onceki kodda ayni GROUP BY uc kere calisiyordu; buyuk


### PR DESCRIPTION
## Summary

Fixes the customer's **#8/#9** — "Kopya Dosyalar" + "Adlandırma Uyumu" pages stuck on **"yükleniyor"** with no data — diagnosed from their `file_activity.log`.

## Root cause (from the log)
During the 2026-05-25 scan the log shows a continuous `database is locked` storm:
```
WARNING file_activity.staging       | DuckDB ingest basarisiz (database is locked) ...
WARNING file_activity.analyzer.cache | analyzer_cache DB write failed: database is locked
```
`scanner.parquet_staging` is still **enabled** on the box → DuckDB `ATTACH(READ_WRITE)` ingest contends with the live SQLite writer (the #174 lock class). Two code-level faults turned that contention into a permanent spinner:

1. **Report reads ran on the writer pool.** `get_duplicate_groups` / `get_file_owners_stats` / `get_files_by_owner` used `get_cursor()` (writer pool), so during a scan they hit the write lock and raised `database is locked` → the duplicate endpoint **500**'d.
2. **Frontend swallowed the error.** `loadDuplicates` / `loadNaming` caught with `console.error` only → the page never left its loading skeleton.

## Fix (this PR)
- **`src/storage/database.py`** — switch those three **read-only** report methods to `get_read_cursor()`. Under WAL a read-only connection does **not** block on the writer, so the duplicate/owner reports load even mid-scan (aligns with endpoint-conventions Rule 6).
- **`src/dashboard/static/index.html`** — `loadDuplicates` / `loadNaming` now render a clear error state ("… tarama sürüyorsa bitince tekrar deneyin") instead of an infinite spinner.

## Operator action (the lock *source*)
Set `scanner.parquet_staging.enabled: false` in `config\config.yaml`, restart, rescan — removes the DuckDB-ingest lock storm entirely. (Why the #174 migration didn't disable it on this box — key absent / non-canonical value — is a separate **durable migration fix** I'll ship next.)

## Test plan
- [x] `get_read_cursor` smoke: temp DB, duplicate group + owner rows → `get_duplicate_groups` (1 group/3 files), `get_file_owners_stats` (alice:2, Bilinmiyor:1), `get_files_by_owner` (2) all correct via the read pool.
- [x] `node --check` on extracted inline JS · 9/9 `ci_guards` · `py_compile`.
- [ ] On-box: with `parquet_staging:false` + a scan, Kopya/Adlandırma load; mid-scan they show the error state, not a frozen spinner.

## Follow-ups (tracked, not in this PR)
- **#1 owner "(Bilinmiyor)":** the **MFT backend captures no owner** (path-only) — `read_owner` only works on the win32/SMB path; needs a post-walk owner-enrichment pass in `ntfs_mft` (Windows-only). 
- Durable `migrate_config` fix so `parquet_staging` actually flips off on `update.cmd` (handle missing-key + truthy variants).

https://claude.ai/code/session_012n24XMRY5sdH9SyCq2Mo6c

---
_Generated by [Claude Code](https://claude.ai/code/session_012n24XMRY5sdH9SyCq2Mo6c)_