### PR TITLE
fix(scanner): #1 capture owner on MFT scans (stop "(Bilinmiyor)")

### DIFF
--- a/src/scanner/size_enricher.py
+++ b/src/scanner/size_enricher.py
@@ -103,6 +103,13 @@ class SizeEnricher:
         # specific files, e.g. some legacy network FS edge cases).
         self.max_mb = int(scanner_cfg.get("size_enrich_max_mb", 0) or 0)
 
+        # Issue #1 — capture owner during this same post-walk pass when
+        # scanner.read_owner is on. The MFT backend is path-only (yields no
+        # owner), so without this the owner column stays NULL and the
+        # dashboard shows "(Bilinmiyor)". Windows-only resolution
+        # (LookupAccountSid); a no-op on other platforms.
+        self.read_owner = bool(scanner_cfg.get("read_owner", False))
+
         # Lazy-loaded FSCTL backend on Windows. Module import happens
         # inside ``enrich`` to keep Linux/macOS test runs free of any
         # ctypes setup cost.
@@ -305,12 +312,32 @@ class SizeEnricher:
             )
             return None
 
-        return {
+        row = {
             "file_size": size,
             "last_modify_time": _to_iso(getattr(st, "st_mtime", None)),
             "last_access_time": _to_iso(getattr(st, "st_atime", None)),
             "creation_time": _to_iso(getattr(st, "st_ctime", None)),
         }
+        if self.read_owner:
+            # Resolve owner in the same post-walk pass (Windows-only; None
+            # on other platforms or on failure). bulk_update_file_sizes
+            # COALESCEs it, so a None never clobbers an owner a richer
+            # backend (e.g. the SMB walk) already populated.
+            row["owner"] = self._resolve_owner(path)
+        return row
+
+    @staticmethod
+    def _resolve_owner(path: str) -> Optional[str]:
+        """Best-effort file owner (``DOMAIN\\name``) via the win32 helper.
+
+        Lazy-imports so Linux/macOS runs pay nothing; returns ``None`` when
+        pywin32/Windows is unavailable or the lookup fails.
+        """
+        try:
+            from src.scanner.win_attributes import _get_file_owner, _long_path
+            return _get_file_owner(_long_path(path))
+        except Exception:  # pragma: no cover - defensive
+            return None
 
     # ── (future) FSCTL backend hook ──────────────────────────────────
 

--- a/src/storage/database.py
+++ b/src/storage/database.py
@@ -1561,7 +1561,9 @@ class Database:
         Used by the post-walk size-enrich pass (see
         :class:`src.scanner.size_enricher.SizeEnricher`). Each row dict
         carries ``scan_id``, ``file_path``, ``file_size`` and any subset
-        of ``last_modify_time`` / ``last_access_time`` / ``creation_time``.
+        of ``last_modify_time`` / ``last_access_time`` / ``creation_time`` /
+        ``owner`` (owner is filled by the post-walk pass when
+        ``scanner.read_owner`` is on, for path-only backends like MFT — #1).
         The match is on ``(scan_id, file_path)`` so the same path on a
         different historical scan is not affected.
 
@@ -1586,6 +1588,7 @@ class Database:
                 r.get("last_modify_time"),
                 r.get("last_access_time"),
                 r.get("creation_time"),
+                r.get("owner"),
                 int(r["scan_id"]),
                 r["file_path"],
             )
@@ -1596,7 +1599,8 @@ class Database:
             "SET file_size = ?, "
             "    last_modify_time = COALESCE(?, last_modify_time), "
             "    last_access_time = COALESCE(?, last_access_time), "
-            "    creation_time    = COALESCE(?, creation_time) "
+            "    creation_time    = COALESCE(?, creation_time), "
+            "    owner            = COALESCE(?, owner) "
             "WHERE scan_id = ? AND file_path = ?"
         )
 

--- a/tests/test_owner_enrich.py
+++ b/tests/test_owner_enrich.py
@@ -1,0 +1,100 @@
+"""Issue #1 — owner enrichment plumbing.
+
+The actual win32 owner resolution (LookupAccountSid) is Windows-only and
+not exercised here; these cover the cross-platform plumbing that makes the
+MFT path-only backend stop reporting every owner as "(Bilinmiyor)":
+  * bulk_update_file_sizes writes ``owner`` with COALESCE semantics
+    (a real owner is set; a None never clobbers an existing one),
+  * SizeEnricher honours ``scanner.read_owner`` and only emits an ``owner``
+    key on the enrich row when it is enabled.
+"""
+from __future__ import annotations
+
+import os
+import sys
+
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if REPO_ROOT not in sys.path:
+    sys.path.insert(0, REPO_ROOT)
+
+from src.scanner.size_enricher import SizeEnricher  # noqa: E402
+from src.storage.database import Database  # noqa: E402
+
+
+class _FakeDB:
+    """SizeEnricher.__init__/_stat_path never touch the db."""
+
+
+def _seed(tmp_path):
+    db = Database({"path": str(tmp_path / "t.db")})
+    db.connect()
+    with db.get_cursor() as cur:
+        cur.execute("INSERT INTO sources (name, unc_path) VALUES ('s','/x')")
+        sid = cur.lastrowid
+        cur.execute(
+            "INSERT INTO scan_runs (source_id, status) VALUES (?, 'completed')",
+            (sid,),
+        )
+        scan = cur.lastrowid
+    return db, sid, scan
+
+
+def _insert(db, sid, scan, path, owner=None):
+    with db.get_cursor() as cur:
+        cur.execute(
+            "INSERT INTO scanned_files "
+            "(source_id, scan_id, file_path, relative_path, file_name, file_size, owner) "
+            "VALUES (?,?,?,?,?,0,?)",
+            (sid, scan, path, os.path.basename(path), os.path.basename(path), owner),
+        )
+
+
+def _owner_of(db, scan, path):
+    with db.get_read_cursor() as cur:
+        cur.execute(
+            "SELECT owner FROM scanned_files WHERE scan_id=? AND file_path=?",
+            (scan, path),
+        )
+        return cur.fetchone()["owner"]
+
+
+def test_bulk_update_sets_owner(tmp_path):
+    db, sid, scan = _seed(tmp_path)
+    _insert(db, sid, scan, "/x/a.txt", owner=None)
+    n = db.bulk_update_file_sizes(
+        [{"scan_id": scan, "file_path": "/x/a.txt", "file_size": 10,
+          "owner": "DOMAIN\\bob"}]
+    )
+    assert n == 1
+    assert _owner_of(db, scan, "/x/a.txt") == "DOMAIN\\bob"
+
+
+def test_bulk_update_owner_none_preserves_existing(tmp_path):
+    db, sid, scan = _seed(tmp_path)
+    _insert(db, sid, scan, "/x/b.txt", owner="ACME\\alice")
+    db.bulk_update_file_sizes(
+        [{"scan_id": scan, "file_path": "/x/b.txt", "file_size": 20,
+          "owner": None}]
+    )
+    # COALESCE(NULL, owner) keeps the existing owner — a size-only enrich
+    # row must never wipe an owner a richer backend already set.
+    assert _owner_of(db, scan, "/x/b.txt") == "ACME\\alice"
+
+
+def test_size_enricher_honours_read_owner_flag():
+    on = SizeEnricher({"scanner": {"read_owner": True}}, _FakeDB())
+    off = SizeEnricher({"scanner": {"read_owner": False}}, _FakeDB())
+    assert on.read_owner is True
+    assert off.read_owner is False
+
+
+def test_stat_path_owner_key_gated_on_read_owner(tmp_path):
+    f = tmp_path / "c.txt"
+    f.write_text("hi")
+    on = SizeEnricher({"scanner": {"read_owner": True}}, _FakeDB())
+    row = on._stat_path(str(f))
+    # Key present when enabled (value is None off-Windows; win32 fills it
+    # on the customer's box).
+    assert "owner" in row
+    off = SizeEnricher({"scanner": {"read_owner": False}}, _FakeDB())
+    assert "owner" not in off._stat_path(str(f))


### PR DESCRIPTION
## Summary

Fixes **#1** — User Activity shows every file owner as **"(Bilinmiyor)"**.

## Root cause (verified)
The customer scans `E:\` with the **NTFS MFT backend**, which is **path-only** — `ntfs_mft` yields no `owner`, so `file_scanner` stores `owner = NULL` for every file and the dashboard's `COALESCE(owner, 'Bilinmiyor')` labels them all unknown. `scanner.read_owner: true` (the default) only had an effect on the **win32/SMB** walk path; the MFT backend ignored it entirely. **Not an AD/SID-resolution problem** and not gated on `active_directory.enabled`.

## Fix
Capture owner in the **existing post-walk size-enrich pass** (it already `os.stat`s every path-only row):
- `SizeEnricher` now reads `scanner.read_owner`; when on, `_stat_path` resolves the owner via `win_attributes._get_file_owner` (`GetFileSecurity` → `LookupAccountSid` → `DOMAIN\name`) alongside the stat.
- `Database.bulk_update_file_sizes` writes it with `owner = COALESCE(?, owner)` — a `None` (off-Windows / lookup failure) never clobbers an owner a richer backend (the SMB walk) already set.
- Windows-only resolution; a no-op on Linux/macOS. On a **domain-joined** host `LookupAccountSid` resolves names with **no LDAP / `active_directory` config** needed.

Only path-only (`file_size = 0`) rows are touched — exactly the MFT case; SMB rows already carry owner + size and are skipped by the enrich query.

**Tradeoff (documented):** with `read_owner: true` this adds one `GetFileSecurity` call per file on MFT scans (the cost MFT was designed to avoid). It runs in the existing parallel size-enrich pool, post-walk, non-blocking — consistent with the `read_owner` "(biraz yavaşlatır)" note in `config.yaml`.

## Test plan
- [x] `tests/test_owner_enrich.py` (new): `bulk_update_file_sizes` sets owner; a `None` owner preserves an existing one (COALESCE); `SizeEnricher` honours `read_owner`; `_stat_path` only emits an `owner` key when enabled.
- [x] `tests/test_size_enrich.py` 14 passed (no regression) · `py_compile` · 9/9 `ci_guards`.
- [ ] **On-box (Windows, domain-joined):** rescan with `read_owner: true` → User Activity shows real `DOMAIN\name` owners instead of "(Bilinmiyor)". *(win32 resolution can't be exercised in the Linux CI/dev env — needs the customer's box.)*

https://claude.ai/code/session_012n24XMRY5sdH9SyCq2Mo6c

---
_Generated by [Claude Code](https://claude.ai/code/session_012n24XMRY5sdH9SyCq2Mo6c)_