### PR TITLE
fix(security): raise pyarrow + streamlit floors off known-vulnerable ranges

### DIFF
--- a/requirements-playground.txt
+++ b/requirements-playground.txt
@@ -10,9 +10,13 @@
 # DuckDB (already in requirements.txt) is reused via read-only ATTACH;
 # the playground doesn't add a second DuckDB pin.
 
-# plotly 6 emits base64-encoded typed arrays in figure JSON; Streamlit
-# renders that format only from 1.42 — older Streamlit shows blank
-# charts. Keep this floor in sync with the plotly major (audit 2026-06-10).
-streamlit>=1.42
+# Floor >=1.54.0: <1.54 carries GHSA-7p48-42j8-8846 (MODERATE — an
+# unauthenticated SSRF on Windows that can leak NTLM credentials).
+# FILE ACTIVITY ships on Windows, so this is directly relevant even
+# though the playground is an opt-in admin tool. 1.54 still satisfies the
+# >=1.42 plotly-6 base64-JSON rendering requirement below.
+# (plotly 6 emits base64-encoded typed arrays in figure JSON; Streamlit
+# renders that format only from 1.42 — older Streamlit shows blank charts.)
+streamlit>=1.54.0
 plotly>=6.7.0
 pandas>=2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -33,7 +33,19 @@ duckdb>=1.5.2
 # sqlite_scanner extension. 10-50x faster than per-batch executemany on
 # 100k+ row scans. Missing package -> ParquetStager.available=False and
 # the scanner silently falls back to bulk_insert_scanned_files.
-pyarrow>=14.0
+#
+# Floor >=23.0.1 — clears three advisories that the old >=14.0 range
+# still allowed a resolver to pick:
+#   * GHSA-5wvp-7f3h-6wmm (CRITICAL, <14.0.1) — arbitrary code execution
+#     reading a malicious Parquet/IPC file via read_table.
+#   * PYSEC-2024-161 (<17.0.0).
+#   * GHSA-rgxp-2hwp-jwgg / PYSEC-2026-113 (15.0.0–23.0.0) — use-after-free
+#     reading an IPC file with pre-buffering; fixed in 23.0.1.
+# We only ever read .parquet files WE wrote to data/staging/ (crash-recovery
+# re-ingest in staging.py), never untrusted Arrow IPC, so practical
+# exploitability is low — but the floor must not ALLOW a vulnerable resolve.
+# 23.x is API-compatible with our read_table/write_table usage.
+pyarrow>=23.0.1
 
 # Active Directory lookup (optional): pure-Python LDAP client.
 # When installed and active_directory.enabled=true, dashboard resolves


### PR DESCRIPTION
## Why

CVE-resilience pass requested. Scanned **every `requirements*.txt` floor** against the OSV advisory DB (the `>=` floor is what a resolver may legally pick, so a vulnerable floor = an *allowed* vulnerable install — exactly the "1 moderate advisory" GitHub keeps surfacing on push). Three reachable ranges found; this PR clears the two that have clean in-range fixes.

## What

| Dep | Floor | Advisories cleared |
|---|---|---|
| **pyarrow** | `>=14.0` → **`>=23.0.1`** | `GHSA-5wvp-7f3h-6wmm` **CRITICAL** (<14.0.1, arbitrary code execution reading a malicious Parquet/IPC via `read_table`) · `PYSEC-2024-161` (<17.0.0) · `GHSA-rgxp-2hwp-jwgg` / `PYSEC-2026-113` (15.0–23.0, use-after-free reading IPC with pre-buffering; fixed 23.0.1) |
| **streamlit** | `>=1.42` → **`>=1.54.0`** | `GHSA-7p48-42j8-8846` **MODERATE** (unauthenticated SSRF on Windows leaking NTLM creds) |

Both re-verified **CLEAN** against OSV after the bump. ci_guards 12/12.

**Reachability honesty:**
- pyarrow: we only `read_table` `.parquet` files **we wrote ourselves** (crash-recovery re-ingest in `staging.py`), never untrusted Arrow IPC — practical exploitability is low, but the floor must not *allow* the bad versions. 23.x is API-compatible with our `read_table`/`write_table` usage.
- streamlit: the playground is an opt-in admin tool, but we ship on **Windows** so the NTLM-SSRF is directly relevant. 1.54 still satisfies the `>=1.42` plotly-6 base64-JSON rendering requirement from #274.

## Deferred (flagged, not bundled)

- **pytest** `GHSA-6w46-j5rx-g56g` (MODERATE, local tmpdir handling) is **dev-only** and fixed only in `>=9.0.3` — a **major** bump from our `<9` cap. Forcing a major test-framework bump inside a security patch risks a blind CI break that's hard to distinguish from a real regression. Left for a deliberate follow-up that validates pytest 9 in CI on its own.

## Source-code audit (parallel pass — informational, no code change here)

A full defensive source audit (SQLi / path-traversal / command-injection / SSRF / auth-bypass / audit-chain tamper across `src` + `scripts` + `deploy`) ran alongside this and found **no Critical or High reachable vulnerabilities** — parameterized SQL throughout, realpath traversal guards, `shell=False` argv lists, server-computed audit chain, `hmac.compare_digest` auth. Two **Medium** hardening notes worth separate issues: (M1) `list-dir`/`open-folder` allow full-filesystem enumeration for an unauthenticated *localhost* client; (M2) diag/error-report redaction is key-name-based only (a secret under an off-list key or inside a URL value can reach an `--upload`ed GitHub issue). Both are opt-in/local-surface, not request-reachable RCE — I'll file them as tracked hardening issues rather than rush them in.

## Test plan

- [x] OSV re-scan of all manifests: only the deferred dev-only pytest moderate remains.
- [x] `python scripts/ci_guards.py` → 12/12.
- [ ] CI on this head.

https://claude.ai/code/session_01KNp4i1AwzcBwncqJTh1Uog

---
_Generated by [Claude Code](https://claude.ai/code/session_01KNp4i1AwzcBwncqJTh1Uog)_