### PR TITLE
fix(security): require auth for list-dir/open-folder even on localhost (#278)

### DIFF
--- a/src/dashboard/api.py
+++ b/src/dashboard/api.py
@@ -79,13 +79,27 @@ def _phase_progress_pct(phase: str, file_count: int) -> int:
     return 0
 
 
-def open_folder_impl(body: dict, client_host: str, popen=None):
+def open_folder_impl(
+    body: dict,
+    client_host: str,
+    popen=None,
+    *,
+    authed: bool = True,
+    allowed_roots: list[str] | None = None,
+):
     """Run the open-folder decision logic.
 
     Pure-ish helper shared by the HTTP endpoint and the unit tests. Returns
     the JSON-serialisable response dict on success, or raises HTTPException
     for invalid input / missing paths. ``popen`` lets tests inject a stub in
     place of ``subprocess.Popen``.
+
+    Issue #278 (M1) — same scope gate as ``list_dir_impl``: an
+    UNAUTHENTICATED localhost caller (``authed=False``) may only natively
+    open a path inside the configured ``allowed_roots`` (or an ancestor of
+    one); anything else is refused with 403 so a tokenless same-host process
+    cannot pop Explorer at arbitrary server locations. ``authed`` defaults
+    True so existing direct-helper unit tests are unaffected.
     """
     if popen is None:
         import subprocess
@@ -96,11 +110,33 @@ def open_folder_impl(body: dict, client_host: str, popen=None):
         raise HTTPException(400, "path gerekli")
 
     # Guvenlik: normalize + gercek yol cozumleme (symlink/junction eskape koruma)
+    # NOTE (CodeQL py/path-injection, #278): accepted sink. Reachable only by
+    # localhost callers (the remote branch below never spawns Explorer); an
+    # UNAUTHENTICATED localhost caller is confined to configured source roots by
+    # the #278 scope gate immediately after this line, and an authenticated
+    # admin opening any path is the intended feature. realpath must run FIRST so
+    # symlink/junction targets can't escape the scope check below.
     folder = os.path.realpath(os.path.normpath(folder))
+
+    is_local = client_host in _LOCAL_CLIENT_HOSTS
+
+    # #278 scope gate (local, tokenless callers only) — evaluated before the
+    # existence check so an out-of-scope path returns 403 whether or not it
+    # exists (no existence oracle). Remote clients never reach the native-open
+    # path below anyway; authenticated admins are unrestricted.
+    if is_local and not authed and not _path_within_source_scope(
+        folder, allowed_roots or []
+    ):
+        raise HTTPException(
+            403,
+            "Bu konum kaynak kok dizinlerinin disinda. Yetkilendirme "
+            "olmadan Explorer yalnizca yapilandirilmis kaynaklar icin "
+            "acilabilir.",
+        )
+
     if not (os.path.isdir(folder) or os.path.isfile(folder)):
         raise HTTPException(404, f"Dizin bulunamadi: {folder}")
 
-    is_local = client_host in _LOCAL_CLIENT_HOSTS
     if not is_local:
         return {
             "success": False,
@@ -140,6 +176,58 @@ def open_folder_impl(body: dict, client_host: str, popen=None):
 #     so the UI can boot the browser without knowing the platform.
 
 LIST_DIR_MAX_ENTRIES = 5000
+
+
+def _normalize_source_roots(raw_roots) -> list[str]:
+    """Realpath/normpath a list of source-root strings, dropping blanks.
+
+    Shared by the ``list_dir`` / ``open_folder`` scope check (#278) and the
+    explorer-open endpoint. Trailing separators are stripped so the prefix
+    comparisons below (``target == root`` / ``startswith(root + sep)``) are
+    exact rather than substring-y.
+    """
+    out: list[str] = []
+    for root in raw_roots or []:
+        root = (root or "").strip()
+        if not root:
+            continue
+        try:
+            out.append(os.path.realpath(os.path.normpath(root)).rstrip("\\/"))
+        except Exception:
+            continue
+    return out
+
+
+def _path_within_source_scope(resolved: str, allowed_roots: list[str]) -> bool:
+    """Issue #278 (M1): is ``resolved`` reachable for an UNAUTHENTICATED
+    localhost folder-picker call?
+
+    Allowed when the path is EITHER inside a configured source root (browse
+    an existing source) OR an *ancestor* of one (navigate *down to* it —
+    "source roots + their parents" from the issue). Everything else
+    (``C:\\Users``, arbitrary system dirs) is refused — that is what closes
+    the whole-filesystem enumeration surface for a tokenless same-host
+    caller.
+
+    With no configured roots (first-run, ``sources: []``) nothing matches,
+    so an unauthenticated caller cannot browse concrete paths at all: they
+    type the UNC path manually (the 403 message says exactly that) or export
+    the bearer token. An *authenticated* admin bypasses this scope at the
+    call site, preserving the full picker.
+    """
+    if not allowed_roots:
+        return False
+    target = (resolved or "").rstrip("\\/")
+    for root in allowed_roots:
+        if target == root:
+            return True
+        # target inside root → normal "browse this source" case.
+        if target.startswith(root + os.sep):
+            return True
+        # target is an ancestor of root → "navigate down to the source".
+        if root.startswith(target + os.sep):
+            return True
+    return False
 
 
 def _list_dir_logical_roots() -> list[dict]:
@@ -202,12 +290,24 @@ def list_dir_impl(
     client_host: str,
     show_hidden: bool = False,
     max_entries: int = LIST_DIR_MAX_ENTRIES,
+    *,
+    authed: bool = True,
+    allowed_roots: list[str] | None = None,
 ):
     """Pure helper backing the /api/system/list-dir endpoint.
 
     Returns ``{path, parent, entries}``; raises HTTPException(403) for a
     remote client and HTTPException(404) for a path that doesn't exist
     or isn't a directory.
+
+    Issue #278 (M1) — scope gate. When ``authed`` is False (the request
+    is an UNAUTHENTICATED localhost caller riding ``allow_unauth_localhost``)
+    concrete paths are restricted to the configured ``allowed_roots`` and
+    their ancestor chain via :func:`_path_within_source_scope`, so a
+    tokenless same-host process can no longer enumerate the whole
+    filesystem (``C:\\Users``, every drive). The route handler passes the
+    real auth result; ``authed`` defaults True so direct unit-test calls
+    of this helper keep the pre-#278 full-listing behaviour.
     """
     if client_host not in _LOCAL_CLIENT_HOSTS:
         raise HTTPException(
@@ -218,6 +318,9 @@ def list_dir_impl(
 
     # Empty path -> logical roots (drives on Windows, "/" on POSIX). We
     # surface ``parent=None`` so the UI hides the "up one level" affordance.
+    # The root list reveals only which drives are mounted (not their
+    # contents), so it stays available to the unauth picker as the
+    # navigation entry point.
     if not path:
         return {
             "path": "",
@@ -226,11 +329,32 @@ def list_dir_impl(
         }
 
     # Path resolution: normpath to collapse ``..``, then realpath to defeat
-    # symlink/junction escape attempts. We don't bind to a specific allow-
-    # list of roots because the operator legitimately needs to pick any
-    # local or mounted UNC path; the localhost-only check above is what
-    # keeps remote clients from walking the filesystem.
+    # symlink/junction escape attempts.
+    # NOTE (CodeQL py/path-injection, #278): accepted sink. list_dir is
+    # localhost-only (a remote client is rejected with 403 above); an
+    # UNAUTHENTICATED localhost caller is scoped to configured source roots by
+    # the #278 gate right after this line, and an authenticated admin is
+    # intentionally unrestricted. realpath must run before the scope check so
+    # symlinks can't escape it.
     resolved = os.path.realpath(os.path.normpath(path))
+
+    # #278 scope gate for unauthenticated localhost callers — evaluated
+    # BEFORE the existence check so an out-of-scope path returns 403 whether
+    # or not it exists (no filesystem-existence oracle). An authenticated
+    # admin (valid bearer token) is unrestricted: picking any local/UNC path
+    # is a legitimate admin action and a hard jail would break first-run UNC
+    # picking. A tokenless caller is confined to configured source roots and
+    # their parents.
+    if not authed and not _path_within_source_scope(
+        resolved, allowed_roots or []
+    ):
+        raise HTTPException(
+            403,
+            "Bu konum kaynak kok dizinlerinin disinda. Yetkilendirme "
+            "olmadan yalnizca yapilandirilmis kaynaklar taranabilir; "
+            "yolu manuel girin veya yonetici jetonu ile baglanin.",
+        )
+
     if not os.path.isdir(resolved):
         raise HTTPException(404, f"Yol bulunamadi: {resolved}")
 
@@ -4118,18 +4242,11 @@ def create_app(db, config, analytics=None, ad_lookup=None, email_notifier=None,
         # Build the allowed-roots set from sources.unc_path. Each candidate
         # path must be inside one of these roots (after realpath). This
         # prevents traversal like ../../etc/passwd and blocks arbitrary
-        # local-disk browsing on the server.
-        allowed_roots: list[str] = []
-        for s in db.get_sources():
-            root = (s.unc_path or "").strip()
-            if not root:
-                continue
-            try:
-                allowed_roots.append(
-                    os.path.realpath(os.path.normpath(root)).rstrip("\\/")
-                )
-            except Exception:
-                continue
+        # local-disk browsing on the server. (Shared helper with the #278
+        # list-dir/open-folder scope gate.)
+        allowed_roots = _normalize_source_roots(
+            (s.unc_path or "") for s in db.get_sources()
+        )
         if not allowed_roots:
             raise HTTPException(
                 400,
@@ -4598,13 +4715,42 @@ def create_app(db, config, analytics=None, ad_lookup=None, email_notifier=None,
             headers={"Content-Disposition": f"attachment; filename={filename}"},
         )
 
+    def _picker_authed(request: Request) -> bool:
+        """Issue #278 (M1): did this request present a VALID bearer token?
+
+        We must distinguish a genuinely authenticated admin from a caller
+        that merely rode the ``allow_unauth_localhost`` bypass, so we ask
+        ``DashboardAuth.has_valid_token`` (which ignores the bypass and is
+        side-effect-free). If the gate is off entirely (``enabled=false``,
+        legacy mode) the operator has opted out of auth, so treat every
+        caller as authed — no restriction beyond the pre-#278 behaviour.
+        """
+        gate = getattr(app.state, "dashboard_auth", None)
+        if gate is None or not getattr(gate, "enabled", True):
+            return True
+        return bool(gate.has_valid_token(request))
+
+    def _picker_allowed_roots() -> list[str]:
+        """Realpath'd configured source roots for the #278 scope gate."""
+        try:
+            return _normalize_source_roots(
+                (s.unc_path or "") for s in db.get_sources()
+            )
+        except Exception:  # pragma: no cover - defensive; empty = deny-all
+            return []
+
     @app.post("/api/system/open-folder")
     async def open_folder(request: Request):
         """Dizini Windows Explorer'da ac (yalnizca yerel istemci icin)."""
         from src.security.dashboard_auth import resolve_effective_client_host
         body = await request.json()
         client_host = resolve_effective_client_host(request)
-        return open_folder_impl(body, client_host)
+        return open_folder_impl(
+            body,
+            client_host,
+            authed=_picker_authed(request),
+            allowed_roots=_picker_allowed_roots(),
+        )
 
     @app.get("/api/system/list-dir")
     def list_dir(
@@ -4621,10 +4767,20 @@ def create_app(db, config, analytics=None, ad_lookup=None, email_notifier=None,
         Uses ``resolve_effective_client_host`` (honours X-Forwarded-For
         when peer is loopback) so a reverse proxy on the same host
         cannot turn every LAN request into a fake "localhost" call.
+
+        Issue #278 (M1): an unauthenticated localhost caller is scoped to
+        configured source roots (+ their parents); an authenticated admin
+        gets the full picker.
         """
         from src.security.dashboard_auth import resolve_effective_client_host
         client_host = resolve_effective_client_host(request)
-        return list_dir_impl(path, client_host, show_hidden=show_hidden)
+        return list_dir_impl(
+            path,
+            client_host,
+            show_hidden=show_hidden,
+            authed=_picker_authed(request),
+            allowed_roots=_picker_allowed_roots(),
+        )
 
     @app.get("/api/system/health")
     def health():

--- a/src/security/dashboard_auth.py
+++ b/src/security/dashboard_auth.py
@@ -140,6 +140,20 @@ class DashboardAuth:
         if self.allow_unauth_localhost and client_host in _LOCAL_HOSTS:
             return True
 
+        return self.has_valid_token(request)
+
+    def has_valid_token(self, request: Any) -> bool:
+        """Return True iff ``request`` carries a VALID bearer token.
+
+        Unlike :meth:`check`, this ignores ``allow_unauth_localhost`` and
+        ``enabled`` entirely — it answers only "did the caller prove the
+        credential?". Issue #278 uses it to distinguish a genuinely
+        authenticated admin from a request that merely rode the localhost
+        bypass, so the folder picker can grant the full filesystem view to
+        the former while scoping the latter to configured source roots.
+        Side-effect-free, so it is safe to call from concurrent threadpool
+        handlers (no shared-state mutation).
+        """
         headers = getattr(request, "headers", None)
         if headers is None:
             return False

--- a/tests/test_list_dir_scope_auth.py
+++ b/tests/test_list_dir_scope_auth.py
@@ -1,0 +1,397 @@
+"""Regression tests for issue #278 (M1): folder-picker scope gate.
+
+`list_dir` / `open_folder` previously let *any* unauthenticated localhost
+caller (riding the ``allow_unauth_localhost`` bypass) enumerate the whole
+server filesystem (drive letters, ``C:\\Users`` …). The fix scopes a
+tokenless localhost caller to the configured source roots + their parent
+chain, while an *authenticated* admin (valid bearer token) keeps the full
+picker.
+
+These tests drive the SAME functions the real route handlers use
+(``list_dir_impl`` / ``open_folder_impl`` + ``DashboardAuth.has_valid_token``
++ ``_normalize_source_roots``) through a minimal FastAPI app that mirrors
+``create_app``'s wiring — the established pattern in ``test_dashboard_auth.py``
+and ``test_list_dir_endpoint.py``.
+
+Coverage:
+  * Unauth localhost, path OUTSIDE source roots -> 403 (the hole is closed).
+  * Unauth localhost, path INSIDE a source root -> 200 (picker still works).
+  * Unauth localhost, path that is an ANCESTOR of a source root -> 200
+    (can navigate down to the source).
+  * Authenticated (valid bearer) localhost, OUT-of-scope path -> 200
+    (admin keeps the full picker).
+  * Empty path (logical roots) -> 200 even unauth (navigation entry point).
+  * First-run (no configured sources) + unauth -> every concrete path 403.
+  * open-folder mirrors the same gate (unauth out-of-scope -> 403).
+  * ``has_valid_token`` ignores the localhost bypass (unit-level).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import tempfile
+from typing import Optional
+
+import pytest
+
+# fastapi may be absent in some CI images. The ``has_valid_token`` unit test
+# (and the pure-helper scope tests) do NOT need fastapi, so we guard only the
+# HTTP-level tests rather than skipping the whole module.
+# ``src.dashboard.api`` imports fastapi at module top, so importing the scope
+# helpers from it requires fastapi. ``DashboardAuth`` lives in
+# ``src.security.dashboard_auth`` which has NO fastapi dependency, so the pure
+# ``has_valid_token`` unit test below runs even where fastapi is absent.
+HAS_FASTAPI = importlib.util.find_spec("fastapi") is not None
+requires_fastapi = pytest.mark.skipif(
+    not HAS_FASTAPI, reason="fastapi not installed in this environment"
+)
+
+from src.security.dashboard_auth import DashboardAuth  # noqa: E402
+
+if HAS_FASTAPI:
+    from src.dashboard.api import (  # noqa: E402
+        _normalize_source_roots,
+        _path_within_source_scope,
+        list_dir_impl,
+        open_folder_impl,
+    )
+
+
+class _FakeSource:
+    """Stand-in for storage.models.Source — only ``unc_path`` is read."""
+
+    def __init__(self, unc_path: str) -> None:
+        self.unc_path = unc_path
+
+
+def _build_app(
+    source_roots: list[str],
+    cfg: dict,
+    *,
+    force_client_host: Optional[str] = None,
+):
+    """Minimal app mirroring create_app's #278 wiring for the two routes.
+
+    Registers the auth middleware FIRST (so it runs INNERMOST relative to
+    the client-host override registered SECOND — Starlette runs middleware
+    LIFO, last-registered outermost), exactly like test_dashboard_auth.py.
+    """
+    from fastapi import FastAPI, Request
+    from fastapi.responses import JSONResponse
+
+    app = FastAPI()
+    app.state.dashboard_auth = DashboardAuth(cfg)
+
+    def _picker_authed(request: Request) -> bool:
+        gate = app.state.dashboard_auth
+        if gate is None or not getattr(gate, "enabled", True):
+            return True
+        return bool(gate.has_valid_token(request))
+
+    def _picker_allowed_roots() -> list[str]:
+        return _normalize_source_roots(
+            (s.unc_path or "") for s in [_FakeSource(r) for r in source_roots]
+        )
+
+    @app.middleware("http")
+    async def auth_mw(request: Request, call_next):
+        gate = app.state.dashboard_auth
+        if gate.check(request):
+            return await call_next(request)
+        return JSONResponse({"detail": "Unauthorized"}, status_code=401)
+
+    if force_client_host is not None:
+        @app.middleware("http")
+        async def _override_client(request: Request, call_next):
+            request.scope["client"] = (force_client_host, 0)
+            return await call_next(request)
+
+    from src.security.dashboard_auth import resolve_effective_client_host
+
+    @app.get("/api/system/list-dir")
+    def list_dir(request: Request, path: str = "", show_hidden: bool = False):
+        client_host = resolve_effective_client_host(request)
+        return list_dir_impl(
+            path,
+            client_host,
+            show_hidden=show_hidden,
+            authed=_picker_authed(request),
+            allowed_roots=_picker_allowed_roots(),
+        )
+
+    @app.post("/api/system/open-folder")
+    async def open_folder(request: Request):
+        body = await request.json()
+        client_host = resolve_effective_client_host(request)
+        return open_folder_impl(
+            body,
+            client_host,
+            popen=lambda *a, **k: None,  # never actually spawn explorer
+            authed=_picker_authed(request),
+            allowed_roots=_picker_allowed_roots(),
+        )
+
+    return app
+
+
+def _client(app):
+    from fastapi.testclient import TestClient
+
+    return TestClient(app)
+
+
+@pytest.fixture
+def source_tree():
+    """A temp 'source root' with a child dir + an out-of-scope sibling dir."""
+    with tempfile.TemporaryDirectory() as base:
+        base = os.path.realpath(base)
+        root = os.path.join(base, "share_root")
+        child = os.path.join(root, "sub")
+        outside = os.path.join(base, "secret_elsewhere")
+        os.makedirs(child)
+        os.makedirs(outside)
+        yield {"base": base, "root": root, "child": child, "outside": outside}
+
+
+def _default_cfg() -> dict:
+    # enabled=true, allow_unauth_localhost=true (the shipped default).
+    return {"dashboard": {"auth": {"enabled": True}}}
+
+
+# ---------------------------------------------------------------------------
+# The core regression: unauth localhost can no longer enumerate out of scope.
+# ---------------------------------------------------------------------------
+
+
+@requires_fastapi
+def test_unauth_localhost_out_of_scope_refused(monkeypatch, source_tree):
+    monkeypatch.delenv("FILEACTIVITY_DASHBOARD_TOKEN", raising=False)
+    app = _build_app(
+        [source_tree["root"]], _default_cfg(), force_client_host="127.0.0.1"
+    )
+    client = _client(app)
+    resp = client.get(
+        "/api/system/list-dir", params={"path": source_tree["outside"]}
+    )
+    assert resp.status_code == 403, resp.text
+
+
+@requires_fastapi
+def test_unauth_localhost_inside_source_allowed(monkeypatch, source_tree):
+    monkeypatch.delenv("FILEACTIVITY_DASHBOARD_TOKEN", raising=False)
+    app = _build_app(
+        [source_tree["root"]], _default_cfg(), force_client_host="127.0.0.1"
+    )
+    client = _client(app)
+    # The configured root itself …
+    assert (
+        client.get(
+            "/api/system/list-dir", params={"path": source_tree["root"]}
+        ).status_code
+        == 200
+    )
+    # … and a child inside it.
+    resp = client.get(
+        "/api/system/list-dir", params={"path": source_tree["child"]}
+    )
+    assert resp.status_code == 200, resp.text
+
+
+@requires_fastapi
+def test_unauth_localhost_ancestor_of_source_allowed(monkeypatch, source_tree):
+    """The picker must let you navigate DOWN to a configured source, so an
+    ancestor of a source root is in scope."""
+    monkeypatch.delenv("FILEACTIVITY_DASHBOARD_TOKEN", raising=False)
+    app = _build_app(
+        [source_tree["root"]], _default_cfg(), force_client_host="127.0.0.1"
+    )
+    client = _client(app)
+    resp = client.get(
+        "/api/system/list-dir", params={"path": source_tree["base"]}
+    )
+    assert resp.status_code == 200, resp.text
+
+
+@requires_fastapi
+def test_authenticated_localhost_out_of_scope_allowed(monkeypatch, source_tree):
+    """A valid bearer token => full picker, even from localhost and even for
+    a path outside the configured source roots."""
+    monkeypatch.setenv("FILEACTIVITY_DASHBOARD_TOKEN", "s3cret")
+    app = _build_app(
+        [source_tree["root"]], _default_cfg(), force_client_host="127.0.0.1"
+    )
+    client = _client(app)
+    resp = client.get(
+        "/api/system/list-dir",
+        params={"path": source_tree["outside"]},
+        headers={"Authorization": "Bearer s3cret"},
+    )
+    assert resp.status_code == 200, resp.text
+
+
+@requires_fastapi
+def test_unauth_empty_path_returns_roots(monkeypatch, source_tree):
+    """Logical roots stay available to the unauth picker (entry point)."""
+    monkeypatch.delenv("FILEACTIVITY_DASHBOARD_TOKEN", raising=False)
+    app = _build_app(
+        [source_tree["root"]], _default_cfg(), force_client_host="127.0.0.1"
+    )
+    client = _client(app)
+    resp = client.get("/api/system/list-dir", params={"path": ""})
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["parent"] is None
+    assert isinstance(resp.json()["entries"], list)
+
+
+@requires_fastapi
+def test_first_run_no_sources_unauth_concrete_path_refused(
+    monkeypatch, source_tree
+):
+    """No configured sources + unauth => every concrete path is refused
+    (deny-all scope). The operator types the UNC path or sets the token."""
+    monkeypatch.delenv("FILEACTIVITY_DASHBOARD_TOKEN", raising=False)
+    app = _build_app([], _default_cfg(), force_client_host="127.0.0.1")
+    client = _client(app)
+    resp = client.get(
+        "/api/system/list-dir", params={"path": source_tree["root"]}
+    )
+    assert resp.status_code == 403, resp.text
+    # …but an authed admin still gets it.
+    monkeypatch.setenv("FILEACTIVITY_DASHBOARD_TOKEN", "tok")
+    app2 = _build_app([], _default_cfg(), force_client_host="127.0.0.1")
+    c2 = _client(app2)
+    assert (
+        c2.get(
+            "/api/system/list-dir",
+            params={"path": source_tree["root"]},
+            headers={"Authorization": "Bearer tok"},
+        ).status_code
+        == 200
+    )
+
+
+@requires_fastapi
+def test_remote_caller_blocked_by_middleware(monkeypatch, source_tree):
+    """Sanity: a remote caller without a token is 401'd by the middleware
+    before the route even runs (unchanged pre-#278 behaviour)."""
+    monkeypatch.setenv("FILEACTIVITY_DASHBOARD_TOKEN", "s3cret")
+    app = _build_app(
+        [source_tree["root"]], _default_cfg(), force_client_host="10.0.0.5"
+    )
+    client = _client(app)
+    resp = client.get(
+        "/api/system/list-dir", params={"path": source_tree["root"]}
+    )
+    assert resp.status_code == 401, resp.text
+
+
+# ---------------------------------------------------------------------------
+# open-folder mirrors the same gate.
+# ---------------------------------------------------------------------------
+
+
+@requires_fastapi
+def test_open_folder_unauth_out_of_scope_refused(monkeypatch, source_tree):
+    monkeypatch.delenv("FILEACTIVITY_DASHBOARD_TOKEN", raising=False)
+    app = _build_app(
+        [source_tree["root"]], _default_cfg(), force_client_host="127.0.0.1"
+    )
+    client = _client(app)
+    resp = client.post(
+        "/api/system/open-folder", json={"path": source_tree["outside"]}
+    )
+    assert resp.status_code == 403, resp.text
+
+
+@requires_fastapi
+def test_open_folder_unauth_in_scope_ok(monkeypatch, source_tree):
+    monkeypatch.delenv("FILEACTIVITY_DASHBOARD_TOKEN", raising=False)
+    app = _build_app(
+        [source_tree["root"]], _default_cfg(), force_client_host="127.0.0.1"
+    )
+    client = _client(app)
+    resp = client.post(
+        "/api/system/open-folder", json={"path": source_tree["child"]}
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json().get("mode") == "native"
+
+
+@requires_fastapi
+def test_open_folder_authed_out_of_scope_ok(monkeypatch, source_tree):
+    monkeypatch.setenv("FILEACTIVITY_DASHBOARD_TOKEN", "s3cret")
+    app = _build_app(
+        [source_tree["root"]], _default_cfg(), force_client_host="127.0.0.1"
+    )
+    client = _client(app)
+    resp = client.post(
+        "/api/system/open-folder",
+        json={"path": source_tree["outside"]},
+        headers={"Authorization": "Bearer s3cret"},
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json().get("mode") == "native"
+
+
+# ---------------------------------------------------------------------------
+# Unit-level: has_valid_token ignores the localhost bypass.
+# ---------------------------------------------------------------------------
+
+
+class _Req:
+    def __init__(self, host: str, headers: dict) -> None:
+        self.client = type("C", (), {"host": host})()
+        self.headers = headers
+
+
+def test_has_valid_token_ignores_localhost_bypass(monkeypatch):
+    monkeypatch.setenv("FILEACTIVITY_DASHBOARD_TOKEN", "s3cret")
+    gate = DashboardAuth({"dashboard": {"auth": {"enabled": True}}})
+    # check() bypasses on localhost (no token needed) …
+    assert gate.check(_Req("127.0.0.1", {})) is True
+    # … but has_valid_token() demands the credential regardless of host.
+    assert gate.has_valid_token(_Req("127.0.0.1", {})) is False
+    assert (
+        gate.has_valid_token(
+            _Req("127.0.0.1", {"Authorization": "Bearer s3cret"})
+        )
+        is True
+    )
+    assert (
+        gate.has_valid_token(
+            _Req("127.0.0.1", {"Authorization": "Bearer wrong"})
+        )
+        is False
+    )
+
+
+# ---------------------------------------------------------------------------
+# Unit-level: the scope predicate itself (no fastapi needed).
+# ---------------------------------------------------------------------------
+
+
+@requires_fastapi
+def test_path_within_source_scope_predicate():
+    sep = os.sep
+    root = sep.join(["", "srv", "share"])  # /srv/share (posix) style
+    roots = [root]
+    # Inside the root and the root itself -> in scope.
+    assert _path_within_source_scope(root, roots) is True
+    assert _path_within_source_scope(root + sep + "sub", roots) is True
+    # Ancestor of the root -> in scope (navigate down to it).
+    assert _path_within_source_scope(sep + "srv", roots) is True
+    # Unrelated sibling / system path -> out of scope.
+    assert _path_within_source_scope(sep + "srv" + sep + "other", roots) is False
+    assert _path_within_source_scope(sep + "etc", roots) is False
+    # A path that merely shares a string prefix but not a path boundary must
+    # NOT match (e.g. /srv/share-secret vs /srv/share).
+    assert _path_within_source_scope(root + "-secret", roots) is False
+    # Empty allow-list -> nothing is in scope (first-run deny-all).
+    assert _path_within_source_scope(root, []) is False
+
+
+@requires_fastapi
+def test_normalize_source_roots_drops_blanks():
+    out = _normalize_source_roots(["", None, "  ", os.getcwd()])
+    assert out == [os.path.realpath(os.getcwd()).rstrip("\\/")]


### PR DESCRIPTION
## Why (#278)

`src/dashboard/api.py` `list_dir` (`/api/system/list-dir`) and `open_folder` (`/api/system/open-folder`) had **no root allow-list**, and `dashboard_auth.py` defaults `allow_unauth_localhost=true`. So any **unauthenticated same-host process** could enumerate the entire server filesystem (drive letters, `C:\Users`, every mounted volume) and pop Explorer at arbitrary paths. Medium severity (information disclosure on a file-server appliance / multi-tenant box). The XFF-spoof guard (`resolve_effective_client_host`) is intact and unchanged — a plain LAN attacker still cannot forge `127.0.0.1`.

## Option 1 vs Option 2 — decision: **Option 2 (scope to source roots + parents)**

The issue recommends Option 1 (force the bearer token even on localhost) **unless first-run needs the picker before a token exists**. I verified the code and **first-run does need it**, so Option 1 as a pure auth-gate is wrong here:

- **The frontend never sends an `Authorization` header.** Neither the global `api()` wrapper (`index.html:2231`) nor the picker's bare `fetch()` (`index.html:3292`) attaches a bearer token — grep for `Authorization|Bearer|setRequestHeader` in `index.html` returns nothing. The whole dashboard works on localhost *purely* via the `allow_unauth_localhost` bypass; there is no browser-side "login" that yields a token.
- **The documented, intended workflow is tokenless localhost browsing.** `config.yaml` (`allow_unauth_localhost`) and `docs/operator-runbook.md` state the operator browses **from an RDP session on the server**, no token. The source-path picker is part of that tokenless first-run/setup flow.
- The 2026-04-28 security audit even notes for `list-dir`: *"A jail would break legitimate UNC-path picking."*

So **pure Option 1 would break the legitimate localhost operator's picker** (the browser has no token to send) — exactly the fallback condition the issue calls out. **Option 2** closes the enumeration hole while preserving every legitimate workflow, and mirrors the **existing** `allowed_roots`-from-`sources.unc_path` pattern already in `api.py` (the explorer-open endpoint, now refactored to share the helper).

## What

- **`DashboardAuth.has_valid_token(request)`** (new, in `src/security/dashboard_auth.py`): a side-effect-free predicate that answers "did the caller present a VALID bearer token?", ignoring the `allow_unauth_localhost` bypass. `check()` now delegates its token tail to it. Lets the picker tell a genuinely authenticated admin apart from a caller that merely rode the localhost bypass (no shared-state mutation → safe under the sync-`def` threadpool).
- **Scope gate in `list_dir_impl` / `open_folder_impl`** (`src/dashboard/api.py`): new `authed` + `allowed_roots` params.
  - **Authenticated admin** → unrestricted full picker (picking any local/UNC path is a legitimate admin action; a hard jail would break first-run UNC entry).
  - **Unauthenticated localhost** → confined to configured source roots **and their ancestor chain** (so you can navigate *down to* a source) via the new `_path_within_source_scope`. Empty path still returns the drive/logical roots (navigation entry point; reveals only which drives are mounted, not their contents). Anything else (`C:\Users`, arbitrary system dirs) → **403**.
  - The scope check runs **before** the existence check, so an out-of-scope path returns 403 whether or not it exists (no filesystem-existence oracle).
  - First-run (`sources: []`) + unauth → every concrete path is 403; the operator types the UNC path manually (the 403 message says exactly that) or exports the token. This satisfies the acceptance bullet ("refused **OR** scoped").
- **Route wiring**: `list_dir` / `open_folder` compute `authed` via `app.state.dashboard_auth.has_valid_token(request)` and `allowed_roots` from `db.get_sources()`.
- **Refactor (no behaviour change)**: extracted `_normalize_source_roots(...)` and pointed the pre-existing explorer-open endpoint's inline root-building at it (DRY).
- **No frontend change** — the picker keeps using its bare `fetch`; authenticated remote admins already pass the middleware and get the full picker, localhost operators get scoped results plus the existing friendly 403 message.
- Defaults chosen so the helpers' existing direct-call unit tests (`test_list_dir_endpoint.py`) are unaffected (`authed=True` default = pre-#278 full listing); the security boundary lives at the route, which always passes the real values.

## Test plan

`tests/test_list_dir_scope_auth.py` (new), mirroring `test_dashboard_auth.py` / `test_list_dir_endpoint.py`. Asserts via the real route wiring + real impls:
- unauth localhost out-of-scope `list-dir` / `open-folder` → **403** (hole closed);
- unauth localhost **inside** a source / **ancestor** of a source → 200 (picker UX preserved);
- **authenticated** localhost out-of-scope → 200 (admin full picker);
- empty path unauth → logical roots;
- **first-run** no-sources unauth concrete path → 403, but authed admin → 200;
- remote caller without token → 401 (middleware, unchanged);
- unit: `has_valid_token` ignores the localhost bypass; `_path_within_source_scope` predicate (incl. the `/srv/share-secret` vs `/srv/share` prefix-trap) and `_normalize_source_roots`.

**`fastapi` is absent in the dev sandbox**, so the HTTP-level tests are `@pytest.mark.skipif(not HAS_FASTAPI)` and the api-import is guarded (the `has_valid_token` unit test still runs — it needs no fastapi). In this env: `1 passed, 12 skipped`. The skipped tests **will run in CI** (fastapi present). I additionally validated the full behaviour by importing the **real** `list_dir_impl`/`open_folder_impl` with a minimal fastapi stub and exercising every case — all green (see commit). 

Verified here:
- `python scripts/ci_guards.py` → **12/12** (A-AUDIT/C-CURSOR/A-AWAIT/… all green; A-AUDIT allowlist count unchanged at 36 — no new mutating endpoint).
- `python -m py_compile` on all three changed files → OK.
- `python -m pytest tests/test_list_dir_scope_auth.py` → 1 passed, 12 skipped (fastapi-gated).

No behaviour change beyond the auth/scope gate. `resolve_effective_client_host` (XFF-spoof guard) untouched.

Closes #278

https://claude.ai/code/session_01KNp4i1AwzcBwncqJTh1Uog

---
_Generated by [Claude Code](https://claude.ai/code/session_01KNp4i1AwzcBwncqJTh1Uog)_