### PR TITLE
fix(users): owner drill-down empty for DOMAIN\user + uncapped CSV export

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -486,6 +486,9 @@ telemetry:
     repo: "deepdarbe/file_activity"
     # Name of the env var that holds a fine-scoped GitHub PAT with
     # ``issues: write``. Never put the token itself in this file.
+    # The same repo + token also power ``fa.cmd diag --upload`` (open a
+    # diagnostics issue). The dashboard "Tanilama Paketi" download button
+    # and plain ``fa.cmd diag`` need NO token — they just write a local zip.
     token_env: "FILEACTIVITY_TELEMETRY_TOKEN"
     label: "auto-report"
   rate_limit:

--- a/main.py
+++ b/main.py
@@ -103,8 +103,10 @@ def cli(ctx, config):
     # Check which command is being invoked
     invoked = ctx.invoked_subcommand
 
-    # 'check' and 'version' commands don't need DB
-    no_db_commands = ["check", "version"]
+    # 'check' / 'version' need no DB; 'diag' uses only the read-only pool
+    # (get_read_cursor opens its own ro connection), so it must run even when
+    # the writer cannot connect — that is exactly when diagnostics matter.
+    no_db_commands = ["check", "version", "diag"]
 
     if invoked in no_db_commands:
         # Don't connect to DB for these commands
@@ -198,6 +200,58 @@ def version():
     # drifted years past the actual release tag (#194 config audit).
     click.echo(f"FILE ACTIVITY v{_read_version_string()}")
     click.echo("Windows File Share Analysis & Archiving System")
+
+
+# -----------------------------------------------
+# DIAG KOMUTU - tanilama paketi
+# -----------------------------------------------
+
+@cli.command("diag")
+@click.option("--out", default=None,
+              help="Cikti klasoru (varsayilan: <data>/diagnostics)")
+@click.option("--lines", default=200, help="Log kuyrugu satir sayisi")
+@click.option("--no-redact", "no_redact", is_flag=True,
+              help="Ornek sahip adlari / UNC yollarini dahil et")
+@click.option("--upload", is_flag=True, help="GitHub issue olarak da gonder")
+@click.option("--repo", default=None,
+              help="owner/name (varsayilan: telemetry.github.repo)")
+@click.option("--token", default=None,
+              help="GitHub token (varsayilan: $FILEACTIVITY_TELEMETRY_TOKEN)")
+@click.pass_context
+def diag(ctx, out, lines, no_redact, upload, repo, token):
+    """Tanilama paketi olustur: surum, ortam, config, log, DB sagligi."""
+    import os as _os
+    from scripts.collect_diag import (
+        _scrub_paths, build_bundle, collect, render_markdown,
+        resolve_github, upload_to_github,
+    )
+
+    app = ctx.obj
+    diag_data = collect(app.db, app.config, log_lines=lines, redact=not no_redact)
+    markdown = render_markdown(diag_data)
+
+    db_conf = app.config.get("database", {}) or {}
+    data_dir = _os.path.dirname(
+        _os.path.abspath(db_conf.get("path", "data/file_activity.db"))
+    )
+    out_dir = out or _os.path.join(data_dir, "diagnostics")
+    bundle = build_bundle(diag_data, markdown, out_dir)
+    click.echo(f"[OK] Tanilama paketi: {bundle}")
+
+    if upload:
+        gh_repo, gh_token, label, scrub = resolve_github(app.config, repo, token)
+        if not gh_repo or not gh_token:
+            click.echo("[UYARI] --upload atlandi: telemetry.github.repo + "
+                       "$FILEACTIVITY_TELEMETRY_TOKEN (veya --repo/--token) gerekli",
+                       err=True)
+            return
+        body = _scrub_paths(markdown) if scrub else markdown
+        try:
+            url = upload_to_github(body, gh_repo, gh_token, label=label)
+            click.echo(f"[OK] GitHub issue: {url}")
+        except Exception as exc:  # noqa: BLE001 - report, don't crash the CLI
+            click.echo(f"[HATA] GitHub yukleme basarisiz: {exc}", err=True)
+            ctx.exit(1)
 
 
 # -----------------------------------------------

--- a/scripts/collect_diag.py
+++ b/scripts/collect_diag.py
@@ -1,0 +1,575 @@
+#!/usr/bin/env python3
+"""Diagnostics bundle collector.
+
+One command that gathers what a remote agent needs to triage a customer
+report — version, environment (incl. Windows domain-join, which gates owner
+SID resolution), sanitized config, log tail, and read-only DB health
+(per-source scan state, owner-resolution ratio, WAL size) — into a single
+Markdown report, optionally zipped and optionally posted to a GitHub issue.
+
+Strictly read-only against the database: every query goes through
+``db.get_read_cursor()``; this tool never writes a row.
+
+Usage (operator box):
+    fa.cmd diag                       # write a zip under data/diagnostics/
+    fa.cmd diag --upload              # also open a GitHub issue (needs token)
+
+Standalone:
+    python scripts/collect_diag.py --config config/config.yaml [--upload]
+
+The same ``collect()`` powers the dashboard "Tanilama Paketi" download button
+(``GET /api/system/diag-bundle``).
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import platform
+import re
+import socket
+import sys
+import zipfile
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Optional
+
+_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if _REPO_ROOT not in sys.path:
+    sys.path.insert(0, _REPO_ROOT)
+
+# --------------------------------------------------------------------------
+# Redaction — secrets are ALWAYS masked, regardless of --no-redact (which only
+# governs whether sample owner names / full paths are included).
+# --------------------------------------------------------------------------
+_SENSITIVE_KEY_HINTS = (
+    "password", "passwd", "secret", "token", "api_key", "apikey",
+    "client_secret", "private_key", "privatekey", "credential", "smtp_pass",
+    "bind_password", "webhook_url", "connection_string", "dsn",
+)
+_REDACTED = "***REDACTED***"
+
+
+def _redact_config(obj: Any) -> Any:
+    """Recursively mask values whose key looks like a secret."""
+    if isinstance(obj, dict):
+        out = {}
+        for key, value in obj.items():
+            if any(hint in str(key).lower() for hint in _SENSITIVE_KEY_HINTS):
+                out[key] = _REDACTED
+            else:
+                out[key] = _redact_config(value)
+        return out
+    if isinstance(obj, list):
+        return [_redact_config(v) for v in obj]
+    return obj
+
+
+# Path scrubbing for the GitHub-upload path — mirrors the patterns the
+# existing telemetry reporter uses (src/telemetry/error_reporter.py) so the
+# operator's ``telemetry.privacy.redact_paths`` setting governs both.
+_UNC_PATTERN = re.compile(r"\\\\([^\\]+)\\([^\\]+)")
+_HOME_PATTERN = re.compile(r"(C:\\Users\\)([^\\]+)", re.I)
+
+
+def _scrub_paths(text: str) -> str:
+    if not isinstance(text, str) or not text:
+        return text
+    text = _UNC_PATTERN.sub(r"\\\\<redacted>\\<redacted>", text)
+    text = _HOME_PATTERN.sub(r"\1<redacted>", text)
+    return text
+
+
+def resolve_github(config: dict, repo_arg: Optional[str] = None,
+                   token_arg: Optional[str] = None) -> tuple:
+    """Resolve (repo, token, label, scrub_paths) from the shared
+    ``telemetry.github`` config — the same surface the auto error-reporter
+    uses, so there is exactly one repo/token to configure on the box.
+
+    ``--upload`` is an explicit operator action, so it does NOT require
+    ``telemetry.enabled: true`` (that flag only gates automatic capture).
+    """
+    tele = (config.get("telemetry") or {}) if isinstance(config, dict) else {}
+    gh = tele.get("github") or {}
+    repo = repo_arg or gh.get("repo")
+    token_env = gh.get("token_env", "FILEACTIVITY_TELEMETRY_TOKEN")
+    token = (token_arg or os.environ.get(token_env)
+             or os.environ.get("FA_GITHUB_TOKEN")
+             or os.environ.get("GITHUB_TOKEN"))
+    label = gh.get("label", "diagnostics")
+    scrub = bool((tele.get("privacy") or {}).get("redact_paths", False))
+    return repo, token, label, scrub
+
+
+def _read_version(base_dir: str) -> str:
+    """Mirror main.py: VERSION file sits next to the entrypoint."""
+    for candidate in (os.path.join(base_dir, "VERSION"),
+                      os.path.join(_REPO_ROOT, "VERSION")):
+        try:
+            with open(candidate, "r", encoding="utf-8") as handle:
+                text = handle.read().strip()
+            if text:
+                return text
+        except OSError:
+            continue
+    return "unknown"
+
+
+def _domain_info() -> dict:
+    """Best-effort host / domain-join facts.
+
+    Owner SIDs that belong to a domain account only resolve via
+    ``LookupAccountSid`` when the box can reach the domain — so a machine
+    that is *not* domain-joined (or a service running as a local account)
+    is the usual reason owners stay "(Bilinmiyor)" after a rescan. Surfacing
+    this here turns a multi-round log chase into a one-glance answer.
+    """
+    info: dict[str, Any] = {
+        "hostname": socket.gethostname(),
+        "fqdn": socket.getfqdn(),
+        "platform": platform.platform(),
+        "is_windows": os.name == "nt",
+        "process_user": os.environ.get("USERNAME") or os.environ.get("USER"),
+    }
+    user_domain = os.environ.get("USERDOMAIN")
+    dns_domain = os.environ.get("USERDNSDOMAIN")
+    computer = os.environ.get("COMPUTERNAME")
+    info["user_domain"] = user_domain
+    info["dns_domain"] = dns_domain
+    # Heuristic: a DNS domain that differs from the machine name means the
+    # logon session is domain-backed. Absence is the red flag for owner resolve.
+    if dns_domain:
+        info["domain_joined"] = True
+    elif user_domain and computer and user_domain.upper() != computer.upper():
+        info["domain_joined"] = True
+    elif info["is_windows"]:
+        info["domain_joined"] = False
+    else:
+        info["domain_joined"] = None  # not applicable off Windows
+    return info
+
+
+def _tail(path: str, n_lines: int) -> tuple[str, dict]:
+    """Return the last ``n_lines`` of a text file plus small metadata.
+
+    Reads a bounded window from the end so a multi-GB log never loads whole.
+    """
+    meta: dict[str, Any] = {"path": path, "exists": False}
+    if not path or not os.path.exists(path):
+        return "", meta
+    meta["exists"] = True
+    size = os.path.getsize(path)
+    meta["size_bytes"] = size
+    window = min(size, max(n_lines * 400, 65536))
+    try:
+        with open(path, "rb") as handle:
+            if size > window:
+                handle.seek(size - window)
+            chunk = handle.read()
+    except OSError as exc:
+        meta["error"] = str(exc)
+        return "", meta
+    text = chunk.decode("utf-8", errors="replace")
+    lines = text.splitlines()
+    if size > window and lines:
+        lines = lines[1:]  # drop the partial first line
+    tail = lines[-n_lines:]
+    meta["returned_lines"] = len(tail)
+    return "\n".join(tail), meta
+
+
+def _file_size(path: str) -> Optional[int]:
+    try:
+        return os.path.getsize(path)
+    except OSError:
+        return None
+
+
+def _fmt_size(num: Optional[int]) -> str:
+    if num is None:
+        return "n/a"
+    value = float(num)
+    for unit in ("B", "KB", "MB", "GB", "TB"):
+        if value < 1024 or unit == "TB":
+            return f"{value:.1f} {unit}" if unit != "B" else f"{int(value)} B"
+        value /= 1024
+    return f"{value:.1f} TB"
+
+
+# --------------------------------------------------------------------------
+# Database section — strictly read-only, every block guarded so a missing
+# table or odd customer state still yields a useful bundle.
+# --------------------------------------------------------------------------
+def _collect_database(db, db_path: str, redact: bool) -> dict:
+    out: dict[str, Any] = {"errors": []}
+
+    out["db_size_bytes"] = _file_size(db_path)
+    out["wal_size_bytes"] = _file_size(db_path + "-wal")
+    out["shm_size_bytes"] = _file_size(db_path + "-shm")
+
+    # Per-source scan state + owner-resolution ratio.
+    sources_report: list[dict] = []
+    try:
+        with db.get_read_cursor() as cur:
+            cur.execute(
+                "SELECT id, name, unc_path, enabled FROM sources ORDER BY id"
+            )
+            sources = [dict(r) for r in cur.fetchall()]
+        for src in sources:
+            entry: dict[str, Any] = {
+                "id": src["id"],
+                "name": src["name"],
+                "enabled": bool(src["enabled"]),
+            }
+            if not redact:
+                entry["unc_path"] = src["unc_path"]
+            try:
+                with db.get_read_cursor() as cur:
+                    cur.execute(
+                        "SELECT id, status, current_phase, started_at, "
+                        "completed_at, total_files, errors FROM scan_runs "
+                        "WHERE source_id=? ORDER BY started_at DESC LIMIT 1",
+                        (src["id"],),
+                    )
+                    scan = cur.fetchone()
+                if scan:
+                    scan = dict(scan)
+                    entry["latest_scan"] = {
+                        "id": scan["id"],
+                        "status": scan["status"],
+                        "phase": scan.get("current_phase"),
+                        "started_at": scan["started_at"],
+                        "completed_at": scan["completed_at"],
+                        "total_files": scan["total_files"],
+                        "errors": scan["errors"],
+                    }
+                    # Owner-resolution ratio for that scan (single pass).
+                    with db.get_read_cursor() as cur:
+                        cur.execute(
+                            "SELECT COUNT(*) AS total, "
+                            "SUM(CASE WHEN owner IS NULL OR owner='' "
+                            "THEN 1 ELSE 0 END) AS unresolved "
+                            "FROM scanned_files WHERE scan_id=?",
+                            (scan["id"],),
+                        )
+                        row = dict(cur.fetchone())
+                    total = row["total"] or 0
+                    unresolved = row["unresolved"] or 0
+                    entry["owner_resolution"] = {
+                        "rows": total,
+                        "unresolved": unresolved,
+                        "resolved": total - unresolved,
+                        "unresolved_pct": round(100.0 * unresolved / total, 1)
+                        if total else None,
+                    }
+                    if not redact and (total - unresolved) > 0:
+                        with db.get_read_cursor() as cur:
+                            cur.execute(
+                                "SELECT owner, COUNT(*) AS c FROM scanned_files "
+                                "WHERE scan_id=? AND owner IS NOT NULL "
+                                "AND owner<>'' GROUP BY owner "
+                                "ORDER BY c DESC LIMIT 10",
+                                (scan["id"],),
+                            )
+                            entry["owner_resolution"]["top_owners"] = [
+                                dict(r) for r in cur.fetchall()
+                            ]
+                else:
+                    entry["latest_scan"] = None
+            except Exception as exc:  # noqa: BLE001 - diag must not abort
+                entry["scan_error"] = str(exc)
+            sources_report.append(entry)
+    except Exception as exc:  # noqa: BLE001
+        out["errors"].append(f"sources: {exc}")
+    out["sources"] = sources_report
+
+    # PII findings count (the page that hung in #8/#9 triage).
+    try:
+        with db.get_read_cursor() as cur:
+            cur.execute("SELECT COUNT(*) AS c FROM pii_findings")
+            out["pii_findings_count"] = dict(cur.fetchone())["c"]
+    except Exception as exc:  # noqa: BLE001
+        out["pii_findings_count"] = None
+        out["errors"].append(f"pii_findings: {exc}")
+
+    # Lightweight table inventory.
+    try:
+        with db.get_read_cursor() as cur:
+            cur.execute(
+                "SELECT name FROM sqlite_master WHERE type='table' "
+                "AND name NOT LIKE 'sqlite_%' ORDER BY name"
+            )
+            out["tables"] = [r["name"] for r in cur.fetchall()]
+    except Exception as exc:  # noqa: BLE001
+        out["errors"].append(f"tables: {exc}")
+
+    return out
+
+
+def collect(db, config: dict, *, log_lines: int = 200, redact: bool = True,
+            base_dir: Optional[str] = None) -> dict:
+    """Gather the full diagnostics snapshot. Read-only; never writes."""
+    base_dir = base_dir or _REPO_ROOT
+    general = (config.get("general") or {}) if isinstance(config, dict) else {}
+    db_conf = (config.get("database") or {}) if isinstance(config, dict) else {}
+    db_path = os.path.abspath(db_conf.get("path", "data/file_activity.db"))
+    log_file = os.path.abspath(general.get("log_file", "logs/file_activity.log"))
+
+    log_text, log_meta = _tail(log_file, log_lines)
+
+    scanner_cfg = (config.get("scanner") or {}) if isinstance(config, dict) else {}
+    parquet_cfg = scanner_cfg.get("parquet_staging") or {}
+    audit_cfg = (config.get("audit") or {}) if isinstance(config, dict) else {}
+    key_flags = {
+        "scanner.read_owner": scanner_cfg.get("read_owner", "(absent -> code default False)"),
+        "scanner.parquet_staging.enabled": parquet_cfg.get(
+            "enabled", "(absent -> code default True)"
+        ),
+        "audit.chain_enabled": audit_cfg.get("chain_enabled", False),
+        "database.path": db_path,
+    }
+
+    return {
+        "meta": {
+            "generated_at": datetime.now(timezone.utc).isoformat(),
+            "version": _read_version(base_dir),
+            "redacted": redact,
+            "tool": "collect_diag",
+        },
+        "environment": _domain_info(),
+        "key_flags": key_flags,
+        "config": _redact_config(config) if isinstance(config, dict) else {},
+        "log": {**log_meta, "tail": log_text},
+        "database": _collect_database(db, db_path, redact),
+    }
+
+
+# --------------------------------------------------------------------------
+# Rendering
+# --------------------------------------------------------------------------
+def render_markdown(diag: dict) -> str:
+    meta = diag.get("meta", {})
+    env = diag.get("environment", {})
+    flags = diag.get("key_flags", {})
+    dbd = diag.get("database", {})
+    lines: list[str] = []
+    add = lines.append
+
+    add(f"# FILE ACTIVITY — Diagnostics bundle")
+    add("")
+    add(f"- Generated: `{meta.get('generated_at')}`")
+    add(f"- Version: `{meta.get('version')}`")
+    add(f"- Redacted: `{meta.get('redacted')}`")
+    add("")
+
+    add("## Environment")
+    add("")
+    add(f"- Host: `{env.get('hostname')}` (fqdn `{env.get('fqdn')}`)")
+    add(f"- Platform: `{env.get('platform')}`")
+    add(f"- Process user: `{env.get('process_user')}` / domain `{env.get('user_domain')}`")
+    joined = env.get("domain_joined")
+    joined_str = {True: "YES", False: "NO (!)", None: "n/a"}.get(joined, str(joined))
+    add(f"- **Domain-joined: {joined_str}**  (owner SID resolution needs domain reach)")
+    add("")
+
+    add("## Key config flags")
+    add("")
+    for key, value in flags.items():
+        add(f"- `{key}` = `{value}`")
+    add("")
+
+    add("## Database")
+    add("")
+    add(f"- DB size: {_fmt_size(dbd.get('db_size_bytes'))}")
+    wal = dbd.get("wal_size_bytes")
+    wal_note = "  ← **>5 GB sustained = WAL bloat, investigate readers**" if (wal or 0) > 5 * 1024**3 else ""
+    add(f"- WAL size: {_fmt_size(wal)}{wal_note}")
+    add(f"- PII findings: {dbd.get('pii_findings_count')}")
+    add("")
+    add("### Sources")
+    add("")
+    for src in dbd.get("sources", []):
+        add(f"#### {src.get('name')} (id {src.get('id')}, enabled={src.get('enabled')})")
+        scan = src.get("latest_scan")
+        if not scan:
+            add("- No scan runs.")
+            add("")
+            continue
+        add(f"- Latest scan: id `{scan['id']}`, status `{scan['status']}`, "
+            f"phase `{scan.get('phase')}`")
+        add(f"- Started `{scan['started_at']}` / completed `{scan['completed_at']}`")
+        add(f"- total_files `{scan['total_files']}`, errors `{scan['errors']}`")
+        owner = src.get("owner_resolution")
+        if owner:
+            add(f"- **Owner resolution: {owner['resolved']}/{owner['rows']} resolved, "
+                f"{owner['unresolved']} unresolved ({owner['unresolved_pct']}%)**")
+            tops = owner.get("top_owners")
+            if tops:
+                pretty = ", ".join(f"{t['owner']} ({t['c']})" for t in tops[:5])
+                add(f"- Top owners: {pretty}")
+        if src.get("scan_error"):
+            add(f"- scan_error: `{src['scan_error']}`")
+        add("")
+
+    if dbd.get("errors"):
+        add("### DB collection errors")
+        add("")
+        for err in dbd["errors"]:
+            add(f"- `{err}`")
+        add("")
+
+    add("## Config (sanitized)")
+    add("")
+    add("```yaml")
+    add(_dump_yaml(diag.get("config", {})))
+    add("```")
+    add("")
+
+    log = diag.get("log", {})
+    add(f"## Log tail (`{log.get('path')}`, {log.get('returned_lines', 0)} lines)")
+    add("")
+    add("```")
+    add(log.get("tail", "") or "(log not found)")
+    add("```")
+    return "\n".join(lines)
+
+
+def _dump_yaml(obj: Any) -> str:
+    try:
+        import yaml  # type: ignore
+        return yaml.safe_dump(obj, allow_unicode=True, sort_keys=False).strip()
+    except Exception:  # noqa: BLE001 - fall back to JSON if pyyaml missing
+        return json.dumps(obj, indent=2, ensure_ascii=False, default=str)
+
+
+# --------------------------------------------------------------------------
+# Bundle + upload
+# --------------------------------------------------------------------------
+def build_bundle_bytes(diag: dict, markdown: str) -> bytes:
+    """Build the diagnostics zip in memory (used by the dashboard endpoint)."""
+    import io
+
+    buffer = io.BytesIO()
+    with zipfile.ZipFile(buffer, "w", zipfile.ZIP_DEFLATED) as zf:
+        zf.writestr("report.md", markdown)
+        zf.writestr("diag.json",
+                    json.dumps(diag, indent=2, ensure_ascii=False, default=str))
+        log_tail = (diag.get("log") or {}).get("tail", "")
+        if log_tail:
+            zf.writestr("log_tail.txt", log_tail)
+    return buffer.getvalue()
+
+
+def build_bundle(diag: dict, markdown: str, out_dir: str) -> Path:
+    os.makedirs(out_dir, exist_ok=True)
+    stamp = datetime.now().strftime("%Y%m%d-%H%M%S")
+    bundle = Path(out_dir) / f"diag-{stamp}.zip"
+    bundle.write_bytes(build_bundle_bytes(diag, markdown))
+    return bundle
+
+
+def upload_to_github(markdown: str, repo: str, token: str, *,
+                     title: Optional[str] = None,
+                     label: str = "diagnostics") -> str:
+    """POST the report as a GitHub issue. Returns the issue URL.
+
+    Uses only the standard library so the operator box needs no extra deps.
+    """
+    import urllib.request
+
+    if not repo or not token:
+        raise ValueError("github repo and token are required for --upload")
+    title = title or f"Diagnostics {datetime.now().strftime('%Y-%m-%d %H:%M')}"
+    body = markdown
+    if len(body) > 60000:  # GitHub issue body cap is ~65k
+        body = body[:60000] + "\n\n*(truncated — full bundle in the zip)*"
+    payload = json.dumps({
+        "title": title,
+        "body": body,
+        "labels": [label] if label else [],
+    }).encode("utf-8")
+    request = urllib.request.Request(
+        f"https://api.github.com/repos/{repo}/issues",
+        data=payload,
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Accept": "application/vnd.github+json",
+            "Content-Type": "application/json",
+            "User-Agent": "file-activity-diag",
+        },
+        method="POST",
+    )
+    with urllib.request.urlopen(request, timeout=30) as resp:  # noqa: S310 - fixed host
+        data = json.loads(resp.read().decode("utf-8"))
+    return data.get("html_url", "")
+
+
+# --------------------------------------------------------------------------
+# Standalone entry point
+# --------------------------------------------------------------------------
+def _build_db_and_config(config_path: str):
+    """Construct config + connected Database the same way main.py does."""
+    from src.utils.config_loader import load_config
+    from src.storage.database import Database
+
+    config = load_config(config_path)
+    db_conf = config.get("database", {}) or {}
+    db_conf["_config_path"] = config_path
+    db = Database(db_conf)
+    db.connect()
+    return db, config
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    parser = argparse.ArgumentParser(description="Collect a diagnostics bundle.")
+    parser.add_argument("--config", "-c", default="config.yaml",
+                        help="Path to config.yaml")
+    parser.add_argument("--out", default=None,
+                        help="Output dir for the zip (default: <data>/diagnostics)")
+    parser.add_argument("--lines", type=int, default=200,
+                        help="Log tail line count (default 200)")
+    parser.add_argument("--no-redact", action="store_true",
+                        help="Include sample owner names / source UNC paths")
+    parser.add_argument("--upload", action="store_true",
+                        help="Also open a GitHub issue with the report")
+    parser.add_argument("--repo", default=None,
+                        help="owner/name (default: telemetry.github.repo)")
+    parser.add_argument("--token", default=None,
+                        help="GitHub token (default: $FILEACTIVITY_TELEMETRY_TOKEN)")
+    args = parser.parse_args(argv)
+
+    db, config = _build_db_and_config(args.config)
+    try:
+        diag = collect(db, config, log_lines=args.lines, redact=not args.no_redact)
+    finally:
+        try:
+            db.close()
+        except Exception:  # noqa: BLE001
+            pass
+
+    markdown = render_markdown(diag)
+    db_conf = config.get("database", {}) or {}
+    data_dir = os.path.dirname(os.path.abspath(db_conf.get("path", "data/file_activity.db")))
+    out_dir = args.out or os.path.join(data_dir, "diagnostics")
+    bundle = build_bundle(diag, markdown, out_dir)
+    print(f"[OK] Diagnostics bundle written: {bundle}")
+
+    if args.upload:
+        repo, token, label, scrub = resolve_github(config, args.repo, args.token)
+        if not repo or not token:
+            print("[WARN] --upload skipped: set telemetry.github.repo + "
+                  "$FILEACTIVITY_TELEMETRY_TOKEN (or --repo/--token)",
+                  file=sys.stderr)
+            return 0
+        body = _scrub_paths(markdown) if scrub else markdown
+        try:
+            url = upload_to_github(body, repo, token, label=label)
+            print(f"[OK] Posted GitHub issue: {url}")
+        except Exception as exc:  # noqa: BLE001
+            print(f"[ERROR] GitHub upload failed: {exc}", file=sys.stderr)
+            return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/config_migrations.yaml
+++ b/scripts/config_migrations.yaml
@@ -21,9 +21,18 @@ migrations:
   # against the writer pool on multi-million-row scans. Customer's WAL
   # leaked to 13+ GB and the scan kept hitting "database is locked".
   # New default is the executemany path which uses busy_timeout + retry.
+  #
+  # set_if_missing: the CODE-side default (src/storage/staging.py:
+  # ``bool(ps_cfg.get("enabled", True))``) is True, so a preserved config
+  # that never carried this key runs the unsafe path silently — and a
+  # plain flip rule no-ops on an absent key. set_if_missing INSERTS
+  # ``enabled: false`` so update.cmd reaches boxes whose config predates
+  # the key (the #8/#9 customer: dashboard reports stuck because the live
+  # parquet ingest locked the DB during a scan).
   - path: "scanner.parquet_staging.enabled"
     old_default: true
     new_default: false
+    set_if_missing: true
     reason: "PR #174 — parquet_staging caused WAL contention + 'database is locked' on multi-million-row scans"
     pr: "#174"
 
@@ -64,3 +73,23 @@ migrations:
     new_default: true
     reason: "operator decision — orphaned-SID report on by default for domain-joined fleets (resolves via Windows LookupAccountSid; no LDAP config needed)"
     pr: "#56"
+
+  # Issue #1 — owner shows "(Bilinmiyor)" on MFT scans. The MFT backend
+  # is path-only; owner is resolved in the post-walk size-enrich pass
+  # (#253) ONLY when scanner.read_owner is on. The code-side default is
+  # False (src/scanner/size_enricher.py, src/utils/config_loader.py) while
+  # the shipped config.yaml carries ``true`` — so a PRESERVED config that
+  # never had the key collects no owners on a rescan, and the dashboard
+  # stays "(Bilinmiyor)" forever. This is a PURE insert-when-absent rule:
+  # old_default == new_default == true, so a present value is never
+  # rewritten — an operator who explicitly set ``read_owner: false`` keeps
+  # it off (current != old_default -> skipped), and a present ``true`` is a
+  # no-op (current == new_default -> skipped). Only an ABSENT key triggers
+  # the insert. NOTE: this just ENABLES collection; owners still populate
+  # only after a completed rescan.
+  - path: "scanner.read_owner"
+    old_default: true
+    new_default: true
+    set_if_missing: true
+    reason: "issue #1 — ensure owner collection is on so MFT rescans stop showing (Bilinmiyor); preserved configs missing the key fall back to code-default False"
+    pr: "#1"

--- a/scripts/migrate_config.py
+++ b/scripts/migrate_config.py
@@ -38,7 +38,7 @@ import shutil
 import sys
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Iterator
+from typing import Any, Iterator, Optional
 
 import yaml
 
@@ -98,20 +98,23 @@ def _indent_of(line: str) -> int:
     return len(line) - len(line.lstrip(" "))
 
 
-def _iter_leaf_assignments(
+def _iter_key_lines(
     lines: list[str],
-) -> Iterator[tuple[int, str, list[str]]]:
-    """Yield ``(line_index, leaf_key, dotted_path_parts)`` for every line
-    that looks like a ``key: value`` assignment.
+) -> Iterator[tuple[int, str, list[str], bool, int]]:
+    """Yield ``(line_index, key, dotted_path_parts, is_container, indent)``
+    for every line that looks like a ``key:`` or ``key: value`` mapping
+    entry.
 
     Tracks an indent stack so nested keys resolve to their full path.
-    Comments and blank lines are skipped. Sequence members (``- ...``)
-    are ignored — we never migrate inside a list. List headers (``key:``
-    with no value) push the key onto the path for the children.
+    Comments, blank lines and sequence members (``- ...``) are skipped —
+    we never traverse into a list. A line whose value is empty is a
+    *container* header (``is_container=True``); it is both pushed onto the
+    path stack (so its children resolve) and emitted (so callers can
+    locate the header line when inserting a missing nested key).
     """
     # Stack of (indent, key) pairs; deepest entry is the current parent.
     stack: list[tuple[int, str]] = []
-    leaf_pattern = re.compile(
+    key_pattern = re.compile(
         r"^(?P<indent> *)(?P<key>[A-Za-z_][\w\-]*)\s*:\s*(?P<rest>.*)$"
     )
     for idx, raw in enumerate(lines):
@@ -122,7 +125,7 @@ def _iter_leaf_assignments(
         # We don't traverse into list items
         if stripped.startswith("- "):
             continue
-        m = leaf_pattern.match(line)
+        m = key_pattern.match(line)
         if not m:
             continue
         indent = len(m.group("indent"))
@@ -134,12 +137,11 @@ def _iter_leaf_assignments(
         # Strip trailing comment to detect "container" vs "leaf"
         value_part = rest.split("#", 1)[0].strip()
         path_parts = [k for _, k in stack] + [key]
-        if value_part == "":
-            # Container — push onto stack for children, do not emit
+        is_container = value_part == ""
+        if is_container:
+            # Push onto stack so children resolve to their full path.
             stack.append((indent, key))
-            continue
-        # Leaf assignment — emit
-        yield idx, key, path_parts
+        yield idx, key, path_parts, is_container, indent
 
 
 def _format_scalar(value: Any) -> str:
@@ -197,6 +199,110 @@ def _replace_value_on_line(line: str, new_value: Any) -> str:
 
 
 # ---------------------------------------------------------------------------
+# Text-level insertion (for ``set_if_missing`` rules — adds an absent key)
+# ---------------------------------------------------------------------------
+
+
+def _render_block(suffix_parts: list[str], value: Any, base_indent: int) -> list[str]:
+    """Render ``suffix_parts`` as a nested YAML block whose deepest leaf is
+    assigned ``value``. Each level indents two spaces deeper than its
+    parent, starting at ``base_indent``. Every returned line ends in
+    ``\\n``. Example: ``(["parquet_staging", "enabled"], False, 2)`` →
+    ``["  parquet_staging:\\n", "    enabled: false\\n"]``."""
+    out: list[str] = []
+    last = len(suffix_parts) - 1
+    for depth, key in enumerate(suffix_parts):
+        pad = " " * (base_indent + depth * 2)
+        if depth == last:
+            out.append(f"{pad}{key}: {_format_scalar(value)}\n")
+        else:
+            out.append(f"{pad}{key}:\n")
+    return out
+
+
+def _find_deepest_container_header(
+    lines: list[str], container_path: list[str]
+) -> Optional[tuple[int, int]]:
+    """Return ``(line_index, indent)`` of the block header whose dotted path
+    equals ``container_path``, or ``None`` when no such header exists (e.g.
+    the mapping was written flow-style: ``scanner: {parquet_staging: ...}``)."""
+    for idx, _key, path_parts, is_container, indent in _iter_key_lines(lines):
+        if is_container and path_parts == container_path:
+            return idx, indent
+    return None
+
+
+def _detect_child_indent(
+    lines: list[str], container_path: list[str], header_indent: int
+) -> int:
+    """Indent used by the existing direct children of ``container_path``;
+    falls back to ``header_indent + 2`` when the container has none yet."""
+    depth = len(container_path)
+    for _idx, _key, path_parts, _is_c, indent in _iter_key_lines(lines):
+        if len(path_parts) == depth + 1 and path_parts[:depth] == container_path:
+            return indent
+    return header_indent + 2
+
+
+def _plan_insertion(
+    lines: list[str], doc: Any, path: str, value: Any
+) -> tuple[int, list[str]]:
+    """Plan a comment-preserving insertion of ``path: value``.
+
+    Returns ``(insert_index, rendered_lines)``: splice ``rendered_lines``
+    in *before* ``lines[insert_index]`` (``insert_index == len(lines)``
+    means append at EOF). Any missing intermediate containers along the
+    dotted path are created.
+
+    Strategy: walk the path against the parsed ``doc`` to find the deepest
+    ancestor that already exists as a mapping, then insert the remaining
+    suffix right after that ancestor's block header (so it lands among the
+    ancestor's children at the file's own indent). When no ancestor
+    exists, append the whole block at top level.
+
+    Raises ``ValueError`` when an existing ancestor is a scalar rather than
+    a mapping (a "non-canonical" config we refuse to guess at), or when an
+    ancestor is present in the parse but not locatable as a block header.
+    """
+    parts = path.split(".")
+    cur = doc if isinstance(doc, dict) else {}
+    container_path: list[str] = []
+    for p in parts[:-1]:
+        if isinstance(cur, dict) and p in cur:
+            nxt = cur[p]
+            if isinstance(nxt, dict):
+                cur = nxt
+                container_path.append(p)
+            elif nxt is None:
+                # Empty header (``key:`` with no children yet): insertable,
+                # but we cannot traverse deeper — the rest is all missing.
+                container_path.append(p)
+                break
+            else:
+                raise ValueError(
+                    f"ancestor {'.'.join(container_path + [p])!r} is a scalar; "
+                    f"refusing to insert nested key {path!r}"
+                )
+        else:
+            break
+
+    suffix = parts[len(container_path):]
+    if not container_path:
+        # Nothing on the path exists — append a fresh top-level block.
+        return len(lines), _render_block(suffix, value, 0)
+
+    header = _find_deepest_container_header(lines, container_path)
+    if header is None:
+        raise ValueError(
+            f"container {'.'.join(container_path)!r} is present in the parse "
+            f"but has no block header (flow style?); refusing to insert {path!r}"
+        )
+    header_idx, header_indent = header
+    child_indent = _detect_child_indent(lines, container_path, header_indent)
+    return header_idx + 1, _render_block(suffix, value, child_indent)
+
+
+# ---------------------------------------------------------------------------
 # Driver
 # ---------------------------------------------------------------------------
 
@@ -204,7 +310,7 @@ def _replace_value_on_line(line: str, new_value: Any) -> str:
 class MigrationResult:
     def __init__(self, path: str, action: str, detail: str = ""):
         self.path = path
-        self.action = action  # "applied" | "skipped" | "missing" | "error"
+        self.action = action  # applied | inserted | skipped | missing | error
         self.detail = detail
 
     def __repr__(self) -> str:
@@ -241,19 +347,48 @@ def migrate(
         return results
 
     # Decide per-rule whether to apply.
-    to_apply: list[tuple[dict, int]] = []  # (rule, line_index)
+    to_apply: list[tuple[dict, int]] = []  # (rule, line_index) — value rewrites
+    to_insert: list[dict] = []  # rules whose absent key we insert
     lines = text.splitlines(keepends=True)
 
     # Build an index of leaf assignments keyed by dotted path.
     leaf_lookup: dict[str, list[int]] = {}
-    for line_idx, _key, path_parts in _iter_leaf_assignments(lines):
-        leaf_lookup.setdefault(".".join(path_parts), []).append(line_idx)
+    for line_idx, _key, path_parts, is_container, _indent in _iter_key_lines(lines):
+        if not is_container:
+            leaf_lookup.setdefault(".".join(path_parts), []).append(line_idx)
 
     for rule in rules:
         path = rule["path"]
         found, current = _navigate(doc, path)
         if not found:
-            results.append(MigrationResult(path, "missing", "key not present"))
+            # Absent key. A plain flip rule no-ops here ("missing"). A
+            # ``set_if_missing`` rule INSERTS new_default, because for those
+            # keys the code-side default is the unsafe value — so an absent
+            # key means the customer silently runs what we shipped a default
+            # to avoid (e.g. parquet_staging.enabled defaults True in code).
+            if rule.get("set_if_missing"):
+                # Validate now (against the original parse) so a
+                # non-canonical config is reported as "error" and dry-run
+                # reports "inserted"; the real splice is re-planned later.
+                try:
+                    _plan_insertion(lines, doc, path, rule["new_default"])
+                except ValueError as e:
+                    results.append(MigrationResult(path, "error", str(e)))
+                    continue
+                to_insert.append(rule)
+                results.append(MigrationResult(
+                    path, "inserted", f"absent -> {rule['new_default']!r}",
+                ))
+            else:
+                results.append(MigrationResult(path, "missing", "key not present"))
+            continue
+        if current == rule["new_default"]:
+            # Already at the target value — nothing to do (and don't write a
+            # needless backup). Also makes a set_if_missing rule whose
+            # old_default == new_default a pure insert-when-absent.
+            results.append(MigrationResult(
+                path, "skipped", f"already at new_default={rule['new_default']!r}",
+            ))
             continue
         if current != rule["old_default"]:
             results.append(MigrationResult(
@@ -274,10 +409,12 @@ def migrate(
             f"{current!r} -> {rule['new_default']!r}",
         ))
 
-    if not to_apply or dry_run:
+    if (not to_apply and not to_insert) or dry_run:
         return results
 
-    # Apply edits.
+    # Apply edits. Value rewrites first: each rewrites one line in place so
+    # the line count is preserved, which keeps the precomputed insertion
+    # indices valid.
     new_lines = list(lines)
     for rule, line_idx in to_apply:
         try:
@@ -291,18 +428,44 @@ def migrate(
                     r_existing.detail = f"line rewrite failed: {e}"
             return results
 
+    # Then insertions. Re-plan each against the current (already-edited)
+    # text so that several inserts which share a missing ancestor stack
+    # under a single created block instead of producing duplicate
+    # top-level keys (e.g. two scanner.* keys into a config with no
+    # ``scanner:`` block at all).
+    for rule in to_insert:
+        cur_text = "".join(new_lines)
+        try:
+            cur_doc = yaml.safe_load(cur_text) or {}
+            insert_idx, rendered = _plan_insertion(
+                new_lines, cur_doc, rule["path"], rule["new_default"]
+            )
+        except (ValueError, yaml.YAMLError) as e:
+            for r_existing in results:
+                if r_existing.path == rule["path"]:
+                    r_existing.action = "error"
+                    r_existing.detail = f"insertion failed: {e}"
+            return results
+        if insert_idx >= len(new_lines):
+            if new_lines and not new_lines[-1].endswith("\n"):
+                new_lines[-1] = new_lines[-1] + "\n"
+            new_lines.extend(rendered)
+        else:
+            new_lines[insert_idx:insert_idx] = rendered
+
     new_text = "".join(new_lines)
 
-    # Verify the result still parses AND the new values are present.
+    # Verify the result still parses AND every changed value is present.
+    changed_rules = [r for r, _ in to_apply] + list(to_insert)
     try:
         new_doc = yaml.safe_load(new_text) or {}
     except yaml.YAMLError as e:
         for r in results:
-            if r.action == "applied":
+            if r.action in ("applied", "inserted"):
                 r.action = "error"
                 r.detail = f"post-edit parse failed: {e}"
         return results
-    for rule, _line_idx in to_apply:
+    for rule in changed_rules:
         _, new_val = _navigate(new_doc, rule["path"])
         if new_val != rule["new_default"]:
             for r_existing in results:
@@ -357,7 +520,7 @@ def main(argv: list[str] | None = None) -> int:
     rules = load_rules(Path(args.rules))
     results = migrate(Path(args.config), rules, dry_run=args.dry_run)
 
-    applied = [r for r in results if r.action == "applied"]
+    changed = [r for r in results if r.action in ("applied", "inserted")]
     errors = [r for r in results if r.action == "error"]
 
     for r in results:
@@ -367,9 +530,9 @@ def main(argv: list[str] | None = None) -> int:
     if errors:
         logger.error("config migration FAILED — %d rule(s) errored", len(errors))
         return 1
-    if applied:
-        verb = "WOULD APPLY" if args.dry_run else "applied"
-        logger.info("config migration: %s %d rule(s)", verb, len(applied))
+    if changed:
+        verb = "WOULD CHANGE" if args.dry_run else "changed"
+        logger.info("config migration: %s %d rule(s)", verb, len(changed))
     else:
         logger.info("config migration: no changes needed")
     return 0

--- a/src/dashboard/api.py
+++ b/src/dashboard/api.py
@@ -4254,6 +4254,34 @@ def create_app(db, config, analytics=None, ad_lookup=None, email_notifier=None,
 
     # --- SYSTEM API ---
 
+    @app.get("/api/system/diag-bundle")
+    def system_diag_bundle(lines: int = 200):
+        """Tanilama paketini (zip) indir: surum, ortam, config, log, DB sagligi.
+
+        Read-only: ``collect`` touches the DB only through ``get_read_cursor``
+        (Rule 6). Plain ``def`` so Starlette runs the blocking IO on the
+        thread pool (Rule 5). Secrets are always redacted and owner names /
+        UNC paths are omitted here — use ``fa.cmd diag --no-redact`` on the
+        box if those are needed.
+        """
+        from datetime import datetime
+        import io
+        from fastapi.responses import StreamingResponse
+        from scripts.collect_diag import (
+            build_bundle_bytes, collect, render_markdown,
+        )
+
+        diag_data = collect(db, config, log_lines=max(1, min(lines, 2000)),
+                            redact=True)
+        markdown = render_markdown(diag_data)
+        payload = build_bundle_bytes(diag_data, markdown)
+        filename = f"diag-{datetime.now().strftime('%Y%m%d-%H%M%S')}.zip"
+        return StreamingResponse(
+            io.BytesIO(payload),
+            media_type="application/zip",
+            headers={"Content-Disposition": f"attachment; filename={filename}"},
+        )
+
     @app.post("/api/system/open-folder")
     async def open_folder(request: Request):
         """Dizini Windows Explorer'da ac (yalnizca yerel istemci icin)."""

--- a/src/dashboard/api.py
+++ b/src/dashboard/api.py
@@ -1882,6 +1882,7 @@ def create_app(db, config, analytics=None, ad_lookup=None, email_notifier=None,
         min_bytes: int = 0,
         max_bytes: Optional[int] = None,
         owner: str = "",
+        format: str = "xlsx",
     ):
         """XLSX export of a drilldown filter result.
 
@@ -1916,27 +1917,27 @@ def create_app(db, config, analytics=None, ad_lookup=None, email_notifier=None,
         if not scan_id:
             raise HTTPException(404, "Tarama verisi bulunamadi")
 
-        MAX_ROWS = 100_000
-
+        # Resolve the filter-specific runner + positional args once, so the
+        # XLSX (capped) and CSV (uncapped stream) paths share one lookup.
         if filter_type == "frequency":
             run = _run_drilldown(analytics.get_files_by_frequency,
                                  db.get_files_by_frequency)
-            result = run(src.id, scan_id, min_days, max_days, MAX_ROWS, 0)
+            f_args = (min_days, max_days)
             sheet_title = f"freq_{min_days}-{max_days or 'inf'}"
         elif filter_type == "type":
             run = _run_drilldown(analytics.get_files_by_extension,
                                  db.get_files_by_extension)
-            result = run(src.id, scan_id, extension, MAX_ROWS, 0)
+            f_args = (extension,)
             sheet_title = f"type_{extension}" if extension else "type_all"
         elif filter_type == "size":
             run = _run_drilldown(analytics.get_files_by_size_range,
                                  db.get_files_by_size_range)
-            result = run(src.id, scan_id, min_bytes, max_bytes, MAX_ROWS, 0)
+            f_args = (min_bytes, max_bytes)
             sheet_title = f"size_{min_bytes}-{max_bytes or 'inf'}"
         elif filter_type == "owner":
             run = _run_drilldown(analytics.get_files_by_owner,
                                  db.get_files_by_owner)
-            result = run(src.id, scan_id, owner, MAX_ROWS, 0)
+            f_args = (owner,)
             sheet_title = (f"owner_{owner}" if owner else "owner_all")[:31]
         else:
             raise HTTPException(
@@ -1945,6 +1946,58 @@ def create_app(db, config, analytics=None, ad_lookup=None, email_notifier=None,
                 "Gecerli: frequency, type, size, owner",
             )
 
+        ts = datetime.now().strftime("%Y%m%d_%H%M%S")
+
+        # CSV (issue #122 / #225 R-2): stream EVERY matching row, no 100k cap.
+        # Pages through the same tested runner so there is no per-filter SQL to
+        # keep in sync; only one page is held in memory at a time.
+        if (format or "").lower() == "csv":
+            from src.utils.xlsx_writer import stream_csv
+            columns = [
+                {"key": "file_path", "header": "file_path", "width": 60},
+                {"key": "file_name", "header": "file_name", "width": 30},
+                {"key": "owner", "header": "owner", "width": 24},
+                {"key": "file_size", "header": "file_size", "width": 14},
+                {"key": "last_modify_time", "header": "last_modify_time", "width": 22},
+                {"key": "last_access_time", "header": "last_access_time", "width": 22},
+            ]
+
+            def _all_rows():
+                PAGE = 100_000
+                offset = 0
+                while True:
+                    res = run(src.id, scan_id, *f_args, PAGE, offset)
+                    chunk = res.get("files", []) or []
+                    if not chunk:
+                        break
+                    for f in chunk:
+                        yield {
+                            "file_path": f.get("file_path", "") or "",
+                            "file_name": f.get("file_name", "") or "",
+                            "owner": f.get("owner", "") or "",
+                            "file_size": f.get("file_size", 0) or 0,
+                            "last_modify_time": f.get("last_modify_time", "") or "",
+                            "last_access_time": f.get("last_access_time", "") or "",
+                        }
+                    if len(chunk) < PAGE:
+                        break
+                    offset += PAGE
+
+            filename_csv = f"drilldown_{filter_type}_{src.name}_{ts}.csv"
+            return StreamingResponse(
+                stream_csv(_all_rows(), columns),
+                media_type="text/csv; charset=utf-8",
+                headers={
+                    "Content-Disposition": f'attachment; filename="{filename_csv}"',
+                    "X-Format-Fallback": "csv",
+                },
+            )
+
+        # XLSX (default) — Excel-friendly, capped at 100k. Larger result sets
+        # use the CSV button; the cap is intentional because openpyxl
+        # materialises the whole workbook in memory.
+        MAX_ROWS = 100_000
+        result = run(src.id, scan_id, *f_args, MAX_ROWS, 0)
         files = result.get("files", []) or []
 
         try:
@@ -1956,7 +2009,6 @@ def create_app(db, config, analytics=None, ad_lookup=None, email_notifier=None,
             logger.error("drilldown XLSX export error: %s", e)
             raise HTTPException(500, str(e))
 
-        ts = datetime.now().strftime("%Y%m%d_%H%M%S")
         filename = f"drilldown_{filter_type}_{src.name}_{ts}.xlsx"
         return StreamingResponse(
             BytesIO(data),
@@ -2077,18 +2129,22 @@ def create_app(db, config, analytics=None, ad_lookup=None, email_notifier=None,
         else:
             # Fallback to file ownership from scanned_files
             owners = []
+            used_source_id = source_id
             if source_id:
                 owners = db.get_file_owners_stats(source_id)
             else:
-                # Try all sources
+                # Try all sources; remember which one actually had a scan so
+                # the frontend drill-down targets the right source (#KullaniciAktivite).
                 sources = db.get_sources()
                 for s in sources:
                     sid = db.get_latest_scan_id(s.id)
                     if sid:
                         owners = db.get_file_owners_stats(s.id, sid)
+                        used_source_id = s.id
                         break
             return {
                 "source": "file_ownership",
+                "source_id": used_source_id,
                 "owners": owners,
                 "top_users": [],
                 "department_stats": [],

--- a/src/dashboard/static/index.html
+++ b/src/dashboard/static/index.html
@@ -787,7 +787,9 @@ body.sidebar-open { overflow: hidden; }
             <button class="btn btn-outline" onclick="loadDbStats()" style="font-size:12px">Istatistikler</button>
             <button class="btn btn-outline" onclick="cleanupOldScans()" style="font-size:12px;border-color:var(--warning);color:var(--warning)">Eski Taramalari Temizle</button>
             <button class="btn btn-outline" onclick="optimizeDb()" style="font-size:12px;border-color:var(--info);color:var(--info)">Optimize Et</button>
+            <button class="btn btn-outline" onclick="downloadDiagBundle(this)" style="font-size:12px;border-color:var(--accent);color:var(--accent)" title="Surum, ortam, config, log ve DB sagligini tek zip'te toplar — destek icin paylasin">Tanilama Paketi</button>
         </div>
+        <div style="margin-top:8px;font-size:11px;color:var(--text-muted)">Tanilama paketi: surum + ortam (domain durumu) + maskelenmis config + son log + tarama/sahip durumu. Sirlar maskelenir; sahip adlari/UNC yollari icin <code>fa.cmd diag --no-redact</code>.</div>
     </div>
 </div>
 
@@ -5735,6 +5737,15 @@ async function exportNamingReport(event) {
             signal,
             `naming-${sourceId}.xlsx`
         );
+    });
+}
+
+async function downloadDiagBundle(btn) {
+    // Tanilama paketi (zip) indir. fetchAndDownload auth/cookie davranisini
+    // export ile ayni sekilde ele alir; isim Content-Disposition'dan gelir.
+    await withButtonLoading(btn, async (signal) => {
+        const ts = new Date().toISOString().slice(0, 19).replace(/[:T]/g, '');
+        await fetchAndDownload(`${API}/system/diag-bundle`, signal, `diag-${ts}.zip`);
     });
 }
 

--- a/src/dashboard/static/index.html
+++ b/src/dashboard/static/index.html
@@ -4445,19 +4445,25 @@ async function loadUsers() {
             // Heatmap: empty
             _setHtmlSafe('users-heatmap', '<div style="padding:20px;color:var(--text-muted);font-size:12px">Event log verisi yok - heatmap kullanilamiyor</div>');
 
-            // Owner table with drill-down + archive button
+            // Owner table with drill-down + archive button. defaultSid prefers
+            // the source the backend actually aggregated owners from, so the
+            // drill-down hits the right scan even with multiple sources.
             const srcSelect = document.getElementById('freq-source') || document.getElementById('types-source') || document.getElementById('overview-source');
-            const defaultSid = srcSelect ? srcSelect.value : (sources.length ? sources[0].id : '');
+            const defaultSid = data.source_id || (srcSelect && srcSelect.value) || (sources.length ? sources[0].id : '');
             _setHtmlSafe('users-table', `
                 <thead><tr><th>Sahip</th><th>Dosya Sayisi</th><th>Toplam Boyut</th><th>Yuzde</th><th>Islem</th></tr></thead>
                 <tbody>${owners.length ? owners.map(o => {
                     const pct = totalSize > 0 ? ((o.total_size||0)/totalSize*100).toFixed(1) : '0';
-                    const ownerEsc = escapeHtml(o.owner || '');
-                    return `<tr class="clickable-row" onclick="drilldownOwner('${ownerEsc}', '${defaultSid}')">
+                    // owner is "DOMAIN\\user"; a raw backslash in a single-quoted
+                    // onclick JS string is swallowed (\\g -> g) so the lookup misses
+                    // and the file list comes back empty. Escape backslash + quote.
+                    const ownerJs = (o.owner || '').replace(/\\/g, '\\\\').replace(/'/g, "\\'");
+                    const sid = parseInt(defaultSid) || 0;
+                    return `<tr class="clickable-row" onclick="drilldownOwner('${ownerJs}', '${defaultSid}')">
                         <td><strong>${escapeHtml(o.owner || 'Bilinmiyor')}</strong></td>
                         <td>${formatNum(o.file_count)}</td><td>${formatSize(o.total_size)}</td>
                         <td><div style="display:flex;align-items:center;gap:8px"><div style="flex:1;background:var(--bg-primary);border-radius:3px;height:6px;overflow:hidden"><div style="width:${pct}%;height:100%;background:var(--accent);border-radius:3px"></div></div><span style="font-size:11px">${pct}%</span></div></td>
-                        <td style="display:flex;gap:4px"><button class="btn btn-sm btn-outline" onclick="event.stopPropagation();drilldownOwner('${ownerEsc}', '${defaultSid}')">Dosyalar</button><button class="btn btn-sm btn-danger" onclick="event.stopPropagation();showDrilldown('Arsivle: ${ownerEsc}', '/drilldown/owner/${defaultSid}?owner=${encodeURIComponent(o.owner||'')}', {source_id:${parseInt(defaultSid)||0}, filter_type:'owner', owner:'${ownerEsc}'})">Arsivle</button></td>
+                        <td style="display:flex;gap:4px"><button class="btn btn-sm btn-outline" onclick="event.stopPropagation();drilldownOwner('${ownerJs}', '${defaultSid}')">Dosyalar</button><button class="btn btn-sm btn-danger" onclick="event.stopPropagation();showDrilldown('Arsivle: ${ownerJs}', '/drilldown/owner/${defaultSid}?owner=${encodeURIComponent(o.owner||'')}', {source_id:${sid}, filter_type:'owner', owner:'${ownerJs}'})">Arsivle</button></td>
                     </tr>`;
                 }).join('') : '<tr><td colspan="5" style="text-align:center;padding:40px;color:var(--text-muted)">Sahiplik verisi bulunamadi. config.yaml dosyasinda read_owner: true yapin.</td></tr>'}</tbody>
             `);
@@ -5218,6 +5224,25 @@ async function downloadDrilldownXLS(event) {
     await withButtonLoading(btn, async (signal) => {
         await fetchAndDownload(exportUrl, signal, 'drilldown.xlsx');
     });
+}
+
+async function downloadDrilldownCSV(event) {
+    // Same drilldown filter as XLS, but ?format=csv streams every matching row
+    // (no 100k Excel cap) — for owners/types/sizes with millions of files.
+    if (!ddCurrentUrl || !ddCurrentUrl.startsWith('/drilldown/')) {
+        notify('Drilldown URL bulunamadi', 'warning');
+        return;
+    }
+    const qIdx = ddCurrentUrl.indexOf('?');
+    const pathPart = qIdx >= 0 ? ddCurrentUrl.slice(0, qIdx) : ddCurrentUrl;
+    const queryPart = qIdx >= 0 ? ddCurrentUrl.slice(qIdx) : '';
+    const sep = queryPart ? '&' : '?';
+    const exportUrl = '/api' + pathPart + '/export.xlsx' + queryPart + sep + 'format=csv';
+    const btn = event?.currentTarget;
+    // Big exports can take minutes to stream; allow up to 10 min before abort.
+    await withButtonLoading(btn, async (signal) => {
+        await fetchAndDownload(exportUrl, signal, 'drilldown.csv');
+    }, 600000);
 }
 
 function drilldownOwner(owner, sourceId) {
@@ -9633,7 +9658,8 @@ async function runFileSearch() {
                     <button data-view="table" class="active" onclick="setDrilldownView('table')">Tablo</button>
                     <button data-view="card" onclick="setDrilldownView('card')">Kart</button>
                 </div>
-                <button class="btn-export" onclick="downloadDrilldownXLS(event)">XLS Indir</button>
+                <button class="btn-export" onclick="downloadDrilldownXLS(event)" title="Excel (en fazla 100.000 satir)">XLS Indir</button>
+                <button class="btn-export" onclick="downloadDrilldownCSV(event)" title="CSV - tum satirlar, 100.000 siniri yok (buyuk listeler icin)">CSV Indir</button>
                 <button id="dd-archive-btn" class="btn btn-sm btn-danger" onclick="archiveDrilldown()" style="display:none">Grubu Arsivle</button>
                 <button class="btn btn-sm btn-outline" onclick="closeDrilldown()">Kapat</button>
             </div>

--- a/tests/test_collect_diag.py
+++ b/tests/test_collect_diag.py
@@ -1,0 +1,236 @@
+"""Tests for scripts/collect_diag.py — the diagnostics bundle collector.
+
+Covers: snapshot structure, secret redaction, owner-resolution ratio against
+a real SQLite Database, key-flag surfacing, log tail, markdown render, the
+in-memory zip, and graceful behaviour when the DB file is missing (the tool
+must still produce a bundle when the DB is the thing that is broken).
+"""
+
+import io
+import os
+import sys
+import zipfile
+
+import pytest
+
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if REPO_ROOT not in sys.path:
+    sys.path.insert(0, REPO_ROOT)
+
+import scripts.collect_diag as cd  # noqa: E402
+from src.storage.database import Database  # noqa: E402
+
+
+def _seed_db(tmp_path, owners):
+    """Build a Database with one source/scan and ``owners`` rows.
+
+    ``owners`` is a list of owner values (None / '' = unresolved).
+    Returns (db, db_path).
+    """
+    db_path = tmp_path / "diag.db"
+    db = Database({"path": str(db_path)})
+    db.connect()
+    with db.get_cursor() as cur:
+        cur.execute("INSERT INTO sources (name, unc_path) VALUES ('ortak', '/share')")
+        source_id = cur.lastrowid
+        cur.execute(
+            "INSERT INTO scan_runs (source_id, status, total_files) "
+            "VALUES (?, 'completed', ?)",
+            (source_id, len(owners)),
+        )
+        scan_id = cur.lastrowid
+        rows = [
+            (source_id, scan_id, f"/share/f{i}.txt", f"f{i}.txt", f"f{i}.txt",
+             "txt", 100, owner)
+            for i, owner in enumerate(owners)
+        ]
+        cur.executemany(
+            "INSERT INTO scanned_files (source_id, scan_id, file_path, "
+            "relative_path, file_name, extension, file_size, owner) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            rows,
+        )
+    return db, db_path
+
+
+def _config(tmp_path, db_path, log_path):
+    return {
+        "general": {"log_file": str(log_path)},
+        "database": {"path": str(db_path)},
+        "scanner": {"read_owner": True, "parquet_staging": {"enabled": False}},
+        "audit": {"chain_enabled": False},
+        "mail": {"smtp_password": "hunter2", "api_token": "secret-abc", "host": "mail.local"},
+    }
+
+
+# ---------------------------------------------------------------------------
+# redaction
+# ---------------------------------------------------------------------------
+def test_redaction_masks_secret_like_keys():
+    src = {
+        "smtp_password": "x", "api_token": "y", "client_secret": "z",
+        "host": "mail.local", "port": 25,
+        "nested": {"bind_password": "p", "name": "svc"},
+    }
+    out = cd._redact_config(src)
+    assert out["smtp_password"] == cd._REDACTED
+    assert out["api_token"] == cd._REDACTED
+    assert out["client_secret"] == cd._REDACTED
+    assert out["nested"]["bind_password"] == cd._REDACTED
+    # non-secret values survive
+    assert out["host"] == "mail.local"
+    assert out["port"] == 25
+    assert out["nested"]["name"] == "svc"
+
+
+# ---------------------------------------------------------------------------
+# collect() structure + owner resolution
+# ---------------------------------------------------------------------------
+def test_collect_structure_and_flags(tmp_path):
+    db, db_path = _seed_db(tmp_path, ["CORP\\alice", "bob", None, ""])
+    log_path = tmp_path / "app.log"
+    log_path.write_text("line1\nline2\nERROR boom\n", encoding="utf-8")
+    config = _config(tmp_path, db_path, log_path)
+
+    diag = cd.collect(db, config, log_lines=50, redact=True)
+
+    assert set(diag) >= {"meta", "environment", "key_flags", "config", "log", "database"}
+    assert diag["meta"]["redacted"] is True
+    # key flags surfaced verbatim from config
+    assert diag["key_flags"]["scanner.read_owner"] is True
+    assert diag["key_flags"]["scanner.parquet_staging.enabled"] is False
+    # secrets masked inside the embedded config
+    assert diag["config"]["mail"]["smtp_password"] == cd._REDACTED
+    assert diag["config"]["mail"]["host"] == "mail.local"
+    db.close()
+
+
+def test_owner_resolution_ratio(tmp_path):
+    db, db_path = _seed_db(tmp_path, ["CORP\\alice", "bob", None, "", None])
+    log_path = tmp_path / "app.log"
+    log_path.write_text("x\n", encoding="utf-8")
+    diag = cd.collect(db, _config(tmp_path, db_path, log_path), redact=True)
+
+    sources = diag["database"]["sources"]
+    assert len(sources) == 1
+    owner = sources[0]["owner_resolution"]
+    assert owner["rows"] == 5
+    assert owner["unresolved"] == 3       # None, '', None
+    assert owner["resolved"] == 2         # alice, bob
+    assert owner["unresolved_pct"] == 60.0
+    # redacted: no sample owner names leaked
+    assert "top_owners" not in owner
+    db.close()
+
+
+def test_owner_samples_only_when_not_redacted(tmp_path):
+    db, db_path = _seed_db(tmp_path, ["alice", "alice", "bob", None])
+    log_path = tmp_path / "app.log"
+    log_path.write_text("x\n", encoding="utf-8")
+    diag = cd.collect(db, _config(tmp_path, db_path, log_path), redact=False)
+
+    owner = diag["database"]["sources"][0]["owner_resolution"]
+    assert "top_owners" in owner
+    names = {row["owner"] for row in owner["top_owners"]}
+    assert names == {"alice", "bob"}
+    # unc_path is surfaced only without redaction
+    assert diag["database"]["sources"][0].get("unc_path") == "/share"
+    db.close()
+
+
+# ---------------------------------------------------------------------------
+# log tail
+# ---------------------------------------------------------------------------
+def test_tail_returns_last_n_lines(tmp_path):
+    log_path = tmp_path / "big.log"
+    log_path.write_text("\n".join(f"line{i}" for i in range(1000)), encoding="utf-8")
+    text, meta = cd._tail(str(log_path), 10)
+    lines = text.splitlines()
+    assert lines[-1] == "line999"
+    assert len(lines) == 10
+    assert meta["exists"] is True
+
+
+def test_tail_missing_file():
+    text, meta = cd._tail("/no/such/file.log", 10)
+    assert text == ""
+    assert meta["exists"] is False
+
+
+# ---------------------------------------------------------------------------
+# render + bundle
+# ---------------------------------------------------------------------------
+def test_render_markdown_has_key_sections(tmp_path):
+    db, db_path = _seed_db(tmp_path, ["alice", None])
+    log_path = tmp_path / "app.log"
+    log_path.write_text("hello\n", encoding="utf-8")
+    diag = cd.collect(db, _config(tmp_path, db_path, log_path))
+    md = cd.render_markdown(diag)
+    assert "Domain-joined" in md
+    assert "Owner resolution" in md
+    assert "Key config flags" in md
+    db.close()
+
+
+def test_build_bundle_bytes_is_valid_zip(tmp_path):
+    db, db_path = _seed_db(tmp_path, ["alice"])
+    log_path = tmp_path / "app.log"
+    log_path.write_text("hello\nworld\n", encoding="utf-8")
+    diag = cd.collect(db, _config(tmp_path, db_path, log_path))
+    md = cd.render_markdown(diag)
+    payload = cd.build_bundle_bytes(diag, md)
+
+    with zipfile.ZipFile(io.BytesIO(payload)) as zf:
+        names = set(zf.namelist())
+        assert {"report.md", "diag.json", "log_tail.txt"} <= names
+        assert b"Domain-joined" in zf.read("report.md")
+    db.close()
+
+
+# ---------------------------------------------------------------------------
+# robustness: the DB is the thing that's broken
+# ---------------------------------------------------------------------------
+def test_collect_survives_missing_db(tmp_path):
+    log_path = tmp_path / "app.log"
+    log_path.write_text("only the log survived\n", encoding="utf-8")
+    config = _config(tmp_path, tmp_path / "does-not-exist.db", log_path)
+    db = Database({"path": str(tmp_path / "does-not-exist.db")})
+
+    diag = cd.collect(db, config)  # must not raise
+
+    assert diag["database"]["errors"]            # recorded, not crashed
+    assert diag["log"]["tail"].startswith("only the log survived")
+    assert diag["environment"]["hostname"]
+
+
+def test_upload_requires_repo_and_token():
+    with pytest.raises(ValueError):
+        cd.upload_to_github("body", "", "")
+
+
+def test_resolve_github_from_telemetry(monkeypatch):
+    monkeypatch.setenv("FILEACTIVITY_TELEMETRY_TOKEN", "tok-123")
+    config = {
+        "telemetry": {
+            "github": {"repo": "o/r", "token_env": "FILEACTIVITY_TELEMETRY_TOKEN",
+                       "label": "diag"},
+            "privacy": {"redact_paths": True},
+        }
+    }
+    repo, token, label, scrub = cd.resolve_github(config)
+    assert repo == "o/r"
+    assert token == "tok-123"
+    assert label == "diag"
+    assert scrub is True
+    # explicit args win over config/env
+    repo2, token2, _, _ = cd.resolve_github(config, "x/y", "argtok")
+    assert (repo2, token2) == ("x/y", "argtok")
+
+
+def test_scrub_paths_masks_unc_and_home():
+    text = r"open \\fileserver\Finans\rapor.xlsx and C:\Users\ahmet\Desktop"
+    out = cd._scrub_paths(text)
+    assert "fileserver" not in out
+    assert "Finans" not in out
+    assert "ahmet" not in out
+    assert "<redacted>" in out

--- a/tests/test_config_migrator.py
+++ b/tests/test_config_migrator.py
@@ -367,6 +367,231 @@ security:
     assert parsed["security"]["orphan_sid"]["cache_ttl_minutes"] == 1440
 
 
+# ---------------------------------------------------------------------------
+# set_if_missing — insert an absent key (the #8/#9 + #1 durable fix)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def rules_parquet_set_if_missing():
+    return [
+        {
+            "path": "scanner.parquet_staging.enabled",
+            "old_default": True,
+            "new_default": False,
+            "set_if_missing": True,
+            "reason": "test",
+            "pr": "#174",
+        }
+    ]
+
+
+def test_set_if_missing_inserts_leaf_under_existing_parent(
+    tmp_path, rules_parquet_set_if_missing
+):
+    cfg = _write(tmp_path / "config.yaml", """\
+scanner:
+  parquet_staging:
+    flush_rows: 50000
+""")
+    results = migrate_config.migrate(cfg, rules_parquet_set_if_missing)
+    assert [r.action for r in results] == ["inserted"]
+    parsed = yaml.safe_load(cfg.read_text(encoding="utf-8"))
+    assert parsed["scanner"]["parquet_staging"]["enabled"] is False
+    assert parsed["scanner"]["parquet_staging"]["flush_rows"] == 50000
+    assert len(list(tmp_path.glob("config.yaml.bak-*"))) == 1
+
+
+def test_set_if_missing_inserts_intermediate_container(
+    tmp_path, rules_parquet_set_if_missing
+):
+    cfg = _write(tmp_path / "config.yaml", """\
+scanner:
+  enrich_sizes: true
+  size_enrich_workers: 8
+""")
+    results = migrate_config.migrate(cfg, rules_parquet_set_if_missing)
+    assert [r.action for r in results] == ["inserted"]
+    parsed = yaml.safe_load(cfg.read_text(encoding="utf-8"))
+    assert parsed["scanner"]["parquet_staging"]["enabled"] is False
+    # Existing siblings untouched.
+    assert parsed["scanner"]["enrich_sizes"] is True
+    assert parsed["scanner"]["size_enrich_workers"] == 8
+
+
+def test_set_if_missing_inserts_top_level_when_root_absent(
+    tmp_path, rules_parquet_set_if_missing
+):
+    cfg = _write(tmp_path / "config.yaml", """\
+dashboard:
+  port: 8085
+""")
+    results = migrate_config.migrate(cfg, rules_parquet_set_if_missing)
+    assert [r.action for r in results] == ["inserted"]
+    parsed = yaml.safe_load(cfg.read_text(encoding="utf-8"))
+    assert parsed["scanner"]["parquet_staging"]["enabled"] is False
+    assert parsed["dashboard"]["port"] == 8085
+
+
+def test_set_if_missing_preserves_comments(tmp_path, rules_parquet_set_if_missing):
+    cfg = _write(tmp_path / "config.yaml", """\
+# top of file
+scanner:
+  # a comment about scanner
+  enrich_sizes: true   # inline note
+""")
+    results = migrate_config.migrate(cfg, rules_parquet_set_if_missing)
+    assert results[0].action == "inserted"
+    new = cfg.read_text(encoding="utf-8")
+    assert "# top of file" in new
+    assert "# a comment about scanner" in new
+    assert "# inline note" in new
+
+
+def test_set_if_missing_present_value_still_flips(
+    tmp_path, rules_parquet_set_if_missing
+):
+    cfg = _write(tmp_path / "config.yaml", """\
+scanner:
+  parquet_staging:
+    enabled: true
+""")
+    results = migrate_config.migrate(cfg, rules_parquet_set_if_missing)
+    assert results[0].action == "applied"
+    parsed = yaml.safe_load(cfg.read_text(encoding="utf-8"))
+    assert parsed["scanner"]["parquet_staging"]["enabled"] is False
+
+
+def test_set_if_missing_present_at_new_default_is_skipped(
+    tmp_path, rules_parquet_set_if_missing
+):
+    cfg = _write(tmp_path / "config.yaml", """\
+scanner:
+  parquet_staging:
+    enabled: false
+""")
+    results = migrate_config.migrate(cfg, rules_parquet_set_if_missing)
+    assert results[0].action == "skipped"
+    assert not list(tmp_path.glob("config.yaml.bak-*"))
+
+
+def test_set_if_missing_scalar_ancestor_is_error(
+    tmp_path, rules_parquet_set_if_missing
+):
+    # Non-canonical: parquet_staging written as a scalar, not a mapping.
+    cfg = _write(tmp_path / "config.yaml", """\
+scanner:
+  parquet_staging: true
+""")
+    results = migrate_config.migrate(cfg, rules_parquet_set_if_missing)
+    assert results[0].action == "error"
+    # File left untouched.
+    assert "parquet_staging: true" in cfg.read_text(encoding="utf-8")
+    assert not list(tmp_path.glob("config.yaml.bak-*"))
+
+
+def test_set_if_missing_dry_run_does_not_write(
+    tmp_path, rules_parquet_set_if_missing
+):
+    original = """\
+scanner:
+  enrich_sizes: true
+"""
+    cfg = _write(tmp_path / "config.yaml", original)
+    results = migrate_config.migrate(cfg, rules_parquet_set_if_missing, dry_run=True)
+    assert results[0].action == "inserted"  # would-insert
+    assert cfg.read_text(encoding="utf-8") == original
+    assert not list(tmp_path.glob("config.yaml.bak-*"))
+
+
+def test_set_if_missing_is_idempotent(tmp_path, rules_parquet_set_if_missing):
+    cfg = _write(tmp_path / "config.yaml", """\
+scanner:
+  enrich_sizes: true
+""")
+    first = migrate_config.migrate(cfg, rules_parquet_set_if_missing)
+    assert first[0].action == "inserted"
+    # Re-run: key now present at new_default -> skipped, no further write.
+    second = migrate_config.migrate(cfg, rules_parquet_set_if_missing)
+    assert second[0].action == "skipped"
+    parsed = yaml.safe_load(cfg.read_text(encoding="utf-8"))
+    assert parsed["scanner"]["parquet_staging"]["enabled"] is False
+
+
+# ---------------------------------------------------------------------------
+# Shipped set_if_missing rules — the real #8/#9 + #1 customer scenario
+# ---------------------------------------------------------------------------
+
+
+def test_shipped_parquet_rule_inserts_when_absent(tmp_path):
+    """A preserved config that never carried scanner.parquet_staging must
+    get enabled:false inserted (the #8/#9 lock-source auto-disable)."""
+    cfg = _write(tmp_path / "config.yaml", """\
+scanner:
+  enrich_sizes: true
+  size_enrich_workers: 8
+""")
+    rules = migrate_config.load_rules()
+    results = migrate_config.migrate(cfg, rules)
+    by_path = {r.path: r for r in results}
+    assert by_path["scanner.parquet_staging.enabled"].action == "inserted"
+    parsed = yaml.safe_load(cfg.read_text(encoding="utf-8"))
+    assert parsed["scanner"]["parquet_staging"]["enabled"] is False
+
+
+def test_shipped_read_owner_rule_inserts_true_when_absent(tmp_path):
+    """A preserved config missing scanner.read_owner must get true inserted
+    so a rescan actually collects owners (issue #1)."""
+    cfg = _write(tmp_path / "config.yaml", """\
+scanner:
+  enrich_sizes: true
+""")
+    rules = migrate_config.load_rules()
+    results = migrate_config.migrate(cfg, rules)
+    by_path = {r.path: r for r in results}
+    assert by_path["scanner.read_owner"].action == "inserted"
+    parsed = yaml.safe_load(cfg.read_text(encoding="utf-8"))
+    assert parsed["scanner"]["read_owner"] is True
+
+
+def test_shipped_read_owner_explicit_false_is_preserved(tmp_path):
+    """An operator who explicitly disabled read_owner keeps it off — the
+    read_owner rule is insert-only, never a flip."""
+    cfg = _write(tmp_path / "config.yaml", """\
+scanner:
+  read_owner: false
+""")
+    rules = migrate_config.load_rules()
+    results = migrate_config.migrate(cfg, rules)
+    by_path = {r.path: r for r in results}
+    assert by_path["scanner.read_owner"].action == "skipped"
+    parsed = yaml.safe_load(cfg.read_text(encoding="utf-8"))
+    assert parsed["scanner"]["read_owner"] is False
+
+
+def test_shipped_rules_both_insert_under_existing_scanner(tmp_path):
+    """The customer's real case: scanner exists but lacks BOTH keys. Both
+    inserts must land under the same scanner block (no duplicate scanner)."""
+    cfg = _write(tmp_path / "config.yaml", """\
+scanner:
+  enrich_sizes: true
+dashboard:
+  port: 8085
+""")
+    rules = migrate_config.load_rules()
+    results = migrate_config.migrate(cfg, rules)
+    by_path = {r.path: r for r in results}
+    assert by_path["scanner.parquet_staging.enabled"].action == "inserted"
+    assert by_path["scanner.read_owner"].action == "inserted"
+    text = cfg.read_text(encoding="utf-8")
+    assert text.count("scanner:") == 1, "must not create a duplicate scanner block"
+    parsed = yaml.safe_load(text)
+    assert parsed["scanner"]["parquet_staging"]["enabled"] is False
+    assert parsed["scanner"]["read_owner"] is True
+    assert parsed["scanner"]["enrich_sizes"] is True
+    assert parsed["dashboard"]["port"] == 8085
+
+
 def test_shipped_rules_applied_against_shipped_config_is_noop(tmp_path):
     """The shipped config.yaml is the post-migration state by definition.
     Running the migrator against a copy of the shipped config must
@@ -377,7 +602,7 @@ def test_shipped_rules_applied_against_shipped_config_is_noop(tmp_path):
     _shutil.copy(shipped, cfg)
     rules = migrate_config.load_rules()
     results = migrate_config.migrate(cfg, rules)
-    applied = [r for r in results if r.action == "applied"]
-    assert applied == [], (
-        f"shipped config.yaml triggers migrations against shipped rules: {applied}"
+    changed = [r for r in results if r.action in ("applied", "inserted")]
+    assert changed == [], (
+        f"shipped config.yaml triggers migrations against shipped rules: {changed}"
     )


### PR DESCRIPTION
## Why

From the live dashboard (Kullanıcı Aktivite, owners like `BURCU\grafik`):

1. **"Dosyalar" comes back empty.** The owner was embedded in a single-quoted `onclick` JS string; a raw backslash in `DOMAIN\user` is swallowed by JS string parsing (`'BURCU\grafik'` → `BURCUgrafik`), so the drill-down queried a non-existent owner and returned nothing. The "Arşivle" button built its URL with `encodeURIComponent` at template time (correct), which is why only "Dosyalar" looked broken — but the latent corruption also affected `archiveParams.owner` (the archive POST) on both buttons.
2. **Excel export stops at 100k rows on other pages.** The drilldown XLSX export is hard-capped at `MAX_ROWS=100_000` because openpyxl materialises the whole workbook in memory (its own docstring flags streaming-CSV as the fix — `#225 R-2`).

## What

**Issue 1 — owner drill-down (fix):**
- Escape backslash + quote for the JS-string context (`ownerJs`) at every `onclick` site, so the owner survives to the handler intact. The file list now loads in the existing sortable **table** overlay (#222), and the archive POST targets the right owner.
- `GET /api/users/overview` now returns the `source_id` it aggregated owners from, so the drill-down hits the correct scan even with multiple sources.

**Issue 2 — uncapped export (feat):**
- `GET /api/drilldown/{filter_type}/{source_id}/export.xlsx?format=csv` streams **every** matching row (no 100k cap), paging the same tested runner so there's no per-filter SQL to keep in sync and only one page is held in memory. XLSX stays the default (Excel-friendly, capped).
- New **"CSV İndir"** button in the drill-down overlay (10-min client timeout for large streams).

**Issue 3 — Adlandırma Uyumu:** no code change. It runs off the *existing completed* scan (no update needed); if empty it's the 1-3 min cold compute on 2.89M rows or no source selected. The #257 diagnostics bundle will confirm once they `update.cmd`.

## Answer to "JSON or CSV?"
**CSV** — it streams unbounded with flat memory and opens in Excel. JSON would also stream but isn't Excel-friendly. This matches the existing `?format=csv` path used by the naming/PII exports.

## Test plan

- [x] `node --check` on extracted inline JS — clean.
- [x] `python scripts/ci_guards.py` — 9/9 (A-AWAIT + C-CURSOR cover the changed endpoint).
- [x] `py_compile src/dashboard/api.py`.
- [ ] On the box: Kullanıcı Aktivite → "Dosyalar" on `BURCU\grafik` lists files in the table; "CSV İndir" on a >100k drill-down downloads all rows.

> `fastapi` isn't in the Linux test container, so the endpoint change is validated via py_compile + ci_guards; needs the on-box smoke above.

https://claude.ai/code/session_01KNp4i1AwzcBwncqJTh1Uog

---
_Generated by [Claude Code](https://claude.ai/code/session_01KNp4i1AwzcBwncqJTh1Uog)_