### PR TITLE
fix(ci-guards): close 4 verified R-5 edge-case gaps (review repros)

### DIFF
--- a/scripts/ci_guards.py
+++ b/scripts/ci_guards.py
@@ -785,52 +785,65 @@ def check_p_page() -> bool:
     def args_iter(fn) -> list[ast.arg]:
         return list(fn.args.args) + list(fn.args.kwonlyargs) + list(fn.args.posonlyargs)
 
-    def has_pagination_param(fn) -> bool:
-        return any(a.arg in PAGINATION_PARAM_NAMES for a in args_iter(fn))
+    def ann_is_pagination_params(ann) -> bool:
+        """True iff the annotation resolves to PaginationParams.
 
-    def uses_pagination_params_helper(fn) -> bool:
-        """True iff any arg is annotated as PaginationParams (with or without
-        a wrapper like Optional[...]).
+        Handles every spelling in active use or recommended by FastAPI:
+        bare ``PaginationParams``, dotted ``helpers.PaginationParams``,
+        ``Optional[PaginationParams]`` (Subscript→Name), PEP 593
+        ``Annotated[PaginationParams, Depends()]`` (Subscript→Tuple),
+        and PEP 604 ``PaginationParams | None`` (BinOp) — recursively,
+        so nested wrappers compose.
         """
-        for arg in args_iter(fn):
-            ann = arg.annotation
-            if ann is None:
-                continue
-            if isinstance(ann, ast.Name) and ann.id == "PaginationParams":
-                return True
-            if isinstance(ann, ast.Attribute) and ann.attr == "PaginationParams":
-                return True
-            # Conservative: dig one level into Optional[...] / Annotated[...].
-            if isinstance(ann, ast.Subscript):
-                inner = ann.slice
-                if isinstance(inner, ast.Name) and inner.id == "PaginationParams":
-                    return True
+        if ann is None:
+            return False
+        if isinstance(ann, ast.Name):
+            return ann.id == "PaginationParams"
+        if isinstance(ann, ast.Attribute):
+            return ann.attr == "PaginationParams"
+        if isinstance(ann, ast.Subscript):
+            inner = ann.slice
+            if isinstance(inner, ast.Tuple):
+                return any(ann_is_pagination_params(el) for el in inner.elts)
+            return ann_is_pagination_params(inner)
+        if isinstance(ann, ast.BinOp):
+            return (ann_is_pagination_params(ann.left)
+                    or ann_is_pagination_params(ann.right))
         return False
 
-    offenders: list[tuple[str, int]] = []
+    # Per-ARG check (not per-function): a pagination-named arg is fine
+    # only when ITS OWN annotation is the helper. This also catches the
+    # partial-migration trap — `p: PaginationParams = Depends()` added
+    # while a legacy `page: int = 1` lingers in the signature would have
+    # FastAPI bind both from the query string, recreating the drift.
+    offenders: list[tuple[str, int, list[str]]] = []
     for node in ast.walk(tree):
         if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
             continue
         if not is_route_handler(node):
             continue
-        if not has_pagination_param(node):
-            continue
-        if uses_pagination_params_helper(node):
+        hand_rolled = [
+            a.arg for a in args_iter(node)
+            if a.arg in PAGINATION_PARAM_NAMES
+            and not ann_is_pagination_params(a.annotation)
+        ]
+        if not hand_rolled:
             continue
         if node.name in P_PAGE_ALLOWLIST:
             continue
-        offenders.append((node.name, node.lineno))
+        offenders.append((node.name, node.lineno, hand_rolled))
 
     if offenders:
-        for name, ln in offenders:
+        for name, ln, params in offenders:
             _err(
                 "P-PAGE",
                 f"api.py:{ln} route handler {name!r} has hand-rolled "
-                "pagination (page/page_size/limit/offset). Use "
+                f"pagination param(s) {params}. Use "
                 "`p: PaginationParams = Depends()` from "
-                "src/dashboard/_endpoint_helpers.py (Rule 2). To "
-                f"grandfather, add {name!r} to P_PAGE_ALLOWLIST in "
-                "scripts/ci_guards.py with a follow-up issue reference.",
+                "src/dashboard/_endpoint_helpers.py (Rule 2) and remove "
+                "the legacy query params. To grandfather, add "
+                f"{name!r} to P_PAGE_ALLOWLIST in scripts/ci_guards.py "
+                "with a follow-up issue reference.",
             )
         return False
     _ok(
@@ -903,7 +916,9 @@ A_AUDIT_ALLOWLIST: set[str] = {
     "text_near_dup_compute",           # 3396 — analytics compute
 }
 
-MUTATING_HTTP_VERBS = frozenset({"post", "put", "delete", "patch"})
+# Same canonical fact as C-CURSOR's _HTTP_WRITE_METHODS — alias, don't fork,
+# so a future verb policy change lands in exactly one place.
+MUTATING_HTTP_VERBS = frozenset(_HTTP_WRITE_METHODS)
 AUDIT_FUNC_NAMES = frozenset({"insert_audit_event_simple", "insert_audit_event"})
 
 
@@ -939,14 +954,37 @@ def check_a_audit() -> bool:
         return False
 
     def calls_audit(fn: ast.FunctionDef | ast.AsyncFunctionDef) -> bool:
-        """True iff fn body contains a call to an audit-emission function."""
-        for n in ast.walk(fn):
-            if not isinstance(n, ast.Call):
-                continue
-            func = n.func
-            if isinstance(func, ast.Attribute) and func.attr in AUDIT_FUNC_NAMES:
-                return True
-            if isinstance(func, ast.Name) and func.id in AUDIT_FUNC_NAMES:
+        """True iff fn's OWN body calls an audit-emission function.
+
+        Deliberately does NOT descend into nested function definitions —
+        same own-body semantics as A-AWAIT and C-CURSOR. An audit call
+        sitting inside a nested helper proves nothing: the helper may
+        never be invoked (dead code), so only a call reachable in the
+        handler's own statement tree counts. Branches (if/try/with/for)
+        DO count — only nested def/async-def boundaries stop the scan.
+        """
+        class AuditFinder(ast.NodeVisitor):
+            def __init__(self) -> None:
+                self.found = False
+
+            def visit_Call(self, node: ast.Call) -> None:
+                func = node.func
+                if isinstance(func, ast.Attribute) and func.attr in AUDIT_FUNC_NAMES:
+                    self.found = True
+                elif isinstance(func, ast.Name) and func.id in AUDIT_FUNC_NAMES:
+                    self.found = True
+                self.generic_visit(node)
+
+            def visit_FunctionDef(self, node) -> None:
+                pass  # don't descend into nested defs
+
+            def visit_AsyncFunctionDef(self, node) -> None:
+                pass
+
+        finder = AuditFinder()
+        for stmt in fn.body:
+            finder.visit(stmt)
+            if finder.found:
                 return True
         return False
 
@@ -998,6 +1036,9 @@ _S_SHAPE_PATTERNS = (
     r'\.get\(\s*[\"\']summary_json[\"\']',
     r'json\.loads\([^)]*summary_json',
     r'\[\s*[\"\']partial_summary_json[\"\']\s*\]',
+    # The .get form was missing at R-5d ship time — api.py:2998/3065 used
+    # exactly this shape and slipped through (2026-06-04 review repro).
+    r'\.get\(\s*[\"\']partial_summary_json[\"\']',
     r'json\.loads\([^)]*partial_summary_json',
 )
 
@@ -1025,7 +1066,10 @@ def check_s_shape() -> bool:
         stripped = line.lstrip()
         if stripped.startswith("#"):
             continue
-        if "noqa: S-SHAPE" in line:
+        # noqa must live in a trailing comment (not a string literal) and
+        # is case-insensitive, matching the flake8/ruff convention.
+        hash_idx = line.find("#")
+        if hash_idx != -1 and "noqa: s-shape" in line[hash_idx:].lower():
             continue
         for pat in patterns:
             if pat.search(line):

--- a/src/dashboard/api.py
+++ b/src/dashboard/api.py
@@ -2995,7 +2995,10 @@ def create_app(db, config, analytics=None, ad_lookup=None, email_notifier=None,
         if not row:
             return None, None
         scan_id_local = row.get("id")
-        blob = row.get("partial_summary_json")
+        # noqa: S-SHAPE - this IS the partial-v2 canonical reader: the
+        # v1->v2 migration + (source_id, updated_at) cache live right here,
+        # so routing through db.get_scan_partial_summary would lose both.
+        blob = row.get("partial_summary_json")  # noqa: S-SHAPE
         updated_at = row.get("partial_updated_at")
         if not blob:
             # No partial snapshot yet — return an empty v2 envelope so
@@ -3062,7 +3065,9 @@ def create_app(db, config, analytics=None, ad_lookup=None, email_notifier=None,
             raise HTTPException(404, "Scan not found")
         if not row:
             raise HTTPException(404, "Scan not found")
-        blob = row.get("partial_summary_json")
+        # noqa: S-SHAPE - per-scan partial-v2 canonical reader (v1->v2
+        # migration lives here); see the source-level reader above.
+        blob = row.get("partial_summary_json")  # noqa: S-SHAPE
         if not blob:
             from src.analyzer.partial_summary_v2 import _empty_v2_payload
             empty = _empty_v2_payload()

--- a/tests/test_ci_guards.py
+++ b/tests/test_ci_guards.py
@@ -351,6 +351,40 @@ def test_p_page_ignores_non_route_functions(fake_api_py):
     assert g.check_p_page() is True
 
 
+def test_p_page_fails_partial_migration(fake_api_py):
+    """Helper added but legacy page/limit args left behind — FastAPI would
+    bind BOTH from the query string, recreating the Rule-2 drift. Flag.
+    (2026-06-04 review repro R4.)"""
+    fake_api_py.write_text(
+        "@app.get('/api/x')\n"
+        "def partial(p: PaginationParams = Depends(), page: int = 1, limit: int = 50):\n"
+        "    return {}\n"
+    )
+    assert g.check_p_page() is False
+
+
+def test_p_page_passes_annotated_pagination_params(fake_api_py):
+    """PEP 593 Annotated[PaginationParams, Depends()] is the canonical
+    FastAPI form — Subscript slice is a Tuple, which the original
+    implementation missed (2026-06-04 review repro R3)."""
+    fake_api_py.write_text(
+        "@app.get('/api/x')\n"
+        "def modern(page: Annotated[PaginationParams, Depends()]):\n"
+        "    return {}\n"
+    )
+    assert g.check_p_page() is True
+
+
+def test_p_page_passes_optional_pagination_params(fake_api_py):
+    """Optional[PaginationParams] (Subscript -> Name) keeps working."""
+    fake_api_py.write_text(
+        "@app.get('/api/x')\n"
+        "def opt(limit: Optional[PaginationParams] = Depends()):\n"
+        "    return {}\n"
+    )
+    assert g.check_p_page() is True
+
+
 def test_p_page_runs_against_real_api_py():
     """Live api.py must pass P-PAGE with the documented allowlists."""
     assert g.check_p_page() is True
@@ -427,6 +461,34 @@ def test_a_audit_ignores_non_route_functions(fake_api_py):
     assert g.check_a_audit() is True
 
 
+def test_a_audit_fails_audit_only_in_dead_nested_def(fake_api_py):
+    """An audit call inside a nested helper proves nothing — the helper
+    may never be invoked. Own-body semantics match A-AWAIT/C-CURSOR.
+    (2026-06-04 review repro R2.)"""
+    fake_api_py.write_text(
+        "@app.post('/api/x')\n"
+        "def evil():\n"
+        "    def _unused():\n"
+        "        db.insert_audit_event_simple('x', {})\n"
+        "    return {}\n"
+    )
+    assert g.check_a_audit() is False
+
+
+def test_a_audit_passes_audit_inside_branch(fake_api_py):
+    """Branches (try/if/with) are part of the own body — they count."""
+    fake_api_py.write_text(
+        "@app.post('/api/x')\n"
+        "def ok():\n"
+        "    try:\n"
+        "        db.insert_audit_event_simple('x', {})\n"
+        "    except Exception:\n"
+        "        pass\n"
+        "    return {}\n"
+    )
+    assert g.check_a_audit() is True
+
+
 def test_a_audit_runs_against_real_api_py():
     """Live api.py must pass A-AUDIT with the documented allowlists."""
     assert g.check_a_audit() is True
@@ -498,6 +560,36 @@ def test_s_shape_ignores_comment_lines(fake_api_py):
         "# Use db.get_scan_summary(scan_id) instead.\n"
     )
     assert g.check_s_shape() is True
+
+
+def test_s_shape_fails_on_partial_get(fake_api_py):
+    """Regression for the on-ship bypass: row.get('partial_summary_json')
+    was not covered by the original pattern set even though api.py used
+    exactly this shape at 2998/3065. (2026-06-04 review repro R1.)"""
+    fake_api_py.write_text(
+        "def bad_read(row):\n"
+        "    return row.get('partial_summary_json')\n"
+    )
+    assert g.check_s_shape() is False
+
+
+def test_s_shape_noqa_case_insensitive(fake_api_py):
+    """flake8/ruff-style lower-case noqa works too."""
+    fake_api_py.write_text(
+        "def needed_raw(row):\n"
+        "    return row['summary_json']  # noqa: s-shape - documented\n"
+    )
+    assert g.check_s_shape() is True
+
+
+def test_s_shape_noqa_in_string_does_not_silence(fake_api_py):
+    """A noqa marker inside a string literal (no # comment) must NOT
+    exempt the line."""
+    fake_api_py.write_text(
+        "def sneaky(row):\n"
+        "    return str(row['summary_json']) + 'noqa: S-SHAPE'\n"
+    )
+    assert g.check_s_shape() is False
 
 
 def test_s_shape_runs_against_real_api_py():


### PR DESCRIPTION
## Why

A max-effort `/code-review` of the R-5 guard series (#270–#272) surfaced 15 findings; the **4 Tier-1 items were then independently verified by running each guard against a synthetic api.py exhibiting the claimed bug shape — 4/4 reproduced**. This PR closes those four, with every repro locked in as a regression test.

## What

**1. S-SHAPE — real on-ship bypass closed**
- `_S_SHAPE_PATTERNS` covered `.get("summary_json")` but NOT `.get("partial_summary_json")` — and `api.py:2998` / `:3065` used exactly that shape. Pattern added.
- Those two lines are the **partial-v2 canonical reader itself** (the v1→v2 migration + `(source_id, updated_at)` cache live right there; `db.get_scan_partial_summary` carries neither, and the first site queries by `source_id`) → they keep working under a justified `# noqa: S-SHAPE` with an explanatory comment. Deeper refactor (moving the reader + cache into the storage layer) noted as future work, not bandaided here.
- noqa marker hardened: must appear in a **trailing comment** (a marker inside a string literal no longer silences the guard) and is **case-insensitive** (flake8/ruff convention).

**2. A-AUDIT — dead-code false-pass closed**
`calls_audit` used `ast.walk(fn)`, which descends into nested defs: an audit call inside a never-invoked nested helper made the endpoint look compliant. Now **own-body semantics** via a visitor that stops at nested def boundaries — exactly matching A-AWAIT / C-CURSOR (the inconsistency the review flagged). Branches (`try`/`if`/`with`) still count. **Real api.py: still exactly 46 allowlisted — no live endpoint relied on nested audit calls.**

**3 + 4. P-PAGE — rewritten per-ARG**
A pagination-named arg is now fine **only when its own annotation resolves to `PaginationParams`** (recursive resolver: bare / dotted / `Optional[...]` / PEP 593 `Annotated[PaginationParams, Depends()]` (Subscript→Tuple) / PEP 604 `| None`). This simultaneously fixes:
- **false positive** on the canonical FastAPI `Annotated` form (was: Subscript-slice only matched `ast.Name`), and
- **false negative** on the partial-migration trap — helper added but legacy `page: int = 1` left behind, so FastAPI binds both from the query string (the exact Rule-2 drift). Error message now names the offending param(s).
**Real api.py: still exactly 27 allowlisted.**

**5. Cleanup ride-along:** `MUTATING_HTTP_VERBS` now aliases C-CURSOR's `_HTTP_WRITE_METHODS` — one source of truth for the verb set (review finding).

## Test plan

- [x] `python scripts/ci_guards.py` — **12/12 against real api.py** (strict A-AUDIT introduced zero new offenders; P-PAGE per-arg kept exactly the 27).
- [x] `pytest tests/test_ci_guards.py -q` — **55 passed** (was 47; +8 regression tests, each tagged with its review-repro ID).
- [x] All 4 original repros re-run post-fix: R1 flagged ✓, R2 flagged ✓, R3 (Annotated canonical) passes ✓, R4 (partial migration) flagged ✓.
- [x] `py_compile` on all three changed files.

## Out of scope (tracked for R-6 / cleanup wave)

Parse caching (5× `ast.parse` of api.py), decorator-helper unification (`is_route_handler` ×2 vs `_decorator_http_method`), allowlist max-len shrinkage tests, stale line-number comments, `parametrize` consolidation, the `summary_json`-substring false-positive class, and the APIRouter-binding assumption — all flagged by the same review, all structural rather than correctness, deliberately not bundled into this fix.

https://claude.ai/code/session_01KNp4i1AwzcBwncqJTh1Uog

---
_Generated by [Claude Code](https://claude.ai/code/session_01KNp4i1AwzcBwncqJTh1Uog)_