### PR TITLE
fix(security): value-level secret scrub in diag + error-report redaction (#279)

### DIFF
--- a/scripts/collect_diag.py
+++ b/scripts/collect_diag.py
@@ -38,9 +38,22 @@ _REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 if _REPO_ROOT not in sys.path:
     sys.path.insert(0, _REPO_ROOT)
 
+# Value-level secret scrub shared with the auto error-reporter (issue #279).
+# ``collect_diag`` is a stdlib-only standalone script under scripts/, but the
+# repo root is on sys.path above, so the src import resolves both when run via
+# fa.cmd and from the dashboard endpoint.
+from src.utils.secret_scrub import scrub_secret_values  # noqa: E402
+
 # --------------------------------------------------------------------------
 # Redaction — secrets are ALWAYS masked, regardless of --no-redact (which only
 # governs whether sample owner names / full paths are included).
+#
+# Two layers, composed: (1) key-name masking — if the KEY looks sensitive the
+# whole value is dropped; (2) value-level scrub — for every surviving STRING
+# value, mask high-signal secret SHAPES (PAT / PEM / URL-creds / ...) no matter
+# the key name, via the shared ``scrub_secret_values`` helper. Layer 2 closes
+# issue #279: a credential under an off-list key (free-text notes, a token in a
+# URL value) no longer reaches an uploaded GitHub issue in clear.
 # --------------------------------------------------------------------------
 _SENSITIVE_KEY_HINTS = (
     "password", "passwd", "secret", "token", "api_key", "apikey",
@@ -51,7 +64,7 @@ _REDACTED = "***REDACTED***"
 
 
 def _redact_config(obj: Any) -> Any:
-    """Recursively mask values whose key looks like a secret."""
+    """Recursively mask secrets: by key name AND by value shape (#279)."""
     if isinstance(obj, dict):
         out = {}
         for key, value in obj.items():
@@ -62,6 +75,9 @@ def _redact_config(obj: Any) -> Any:
         return out
     if isinstance(obj, list):
         return [_redact_config(v) for v in obj]
+    if isinstance(obj, str):
+        # Off-list key, but the value itself may carry a secret shape.
+        return scrub_secret_values(obj)
     return obj
 
 
@@ -561,7 +577,11 @@ def main(argv: Optional[list[str]] = None) -> int:
                   "$FILEACTIVITY_TELEMETRY_TOKEN (or --repo/--token)",
                   file=sys.stderr)
             return 0
+        # Path scrub is operator-gated (redact_paths); the secret-value scrub
+        # is ALWAYS applied on the upload path (#279) — it also catches a token
+        # that surfaced in the log tail, which the per-config scrub never sees.
         body = _scrub_paths(markdown) if scrub else markdown
+        body = scrub_secret_values(body)
         try:
             url = upload_to_github(body, repo, token, label=label)
             print(f"[OK] Posted GitHub issue: {url}")

--- a/src/telemetry/error_reporter.py
+++ b/src/telemetry/error_reporter.py
@@ -30,6 +30,8 @@ from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Any, Optional
 
+from src.utils.secret_scrub import scrub_secret_values
+
 SECRET_KEY_PATTERN = re.compile(
     r"(password|token|api[_-]?key|secret|signing[_-]?key)", re.I
 )
@@ -191,11 +193,17 @@ class ErrorReporter:
         if isinstance(value, tuple):
             return tuple(self._redact_secrets(v) for v in value)
         if isinstance(value, str):
-            return self._redact_paths(value)
+            # Compose the (operator-gated) path scrub with the value-level
+            # secret scrub (#279): a secret under an off-list key — or a PAT
+            # inside a URL value — is masked by shape regardless of key name
+            # and regardless of the redact_paths privacy flag.
+            return scrub_secret_values(self._redact_paths(value))
         return value
 
     def _sanitize_text(self, text: str) -> str:
-        return self._redact_paths(text)
+        # Traceback + exception message: scrub secret shapes (#279) on top of
+        # the gated path redaction. Secrets must never reach an issue body.
+        return scrub_secret_values(self._redact_paths(text))
 
     def _redact_paths(self, text: str) -> str:
         if not isinstance(text, str) or not text:

--- a/src/utils/secret_scrub.py
+++ b/src/utils/secret_scrub.py
@@ -1,0 +1,115 @@
+"""Value-level secret scrubbing (issue #279 — hardening M2).
+
+Both the diagnostics bundle (``scripts/collect_diag.py``) and the auto
+error-reporter (``src/telemetry/error_reporter.py``) historically masked a
+value **only when its KEY name** looked sensitive (``password``, ``token``,
+``secret``, ...). A secret stored under an off-list key — a credential pasted
+into a free-text ``notes:`` field, a PAT embedded in a URL value, creds under
+a custom key — sailed straight through and was uploaded in clear when the
+operator ran ``fa.cmd diag --upload`` or the error-reporter fired.
+
+This module adds the missing half: a **value-level regex scrub** that masks
+the high-signal secret *shapes* regardless of the key they sit under. It is
+composed on top of (not a replacement for) the existing key-name masking and
+path scrubbing in each module.
+
+Design contract:
+    * Mask the MATCH, not the whole value, so a config/log line stays
+      readable (``repo: https://***REDACTED***@github.com/o/r`` rather than
+      the whole line vanishing).
+    * Conservative on generic blobs: the catch-all base64/key-material
+      pattern requires a length floor AND mixed character classes, so a
+      lowercase-hex SHA/MD5 digest or an all-digit id in normal config is
+      NOT mangled. False positives erode trust in the bundle.
+    * Idempotent + safe on non-str / None: ``scrub_secret_values`` returns
+      the input unchanged when it is not a non-empty ``str``, and re-running
+      it over already-scrubbed text is a no-op (the ``***REDACTED***``
+      sentinel contains no character the patterns match).
+    * stdlib only — imported from a ``scripts/`` standalone tool, so it must
+      carry no third-party dependency.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+# The replacement sentinel — identical to the one both call sites already use
+# for key-name redaction, so the output is visually uniform.
+REDACTED = "***REDACTED***"
+
+
+# Each entry is (compiled_pattern, replacement). ``replacement`` may reference
+# capture groups so we can keep the structural framing of a value (e.g. the
+# ``://`` and ``@`` around URL credentials) while masking only the secret.
+#
+# Ordering note: the specific high-signal shapes run BEFORE the generic
+# base64/hex catch-all. The catch-all's character class excludes ``*``, so a
+# value already collapsed to ``***REDACTED***`` by an earlier pattern is never
+# re-matched — keeping the whole pass idempotent.
+_SECRET_VALUE_PATTERNS: tuple[tuple[re.Pattern[str], str], ...] = (
+    # PEM private-key blocks — the entire armored block, any key type
+    # (RSA / EC / OPENSSH / DSA / generic "PRIVATE KEY"). DOTALL so the
+    # base64 body across newlines is consumed; non-greedy to stop at the
+    # first matching END line.
+    (
+        re.compile(
+            r"-----BEGIN [A-Z0-9 ]*PRIVATE KEY-----"
+            r".*?"
+            r"-----END [A-Z0-9 ]*PRIVATE KEY-----",
+            re.DOTALL,
+        ),
+        REDACTED,
+    ),
+    # GitHub tokens: ghp_ (PAT), gho_ (OAuth), ghu_ (user-to-server),
+    # ghs_ (server-to-server), ghr_ (refresh). 36+ char body.
+    (re.compile(r"\bgh[pousr]_[A-Za-z0-9]{36,}\b"), REDACTED),
+    # Slack tokens: xoxb / xoxa / xoxp / xoxr / xoxs prefixes.
+    (re.compile(r"\bxox[baprs]-[A-Za-z0-9-]{10,}\b"), REDACTED),
+    # AWS access key id: AKIA + 16 upper-alnum.
+    (re.compile(r"\bAKIA[0-9A-Z]{16}\b"), REDACTED),
+    # Credentials embedded in a URL authority: scheme://user:pass@host .
+    # Keep the ``://`` and ``@`` framing; mask only the ``user:pass`` run.
+    # The user/pass character class excludes ``/ : @ whitespace`` so the
+    # match is tightly bounded to a single authority component.
+    (
+        re.compile(r"(://)[^/\s:@]+:[^/\s:@]+(@)"),
+        r"\1" + REDACTED + r"\2",
+    ),
+    # Generic base64 / key-material blob — the conservative catch-all.
+    # Requires a 40-char floor AND that the run contains at least one
+    # lowercase, one uppercase AND one digit (lookaheads). That charset
+    # mix deliberately EXCLUDES:
+    #   * lowercase-hex digests (SHA-256/SHA-1/MD5 — no uppercase),
+    #   * all-decimal ids (no letters),
+    #   * UUIDs / paths (too short once dashes/slashes bound the run),
+    # so legitimate config values are not over-masked while real base64
+    # secrets (which mix case + digits, often with +//=) are caught.
+    (
+        re.compile(
+            r"(?<![A-Za-z0-9+/=_-])"            # left boundary
+            r"(?=[A-Za-z0-9+/=_-]{40,})"        # >= 40 chars in the class
+            r"(?=[A-Za-z0-9+/=_-]*[a-z])"       # has a lowercase
+            r"(?=[A-Za-z0-9+/=_-]*[A-Z])"       # has an uppercase
+            r"(?=[A-Za-z0-9+/=_-]*[0-9])"       # has a digit
+            r"[A-Za-z0-9+/=_-]{40,}"
+            r"(?![A-Za-z0-9+/=_-])"             # right boundary
+        ),
+        REDACTED,
+    ),
+)
+
+
+def scrub_secret_values(text: Any) -> Any:
+    """Mask high-signal secret *shapes* anywhere inside *text*.
+
+    Returns *text* unchanged when it is not a non-empty ``str`` (so the
+    helper is safe to drop into a recursive walk over arbitrary config /
+    context values). Masks only the matched substring, not the whole value,
+    and is idempotent: re-running it over its own output is a no-op.
+    """
+    if not isinstance(text, str) or not text:
+        return text
+    for pattern, replacement in _SECRET_VALUE_PATTERNS:
+        text = pattern.sub(replacement, text)
+    return text

--- a/tests/test_collect_diag.py
+++ b/tests/test_collect_diag.py
@@ -84,6 +84,59 @@ def test_redaction_masks_secret_like_keys():
 
 
 # ---------------------------------------------------------------------------
+# value-level redaction (#279) — secret SHAPES masked regardless of key name
+# ---------------------------------------------------------------------------
+def test_redaction_masks_pat_under_non_secret_key():
+    # 'notes' is NOT in _SENSITIVE_KEY_HINTS, so pre-#279 this PAT survived.
+    src = {"notes": "ops left ghp_0123456789abcdefABCDEF0123456789abcdef here"}
+    out = cd._redact_config(src)
+    assert "ghp_0123456789abcdefABCDEF0123456789abcdef" not in out["notes"]
+    assert cd._REDACTED in out["notes"]
+
+
+def test_redaction_masks_credentials_in_url_value():
+    src = {"endpoint": "https://svc:s3cretPATvalue1234@api.example.com/v1"}
+    out = cd._redact_config(src)
+    assert "svc:s3cretPATvalue1234" not in out["endpoint"]
+    assert "s3cretPATvalue1234" not in out["endpoint"]
+    assert cd._REDACTED in out["endpoint"]
+    # URL framing stays readable
+    assert "@api.example.com/v1" in out["endpoint"]
+
+
+def test_redaction_masks_pem_block_in_value():
+    src = {
+        "tls": {
+            "cert_inline": (
+                "-----BEGIN RSA PRIVATE KEY-----\n"
+                "MIIEpAIBAAKCAQEAbody...\n"
+                "-----END RSA PRIVATE KEY-----"
+            )
+        }
+    }
+    out = cd._redact_config(src)
+    assert "BEGIN RSA PRIVATE KEY" not in out["tls"]["cert_inline"]
+    assert cd._REDACTED in out["tls"]["cert_inline"]
+
+
+def test_redaction_does_not_overmask_hex_hash_under_non_secret_key():
+    # A SHA-256 digest under a non-secret key must NOT be mangled — the
+    # value scrub is conservative (false-positive guard).
+    digest = "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08"
+    src = {"baseline_checksum": digest, "rev": "v1.9.0-rc1+30fd8a9"}
+    out = cd._redact_config(src)
+    assert out["baseline_checksum"] == digest
+    assert out["rev"] == "v1.9.0-rc1+30fd8a9"
+
+
+def test_redaction_in_list_values():
+    src = {"args": ["--token", "ghp_0123456789abcdefABCDEF0123456789abcdef"]}
+    out = cd._redact_config(src)
+    assert "ghp_0123456789abcdefABCDEF0123456789abcdef" not in out["args"]
+    assert cd._REDACTED in out["args"]
+
+
+# ---------------------------------------------------------------------------
 # collect() structure + owner resolution
 # ---------------------------------------------------------------------------
 def test_collect_structure_and_flags(tmp_path):

--- a/tests/test_error_reporter.py
+++ b/tests/test_error_reporter.py
@@ -157,3 +157,65 @@ def test_rate_limit_blocks_after_n(monkeypatch):
     assert len(rejected) == 1
     # And the throttled call must not have hit the network.
     assert counter["n"] == 10
+
+
+# --------------------------------------------------------------------- 6
+def test_value_level_secret_scrubbed_under_offlist_key(monkeypatch):
+    """#279: a PAT / URL-creds under a key NOT matched by SECRET_KEY_PATTERN
+    is masked by VALUE shape before the report leaves the box."""
+    monkeypatch.setenv("FAKE_TELEMETRY_TOKEN", "tkn")
+    reporter = ErrorReporter(_enabled_config(), "1.0.0")
+    exc = _raise_exc(lambda: (_ for _ in ()).throw(ValueError("nope")))
+
+    captured = {}
+
+    def fake_urlopen(req, timeout=None):
+        captured["body"] = req.data.decode("utf-8")
+        return _fake_response({"number": 99})
+
+    with patch("urllib.request.urlopen", side_effect=fake_urlopen):
+        reporter.capture(
+            exc,
+            {
+                # 'notes' / 'repo_url' are NOT in SECRET_KEY_PATTERN, so the
+                # key-name pass leaves them — the value scrub must catch them.
+                "notes": "deploy PAT ghp_0123456789abcdefABCDEF0123456789abcdef",
+                "repo_url": "https://ci:supersecretpass123@git.example.com/x",
+            },
+        )
+
+    body = json.loads(captured["body"])["body"]
+    assert "ghp_0123456789abcdefABCDEF0123456789abcdef" not in body
+    assert "supersecretpass123" not in body
+    assert "***REDACTED***" in body
+
+
+# --------------------------------------------------------------------- 7
+def test_value_level_scrub_not_gated_by_redact_paths(monkeypatch):
+    """The secret-value scrub must run even when redact_paths is off — a
+    secret is not a path, so the path-privacy flag must not gate it."""
+    monkeypatch.setenv("FAKE_TELEMETRY_TOKEN", "tkn")
+    config = {
+        "telemetry": {
+            "enabled": True,
+            "github": {"repo": "o/r", "token_env": "FAKE_TELEMETRY_TOKEN"},
+            "privacy": {"redact_paths": False},  # paths NOT redacted
+        }
+    }
+    reporter = ErrorReporter(config, "1.0.0")
+    exc = _raise_exc(lambda: (_ for _ in ()).throw(ValueError("x")))
+
+    captured = {}
+
+    def fake_urlopen(req, timeout=None):
+        captured["body"] = req.data.decode("utf-8")
+        return _fake_response({"number": 7})
+
+    with patch("urllib.request.urlopen", side_effect=fake_urlopen):
+        reporter.capture(
+            exc, {"misc": "tok gho_ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789ab"}
+        )
+
+    body = json.loads(captured["body"])["body"]
+    assert "gho_ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789ab" not in body
+    assert "***REDACTED***" in body

--- a/tests/test_secret_scrub.py
+++ b/tests/test_secret_scrub.py
@@ -1,0 +1,158 @@
+"""Tests for src/utils/secret_scrub.py — value-level secret scrub (issue #279).
+
+The scrub masks high-signal secret SHAPES regardless of the key a value sits
+under, composing with (not replacing) the existing key-name redaction in
+collect_diag.py and error_reporter.py. These tests pin both halves of the
+contract: it masks real secrets, and it is conservative enough NOT to mangle
+ordinary config (lowercase-hex digests, ids, paths, plain URLs).
+"""
+
+import os
+import sys
+
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if REPO_ROOT not in sys.path:
+    sys.path.insert(0, REPO_ROOT)
+
+from src.utils.secret_scrub import REDACTED, scrub_secret_values  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# non-string / empty inputs pass through untouched
+# ---------------------------------------------------------------------------
+def test_non_string_inputs_unchanged():
+    assert scrub_secret_values(None) is None
+    assert scrub_secret_values(42) == 42
+    assert scrub_secret_values(True) is True
+    assert scrub_secret_values("") == ""
+    assert scrub_secret_values(["x"]) == ["x"]  # lists are not strings -> as-is
+
+
+# ---------------------------------------------------------------------------
+# high-signal secret shapes are masked, surrounding text preserved
+# ---------------------------------------------------------------------------
+def test_github_pat_masked_keep_surrounding():
+    text = "see token ghp_0123456789abcdefABCDEF0123456789abcdef now"
+    out = scrub_secret_values(text)
+    assert "ghp_0123456789abcdefABCDEF0123456789abcdef" not in out
+    assert REDACTED in out
+    # surrounding words survive — we mask the match, not the whole value
+    assert out.startswith("see token ")
+    assert out.endswith(" now")
+
+
+def test_github_oauth_and_server_tokens_masked():
+    for tok in (
+        "gho_ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789ab",
+        "ghs_ZYXWVUTSRQPONMLKJIHGFEDCBA9876543210zz",
+        "ghr_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa11",
+    ):
+        assert scrub_secret_values(tok) == REDACTED
+
+
+def test_slack_token_masked():
+    out = scrub_secret_values("hook xoxb-12345678901-abcdEFGHijkl done")
+    assert "xoxb-12345678901-abcdEFGHijkl" not in out
+    assert REDACTED in out
+
+
+def test_aws_access_key_id_masked():
+    out = scrub_secret_values("creds AKIAIOSFODNN7EXAMPLE here")
+    assert "AKIAIOSFODNN7EXAMPLE" not in out
+    assert REDACTED in out
+
+
+def test_pem_private_key_block_masked():
+    pem = (
+        "-----BEGIN RSA PRIVATE KEY-----\n"
+        "MIIEpAIBAAKCAQEA0Z3VS5JJcds3xfn/ygWyF\n"
+        "xQk1Kk3x...truncated...\n"
+        "-----END RSA PRIVATE KEY-----"
+    )
+    text = f"key: {pem}\ntrailer"
+    out = scrub_secret_values(text)
+    assert "BEGIN RSA PRIVATE KEY" not in out
+    assert "MIIEpAIBAAKCAQEA" not in out
+    assert REDACTED in out
+    assert out.endswith("trailer")
+
+
+def test_pem_ec_key_block_masked():
+    pem = (
+        "-----BEGIN EC PRIVATE KEY-----\n"
+        "MHcCAQEEIL... base64 body ...\n"
+        "-----END EC PRIVATE KEY-----"
+    )
+    assert scrub_secret_values(pem) == REDACTED
+
+
+def test_url_credentials_masked_keep_framing():
+    out = scrub_secret_values(
+        "repo: https://alice:ghp_supersecretpat12345@github.com/o/r.git"
+    )
+    # the user:pass run is gone, but the URL framing stays readable
+    assert "alice" not in out
+    assert "ghp_supersecretpat12345" not in out
+    assert "https://" in out
+    assert "@github.com/o/r.git" in out
+    assert REDACTED in out
+
+
+def test_generic_base64_key_material_masked():
+    # mixed case + digits, > 40 chars => looks like key material
+    blob = "dGhpc0lzQVZlcnlMb25nQmFzZTY0RW5jb2RlZFNlY3JldEtleTEyMzQ1Ng=="
+    out = scrub_secret_values(f"opaque = {blob}")
+    assert blob not in out
+    assert REDACTED in out
+
+
+# ---------------------------------------------------------------------------
+# false-positive guard: ordinary config must NOT be over-masked
+# ---------------------------------------------------------------------------
+def test_lowercase_hex_sha256_not_masked():
+    # A real SHA-256 digest (64 lowercase hex chars) is common in config /
+    # logs and must survive — no uppercase => excluded by the charset rule.
+    digest = "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08"
+    assert scrub_secret_values(f"sha256={digest}") == f"sha256={digest}"
+
+
+def test_md5_and_short_hashes_not_masked():
+    assert scrub_secret_values("5d41402abc4b2a76b9719d911017c592") == (
+        "5d41402abc4b2a76b9719d911017c592"
+    )
+
+
+def test_uuid_and_numeric_id_not_masked():
+    uuid = "550e8400-e29b-41d4-a716-446655440000"
+    assert scrub_secret_values(uuid) == uuid
+    assert scrub_secret_values("1234567890123456789012345") == (
+        "1234567890123456789012345"
+    )
+
+
+def test_clean_url_and_paths_not_masked():
+    url = "https://github.com/deepdarbe/file_activity"
+    assert scrub_secret_values(url) == url
+    path = r"\\fileserver\Finans\rapor.xlsx"
+    assert scrub_secret_values(path) == path
+    assert scrub_secret_values("host: mail.local port 25") == (
+        "host: mail.local port 25"
+    )
+
+
+# ---------------------------------------------------------------------------
+# idempotency — re-running over scrubbed output is a no-op
+# ---------------------------------------------------------------------------
+def test_idempotent():
+    samples = [
+        "token ghp_0123456789abcdefABCDEF0123456789abcdef end",
+        "https://u:p@host/x",
+        "-----BEGIN RSA PRIVATE KEY-----\nzz\n-----END RSA PRIVATE KEY-----",
+        "AKIAIOSFODNN7EXAMPLE",
+        "blob dGhpc0lzQVZlcnlMb25nQmFzZTY0RW5jb2RlZFNlY3JldEtleTEyMzQ1Ng==",
+    ]
+    for s in samples:
+        once = scrub_secret_values(s)
+        twice = scrub_secret_values(once)
+        assert once == twice, s
+        assert REDACTED in once


### PR DESCRIPTION
## Why (#279 — hardening M2)

Redaction in `scripts/collect_diag.py` `_redact_config` and `src/telemetry/error_reporter.py` `_redact_secrets` masked a value **only when its KEY name** matched a sensitive-key hint (`password`, `token`, `secret`, ...). A secret stored under an **off-list key** — a credential pasted into a free-text `notes:` field, a PAT embedded inside a URL value (`https://user:pat@host/...`), creds under a custom key — survived redaction and was uploaded in clear when the operator ran `fa.cmd diag --upload` or the auto error-reporter fired.

Medium-severity data-exposure path on the opt-in upload flows. Filed by the 2026-06-12 security-audit pass.

## What

Add a **shared, stdlib-only value-level scrub** that masks high-signal secret *shapes* regardless of key name, composed **on top of** (not replacing) the existing key-name masking + path scrubbing in both modules.

- **New `src/utils/secret_scrub.py`** — module-level list of compiled patterns + `scrub_secret_values(text) -> str`. Single shared home, imported by both `collect_diag.py` (script; repo root already on `sys.path`) and `error_reporter.py` (`src/telemetry/`).
- Patterns covered:
  - PEM private-key blocks (`-----BEGIN … PRIVATE KEY-----` … `-----END … -----`, any key type)
  - GitHub tokens (`gh[pousr]_[A-Za-z0-9]{36,}`)
  - Slack tokens (`xox[baprs]-…`)
  - AWS access key id (`AKIA[0-9A-Z]{16}`)
  - `user:pass@` credentials inside a URL authority — masks only the `user:pass` run, keeps the `://` and `@host` framing
  - conservative base64/key-material catch-all: **≥ 40 chars AND mixed case AND a digit**, so a lowercase-hex SHA/MD5 digest or an all-decimal id in normal config is **not** over-masked (false-positive guard)
- **Masks the match, not the whole value**, so config/log lines stay readable. Idempotent + safe on non-str/`None`.
- Applied to every STRING value during the recursive walk in both modules' redaction. On the diag `--upload` path the scrub is also applied to the full markdown body **unconditionally** (catches a token that surfaced in the log tail); in the error-reporter it runs **regardless of the `redact_paths` privacy flag** (a secret is not a path).
- Existing behaviour preserved: key-name redaction, path scrubbing, and clean-config pass-through are unchanged.

## Test plan

- `python scripts/ci_guards.py` → **12/12** green.
- `python -m pytest tests/test_collect_diag.py tests/test_secret_scrub.py tests/test_error_reporter.py -q` → **38 passed**.
  - New `tests/test_secret_scrub.py`: every secret shape masked; lowercase-hex SHA-256/MD5, UUIDs, numeric ids, plain URLs/paths NOT over-masked; idempotency; non-str/`None`/empty pass-through.
  - `tests/test_collect_diag.py`: PAT under a non-secret key masked, `user:pass@host` URL value masked, inline PEM masked, hex hash under a non-secret key NOT over-masked, list values scrubbed; existing key-name + path tests still pass.
  - `tests/test_error_reporter.py`: PAT/URL-creds under off-list keys masked in the issue body; value scrub fires even with `redact_paths: false`; existing secret/path/fingerprint/rate-limit tests still pass.
- `py_compile` clean on all touched files.
- End-to-end: `_redact_config` on a config with a PAT-in-URL under `telemetry.github.repo` + a Slack token under `notes` masks both while preserving a SHA-256 checksum and key-name redaction.
- Full suite: my three modules import clean; the unrelated failures in this env are all pre-existing missing-dependency collection errors (fastapi/pillow/watchdog/docker), none reference the changed modules.

Closes #279

https://claude.ai/code/session_01KNp4i1AwzcBwncqJTh1Uog

---
_Generated by [Claude Code](https://claude.ai/code/session_01KNp4i1AwzcBwncqJTh1Uog)_