### PR TITLE
feat(audit): R-6 wave 1 — emit audit events on 10 compliance-critical endpoints

### DIFF
--- a/scripts/ci_guards.py
+++ b/scripts/ci_guards.py
@@ -890,8 +890,6 @@ A_AUDIT_ALLOWLIST: set[str] = {
     "duplicates_quarantine",           # 3484
     "duplicates_quarantine_preview",   # 3468 — dry-run
     "insights_recompute",              # 2471 — analytics compute
-    "legal_holds_add",                 # 6852
-    "legal_holds_release",             # 6869
     "notifications_send_to",           # 4641
     "notifications_test",              # 4605 — self-test
     "notify_users_run_now",            # 1742
@@ -899,15 +897,7 @@ A_AUDIT_ALLOWLIST: set[str] = {
     "orphan_sid_reassign",             # 5506
     "overview_recompute",              # 2919 — analytics compute
     "pii_scan",                        # 6410 — analytics compute
-    "quarantine_purge",                # 3653
-    "quarantine_restore",              # 3701
     "ransomware_test",                 # 5321 — self-test
-    "restore_by_operation",            # 4310
-    "restore_file",                    # 1634
-    "restore_snapshot",                # 6281
-    "retention_policy_apply",          # 6731
-    "retention_policy_create",         # 6707
-    "retention_policy_remove",         # 6724
     "run_archive",                     # 1519
     "run_scan",                        # 1005
     "start_export",                    # 5187 — export-only

--- a/src/dashboard/api.py
+++ b/src/dashboard/api.py
@@ -1639,24 +1639,24 @@ def create_app(db, config, analytics=None, ad_lookup=None, email_notifier=None,
             if result.get("success"):
                 try:
                     db.insert_audit_event_simple(
-                        source_id=None, event_type="restore.file", username="admin",
+                        source_id=None, event_type="file_restored", username="admin",
                         file_path=result.get("original_path"),
                         details=f"archive_id={data.archive_id}",
                     )
                 except Exception as e:  # pragma: no cover - audit is best-effort
-                    logger.warning("audit emit failed for restore.file: %s", e)
+                    logger.warning("audit emit failed for file_restored: %s", e)
             return result
         elif data.original_path:
             result = engine.restore_by_path(data.original_path)
             if result.get("success"):
                 try:
                     db.insert_audit_event_simple(
-                        source_id=None, event_type="restore.file", username="admin",
+                        source_id=None, event_type="file_restored", username="admin",
                         file_path=result.get("original_path") or data.original_path,
                         details=f"original_path={data.original_path}",
                     )
                 except Exception as e:  # pragma: no cover - audit is best-effort
-                    logger.warning("audit emit failed for restore.file: %s", e)
+                    logger.warning("audit emit failed for file_restored: %s", e)
             return result
         raise HTTPException(400, "archive_id veya original_path gerekli")
 
@@ -3702,7 +3702,7 @@ def create_app(db, config, analytics=None, ad_lookup=None, email_notifier=None,
             if result.status == "purged":
                 try:
                     db.insert_audit_event_simple(
-                        source_id=None, event_type="quarantine.purge",
+                        source_id=None, event_type="quarantine_purged",
                         username=purged_by,
                         file_path=result.original_path,
                         details=(
@@ -3711,7 +3711,7 @@ def create_app(db, config, analytics=None, ad_lookup=None, email_notifier=None,
                         ),
                     )
                 except Exception as e:  # pragma: no cover - audit is best-effort
-                    logger.warning("audit emit failed for quarantine.purge: %s", e)
+                    logger.warning("audit emit failed for quarantine_purged: %s", e)
             return result.to_dict()
         if result.status == "skipped_not_found":
             raise HTTPException(404, result.reason or "not found")
@@ -3751,7 +3751,7 @@ def create_app(db, config, analytics=None, ad_lookup=None, email_notifier=None,
         if result.status == "restored":
             try:
                 db.insert_audit_event_simple(
-                    source_id=None, event_type="quarantine.restore",
+                    source_id=None, event_type="quarantine_restored",
                     username=restored_by,
                     file_path=result.original_path,
                     details=(
@@ -3760,7 +3760,7 @@ def create_app(db, config, analytics=None, ad_lookup=None, email_notifier=None,
                     ),
                 )
             except Exception as e:  # pragma: no cover - audit is best-effort
-                logger.warning("audit emit failed for quarantine.restore: %s", e)
+                logger.warning("audit emit failed for quarantine_restored: %s", e)
             return result.to_dict()
         if result.status == "skipped_not_found":
             raise HTTPException(404, result.reason or "not found")
@@ -4421,7 +4421,7 @@ def create_app(db, config, analytics=None, ad_lookup=None, email_notifier=None,
         try:
             db.insert_audit_event_simple(
                 source_id=operation.get("source_id"),
-                event_type="restore.by-operation", username="admin",
+                event_type="operation_restored", username="admin",
                 file_path=None,
                 details=(
                     f"op_id={op_id};restore_op_id={restore_op_id};"
@@ -4430,7 +4430,7 @@ def create_app(db, config, analytics=None, ad_lookup=None, email_notifier=None,
                 ),
             )
         except Exception as e:  # pragma: no cover - audit is best-effort
-            logger.warning("audit emit failed for restore.by-operation: %s", e)
+            logger.warning("audit emit failed for operation_restored: %s", e)
 
         return {
             "restored": restored,
@@ -6390,12 +6390,12 @@ def create_app(db, config, analytics=None, ad_lookup=None, email_notifier=None,
         result = _do_snapshot_restore({"snapshot_id": snapshot_id})
         try:
             db.insert_audit_event_simple(
-                source_id=None, event_type="restore.snapshot", username="admin",
+                source_id=None, event_type="snapshot_restored", username="admin",
                 file_path=None,
                 details=f"snapshot_id={snapshot_id}",
             )
         except Exception as e:  # pragma: no cover - audit is best-effort
-            logger.warning("audit emit failed for restore.snapshot: %s", e)
+            logger.warning("audit emit failed for snapshot_restored: %s", e)
         return result
 
     @app.get("/api/system/backups/export")
@@ -6793,7 +6793,7 @@ def create_app(db, config, analytics=None, ad_lookup=None, email_notifier=None,
             raise HTTPException(400, str(e))
         try:
             db.insert_audit_event_simple(
-                source_id=None, event_type="retention-policy.create",
+                source_id=None, event_type="retention_policy_created",
                 username="admin", file_path=None,
                 details=(
                     f"policy_id={pid};name={data.name};"
@@ -6802,7 +6802,7 @@ def create_app(db, config, analytics=None, ad_lookup=None, email_notifier=None,
                 ),
             )
         except Exception as e:  # pragma: no cover - audit is best-effort
-            logger.warning("audit emit failed for retention-policy.create: %s", e)
+            logger.warning("audit emit failed for retention_policy_created: %s", e)
         return {"id": pid, "name": data.name}
 
     @app.delete("/api/compliance/retention/policies/{name}")
@@ -6812,12 +6812,12 @@ def create_app(db, config, analytics=None, ad_lookup=None, email_notifier=None,
             raise HTTPException(404, f"Policy not found: {name}")
         try:
             db.insert_audit_event_simple(
-                source_id=None, event_type="retention-policy.remove",
+                source_id=None, event_type="retention_policy_removed",
                 username="admin", file_path=None,
                 details=f"name={name}",
             )
         except Exception as e:  # pragma: no cover - audit is best-effort
-            logger.warning("audit emit failed for retention-policy.remove: %s", e)
+            logger.warning("audit emit failed for retention_policy_removed: %s", e)
         return {"removed": True, "name": name}
 
     @app.post("/api/compliance/retention/apply/{policy_name}")
@@ -6837,7 +6837,7 @@ def create_app(db, config, analytics=None, ad_lookup=None, email_notifier=None,
             raise HTTPException(503, str(e))
         try:
             db.insert_audit_event_simple(
-                source_id=None, event_type="retention-policy.apply",
+                source_id=None, event_type="retention_policy_applied",
                 username="admin", file_path=None,
                 details=(
                     f"policy={policy_name};dry_run={bool(dry_run)};"
@@ -6846,7 +6846,7 @@ def create_app(db, config, analytics=None, ad_lookup=None, email_notifier=None,
                 ),
             )
         except Exception as e:  # pragma: no cover - audit is best-effort
-            logger.warning("audit emit failed for retention-policy.apply: %s", e)
+            logger.warning("audit emit failed for retention_policy_applied: %s", e)
         return result
 
     @app.get("/api/compliance/retention/attestation")
@@ -6970,7 +6970,7 @@ def create_app(db, config, analytics=None, ad_lookup=None, email_notifier=None,
             raise HTTPException(400, str(e))
         try:
             db.insert_audit_event_simple(
-                source_id=None, event_type="legal-hold.add",
+                source_id=None, event_type="legal_hold_added",
                 username=created_by, file_path=pattern,
                 details=(
                     f"hold_id={hold_id};case_ref={case_ref or '-'};"
@@ -6978,7 +6978,7 @@ def create_app(db, config, analytics=None, ad_lookup=None, email_notifier=None,
                 ),
             )
         except Exception as e:  # pragma: no cover - audit is best-effort
-            logger.warning("audit emit failed for legal-hold.add: %s", e)
+            logger.warning("audit emit failed for legal_hold_added: %s", e)
         return {"id": hold_id, "ok": True}
 
     @app.post("/api/compliance/legal-holds/{hold_id}/release")
@@ -6994,12 +6994,12 @@ def create_app(db, config, analytics=None, ad_lookup=None, email_notifier=None,
             return {"ok": False, "reason": "not_found_or_already_released"}
         try:
             db.insert_audit_event_simple(
-                source_id=None, event_type="legal-hold.release",
+                source_id=None, event_type="legal_hold_released",
                 username=released_by, file_path=None,
                 details=f"hold_id={hold_id}",
             )
         except Exception as e:  # pragma: no cover - audit is best-effort
-            logger.warning("audit emit failed for legal-hold.release: %s", e)
+            logger.warning("audit emit failed for legal_hold_released: %s", e)
         return {"ok": True}
 
     @app.get("/api/compliance/legal-holds/check")

--- a/src/dashboard/api.py
+++ b/src/dashboard/api.py
@@ -1635,9 +1635,29 @@ def create_app(db, config, analytics=None, ad_lookup=None, email_notifier=None,
         from src.archiver.restore_engine import RestoreEngine
         engine = RestoreEngine(db)
         if data.archive_id:
-            return engine.restore_by_id(data.archive_id)
+            result = engine.restore_by_id(data.archive_id)
+            if result.get("success"):
+                try:
+                    db.insert_audit_event_simple(
+                        source_id=None, event_type="restore.file", username="admin",
+                        file_path=result.get("original_path"),
+                        details=f"archive_id={data.archive_id}",
+                    )
+                except Exception as e:  # pragma: no cover - audit is best-effort
+                    logger.warning("audit emit failed for restore.file: %s", e)
+            return result
         elif data.original_path:
-            return engine.restore_by_path(data.original_path)
+            result = engine.restore_by_path(data.original_path)
+            if result.get("success"):
+                try:
+                    db.insert_audit_event_simple(
+                        source_id=None, event_type="restore.file", username="admin",
+                        file_path=result.get("original_path") or data.original_path,
+                        details=f"original_path={data.original_path}",
+                    )
+                except Exception as e:  # pragma: no cover - audit is best-effort
+                    logger.warning("audit emit failed for restore.file: %s", e)
+            return result
         raise HTTPException(400, "archive_id veya original_path gerekli")
 
     # --- POLICY API ---
@@ -3679,6 +3699,19 @@ def create_app(db, config, analytics=None, ad_lookup=None, email_notifier=None,
         cleaner = DuplicateCleaner(db, config)
         result = cleaner.purge_one(int(quarantine_log_id), purged_by=purged_by)
         if result.status in ("purged", "skipped_missing"):
+            if result.status == "purged":
+                try:
+                    db.insert_audit_event_simple(
+                        source_id=None, event_type="quarantine.purge",
+                        username=purged_by,
+                        file_path=result.original_path,
+                        details=(
+                            f"quarantine_log_id={quarantine_log_id};"
+                            f"quarantine_path={result.quarantine_path}"
+                        ),
+                    )
+                except Exception as e:  # pragma: no cover - audit is best-effort
+                    logger.warning("audit emit failed for quarantine.purge: %s", e)
             return result.to_dict()
         if result.status == "skipped_not_found":
             raise HTTPException(404, result.reason or "not found")
@@ -3716,6 +3749,18 @@ def create_app(db, config, analytics=None, ad_lookup=None, email_notifier=None,
             int(quarantine_log_id), restored_by=restored_by
         )
         if result.status == "restored":
+            try:
+                db.insert_audit_event_simple(
+                    source_id=None, event_type="quarantine.restore",
+                    username=restored_by,
+                    file_path=result.original_path,
+                    details=(
+                        f"quarantine_log_id={quarantine_log_id};"
+                        f"quarantine_path={result.quarantine_path}"
+                    ),
+                )
+            except Exception as e:  # pragma: no cover - audit is best-effort
+                logger.warning("audit emit failed for quarantine.restore: %s", e)
             return result.to_dict()
         if result.status == "skipped_not_found":
             raise HTTPException(404, result.reason or "not found")
@@ -4372,6 +4417,20 @@ def create_app(db, config, analytics=None, ad_lookup=None, email_notifier=None,
                 db.complete_archive_operation(restore_op_id, restored, total_size, status)
             except Exception:
                 pass
+
+        try:
+            db.insert_audit_event_simple(
+                source_id=operation.get("source_id"),
+                event_type="restore.by-operation", username="admin",
+                file_path=None,
+                details=(
+                    f"op_id={op_id};restore_op_id={restore_op_id};"
+                    f"restored={restored};failed={failed};"
+                    f"total_size={total_size}"
+                ),
+            )
+        except Exception as e:  # pragma: no cover - audit is best-effort
+            logger.warning("audit emit failed for restore.by-operation: %s", e)
 
         return {
             "restored": restored,
@@ -6328,7 +6387,16 @@ def create_app(db, config, analytics=None, ad_lookup=None, email_notifier=None,
                 "message": "Awaiting second-person approval",
             }
 
-        return _do_snapshot_restore({"snapshot_id": snapshot_id})
+        result = _do_snapshot_restore({"snapshot_id": snapshot_id})
+        try:
+            db.insert_audit_event_simple(
+                source_id=None, event_type="restore.snapshot", username="admin",
+                file_path=None,
+                details=f"snapshot_id={snapshot_id}",
+            )
+        except Exception as e:  # pragma: no cover - audit is best-effort
+            logger.warning("audit emit failed for restore.snapshot: %s", e)
+        return result
 
     @app.get("/api/system/backups/export")
     def export_backups_xlsx():
@@ -6723,6 +6791,18 @@ def create_app(db, config, analytics=None, ad_lookup=None, email_notifier=None,
         except Exception as e:
             # Most likely a UNIQUE-name collision.
             raise HTTPException(400, str(e))
+        try:
+            db.insert_audit_event_simple(
+                source_id=None, event_type="retention-policy.create",
+                username="admin", file_path=None,
+                details=(
+                    f"policy_id={pid};name={data.name};"
+                    f"action={data.action};retain_days={data.retain_days};"
+                    f"pattern={data.pattern_match or ''}"
+                ),
+            )
+        except Exception as e:  # pragma: no cover - audit is best-effort
+            logger.warning("audit emit failed for retention-policy.create: %s", e)
         return {"id": pid, "name": data.name}
 
     @app.delete("/api/compliance/retention/policies/{name}")
@@ -6730,6 +6810,14 @@ def create_app(db, config, analytics=None, ad_lookup=None, email_notifier=None,
         engine = _get_retention_engine()
         if not engine.remove_policy(name):
             raise HTTPException(404, f"Policy not found: {name}")
+        try:
+            db.insert_audit_event_simple(
+                source_id=None, event_type="retention-policy.remove",
+                username="admin", file_path=None,
+                details=f"name={name}",
+            )
+        except Exception as e:  # pragma: no cover - audit is best-effort
+            logger.warning("audit emit failed for retention-policy.remove: %s", e)
         return {"removed": True, "name": name}
 
     @app.post("/api/compliance/retention/apply/{policy_name}")
@@ -6747,6 +6835,18 @@ def create_app(db, config, analytics=None, ad_lookup=None, email_notifier=None,
             raise HTTPException(404, str(e))
         except RuntimeError as e:
             raise HTTPException(503, str(e))
+        try:
+            db.insert_audit_event_simple(
+                source_id=None, event_type="retention-policy.apply",
+                username="admin", file_path=None,
+                details=(
+                    f"policy={policy_name};dry_run={bool(dry_run)};"
+                    f"matched={result.get('matched')};"
+                    f"processed={result.get('processed')}"
+                ),
+            )
+        except Exception as e:  # pragma: no cover - audit is best-effort
+            logger.warning("audit emit failed for retention-policy.apply: %s", e)
         return result
 
     @app.get("/api/compliance/retention/attestation")
@@ -6868,6 +6968,17 @@ def create_app(db, config, analytics=None, ad_lookup=None, email_notifier=None,
             )
         except ValueError as e:
             raise HTTPException(400, str(e))
+        try:
+            db.insert_audit_event_simple(
+                source_id=None, event_type="legal-hold.add",
+                username=created_by, file_path=pattern,
+                details=(
+                    f"hold_id={hold_id};case_ref={case_ref or '-'};"
+                    f"reason={reason}"
+                ),
+            )
+        except Exception as e:  # pragma: no cover - audit is best-effort
+            logger.warning("audit emit failed for legal-hold.add: %s", e)
         return {"id": hold_id, "ok": True}
 
     @app.post("/api/compliance/legal-holds/{hold_id}/release")
@@ -6881,6 +6992,14 @@ def create_app(db, config, analytics=None, ad_lookup=None, email_notifier=None,
             # Either unknown id or already released — same response so
             # the dashboard can treat it idempotently.
             return {"ok": False, "reason": "not_found_or_already_released"}
+        try:
+            db.insert_audit_event_simple(
+                source_id=None, event_type="legal-hold.release",
+                username=released_by, file_path=None,
+                details=f"hold_id={hold_id}",
+            )
+        except Exception as e:  # pragma: no cover - audit is best-effort
+            logger.warning("audit emit failed for legal-hold.release: %s", e)
         return {"ok": True}
 
     @app.get("/api/compliance/legal-holds/check")


### PR DESCRIPTION
## Why

First slice of **EPIC #225 R-6** (audit-backlog flush). Per CLAUDE.md, `A_AUDIT_ALLOWLIST` is meant to be drained in waves of 5-10 endpoints, compliance-critical first. This wave moves the 10 compliance-critical mutating endpoints out of the allowlist by adding a real `db.insert_audit_event_simple(...)` emission on each success path.

## What

10 endpoints + event_types — **snake_case, aligned with master's existing convention** (`source_created`, `policy_deleted`, `scan_cancelled`, ...). The draft originally proposed kebab-dotted names; commit `08bb265` renamed them before any event was ever emitted (zero migration cost), and `retention_policy_*` also disambiguates from the existing archive-policy `policy_created`/`policy_deleted` events:

| Endpoint | event_type | Notes |
|---|---|---|
| `legal_holds_add` | `legal_hold_added` | actor from body `created_by` |
| `legal_holds_release` | `legal_hold_released` | only on `ok=True` path (idempotent no-op skips) |
| `retention_policy_create` | `retention_policy_created` | after engine returns `pid` |
| `retention_policy_remove` | `retention_policy_removed` | only after engine confirms removal |
| `retention_policy_apply` | `retention_policy_applied` | records `dry_run` flag + matched/processed |
| `quarantine_purge` | `quarantine_purged` | **`status=="purged"` only** (not `skipped_*`) |
| `quarantine_restore` | `quarantine_restored` | **`status=="restored"` only** |
| `restore_file` | `file_restored` | success path only, both `archive_id` and `original_path` variants |
| `restore_snapshot` | `snapshot_restored` | direct path only; approvals-gated branch emits via `approvals_execute` in a later wave |
| `restore_by_operation` | `operation_restored` | records restored/failed/total_size aggregates |

### Discipline notes
- Emission RIGHT BEFORE the success return, after the mutation committed — failed mutations never look successful to auditors.
- In addition to (not replacing) engine-internal audits (`LegalHoldRegistry._audit`, `DuplicateCleaner._audit`, `RestoreEngine`'s internal event, `RetentionEngine._write_audit`); the endpoint-level event records the HTTP-side actor + request identifiers (what A-AUDIT checks: the route handler's OWN body).
- Each emission wrapped in `try/except logger.warning(...)` — audit failure never rolls back the user-facing mutation.
- No signature, response-shape, or behaviour change beyond the audit call.

### Allowlist
`A_AUDIT_ALLOWLIST` shrinks **46 → 36**. Remaining 36 = wave-2/3 candidates (`approvals_*`, `chargeback_*`, `bulk_restore`, `orphan_sid_reassign`, `acl_snapshot`, `archive_*`) + justified analytics-compute / self-test exemptions.

### CodeQL alerts 327/328 (api.py:1648/1660) — pre-existing, tracked separately
The two "information exposure through an exception" comments flag the `return result` lines in `restore_file`. The flow originates in `restore_engine.py:105` (`{"success": False, "error": str(e)}`) and **predates this PR** — the diff merely split `return engine.restore_by_id(...)` into `result = ...; return result`, surfacing the old flow on touched lines. Sanitizing engine error text (generic client message + server-side log detail) is a separate small follow-up, deliberately not bundled into this scope-disciplined audit PR.

## Test plan

- [x] `python scripts/ci_guards.py` → **12/12 OK**; A-AUDIT shows `allowlisted: 36`
- [x] `python -m pytest tests/test_ci_guards.py -q` → **55 passed**
- [x] Engine unit tests green: legal_hold (8), retention_engine (6), duplicate_cleaner (17+15) → 101 related passed
- [x] `ast.parse(api.py)` → OK
- [ ] CI on head `08bb265`

https://claude.ai/code/session_01KNp4i1AwzcBwncqJTh1Uog