### PR TITLE
feat(audit): R-6 wave 3 — emit audit events on 8 mutating endpoints (#225)

### DIFF
--- a/scripts/ci_guards.py
+++ b/scripts/ci_guards.py
@@ -873,15 +873,9 @@ A_AUDIT_ALLOWLIST: set[str] = {
     "approvals_reject",                # 7294 — audited by ApprovalRegistry._audit (approval_rejected)
     "archive_dry_run",                 # 1574
     "audit_export",                    # 2417 — export-only, no mutation
-    "chargeback_add_center",           # 7140
-    "chargeback_add_owner",            # 7186
-    "chargeback_remove_center",        # 7179
-    "chargeback_remove_owner",         # 7199
-    "chargeback_update_center",        # 7160
     "content_duplicates_compute",      # 3318 — analytics compute
     "create_snapshot",                 # 6216
     "db_optimize",                     # 4969 — maintenance op
-    "drilldown_archive",               # 2080
     "duplicates_delete",               # 3529
     "duplicates_quarantine",           # 3484
     "duplicates_quarantine_preview",   # 3468 — dry-run
@@ -893,8 +887,6 @@ A_AUDIT_ALLOWLIST: set[str] = {
     "overview_recompute",              # 2919 — analytics compute
     "pii_scan",                        # 6410 — analytics compute
     "ransomware_test",                 # 5321 — self-test
-    "run_archive",                     # 1519
-    "run_scan",                        # 1005
     "start_export",                    # 5187 — export-only
     "syslog_test",                     # 6080 — self-test
     "test_source",                     # 987 — connectivity test

--- a/src/dashboard/api.py
+++ b/src/dashboard/api.py
@@ -1197,6 +1197,18 @@ def create_app(db, config, analytics=None, ad_lookup=None, email_notifier=None,
         _scan_results.pop(source_id, None)
         t.start()
 
+        # R-6: audit the scan trigger (the already_running early-return above
+        # is a no-op and is intentionally not audited). Best-effort so an
+        # audit outage never blocks the scan.
+        try:
+            db.insert_audit_event_simple(
+                source_id=src.id, event_type="scan_started",
+                username="dashboard", file_path=None,
+                details=f"source_name={src.name}",
+            )
+        except Exception as e:  # pragma: no cover - audit is best-effort
+            logger.warning("audit emit failed for scan_started: %s", e)
+
         return {"status": "started", "message": f"Tarama baslatildi: {src.name}"}
 
     @app.post("/api/scan/{source_id}/stop")
@@ -1689,10 +1701,28 @@ def create_app(db, config, analytics=None, ad_lookup=None, email_notifier=None,
         # Plumb the resolved dry_run override into the engine so the
         # API contract is honoured even if the engine's default
         # (config.archiving.dry_run) drifts later.
-        return engine.archive_files(
+        result = engine.archive_files(
             files, src.archive_dest, src.unc_path, src.id, archived_by,
             dry_run=effective_dry_run,
         )
+        # R-6: endpoint-level audit summary (in addition to the engine's
+        # per-file audits), mirroring archive_selective_run (#280).
+        try:
+            db.insert_audit_event_simple(
+                source_id=src.id, event_type="archive_run",
+                username=archived_by, file_path=None,
+                details=(
+                    f"archived_by={archived_by};"
+                    f"matched={len(files)};"
+                    f"archived={result.get('archived')};"
+                    f"failed={result.get('failed')};"
+                    f"total_size={result.get('total_size')};"
+                    f"dry_run={effective_dry_run}"
+                ),
+            )
+        except Exception as e:  # pragma: no cover - audit is best-effort
+            logger.warning("audit emit failed for archive_run: %s", e)
+        return result
 
     @app.post("/api/archive/dry-run")
     def archive_dry_run(data: ArchiveRequest):
@@ -2248,7 +2278,23 @@ def create_app(db, config, analytics=None, ad_lookup=None, email_notifier=None,
 
         engine = ArchiveEngine(db, config)
         archived_by = f"drilldown:{data.filter_type}"
-        return engine.archive_files(files, src.archive_dest, src.unc_path, src.id, archived_by)
+        result = engine.archive_files(files, src.archive_dest, src.unc_path, src.id, archived_by)
+        # R-6: endpoint-level audit summary (live archive; no dry_run param).
+        try:
+            db.insert_audit_event_simple(
+                source_id=src.id, event_type="drilldown_archive_run",
+                username=archived_by, file_path=None,
+                details=(
+                    f"filter_type={data.filter_type};"
+                    f"matched={len(files)};"
+                    f"archived={result.get('archived')};"
+                    f"failed={result.get('failed')};"
+                    f"total_size={result.get('total_size')}"
+                ),
+            )
+        except Exception as e:  # pragma: no cover - audit is best-effort
+            logger.warning("audit emit failed for drilldown_archive_run: %s", e)
+        return result
 
     # --- EXPORT API (XLS / PDF) ---
 
@@ -7533,6 +7579,18 @@ def create_app(db, config, analytics=None, ad_lookup=None, email_notifier=None,
         except Exception as e:
             # UNIQUE name violation surfaces as IntegrityError on SQLite.
             raise HTTPException(409, f"Eklenemedi: {e}")
+        # R-6: chargeback config is global (no source) -> source_id=None.
+        try:
+            db.insert_audit_event_simple(
+                source_id=None, event_type="chargeback_center_added",
+                username="admin", file_path=None,
+                details=(
+                    f"center_id={cid};name={name};"
+                    f"cost_per_gb_month={body.get('cost_per_gb_month') or 0}"
+                ),
+            )
+        except Exception as e:  # pragma: no cover - audit is best-effort
+            logger.warning("audit emit failed for chargeback_center_added: %s", e)
         return {"id": cid, "ok": True}
 
     @app.put("/api/chargeback/centers/{center_id}")
@@ -7552,6 +7610,17 @@ def create_app(db, config, analytics=None, ad_lookup=None, email_notifier=None,
             existing = _chargeback_report().get_center(center_id)
             if not existing:
                 raise HTTPException(404, "cost_center bulunamadi")
+        # R-6: only audit a real update (ok=True); a no-op/idempotent path
+        # leaves ok=False and writes no fake audit row.
+        if ok:
+            try:
+                db.insert_audit_event_simple(
+                    source_id=None, event_type="chargeback_center_updated",
+                    username="admin", file_path=None,
+                    details=f"center_id={center_id};changes={fields}",
+                )
+            except Exception as e:  # pragma: no cover - audit is best-effort
+                logger.warning("audit emit failed for chargeback_center_updated: %s", e)
         return {"ok": True}
 
     @app.delete("/api/chargeback/centers/{center_id}")
@@ -7559,6 +7628,17 @@ def create_app(db, config, analytics=None, ad_lookup=None, email_notifier=None,
         # Idempotent: deleting an already-deleted center returns ok=True
         # with deleted=False so callers can call this on stale UI state.
         deleted = _chargeback_report().remove_center(center_id)
+        # R-6: only audit when a row was actually deleted (idempotent no-op
+        # path writes no fake audit row).
+        if deleted:
+            try:
+                db.insert_audit_event_simple(
+                    source_id=None, event_type="chargeback_center_removed",
+                    username="admin", file_path=None,
+                    details=f"center_id={center_id}",
+                )
+            except Exception as e:  # pragma: no cover - audit is best-effort
+                logger.warning("audit emit failed for chargeback_center_removed: %s", e)
         return {"ok": True, "deleted": deleted}
 
     @app.post("/api/chargeback/centers/{center_id}/owners")
@@ -7572,6 +7652,17 @@ def create_app(db, config, analytics=None, ad_lookup=None, email_notifier=None,
             added = _chargeback_report().add_owner(center_id, pat)
         except ValueError as e:
             raise HTTPException(404 if "bulunamadi" in str(e) else 400, str(e))
+        # R-6: only audit when a mapping was actually added (already-present
+        # pattern returns added=False -> idempotent no-op, no audit row).
+        if added:
+            try:
+                db.insert_audit_event_simple(
+                    source_id=None, event_type="chargeback_owner_added",
+                    username="admin", file_path=None,
+                    details=f"center_id={center_id};owner_pattern={pat}",
+                )
+            except Exception as e:  # pragma: no cover - audit is best-effort
+                logger.warning("audit emit failed for chargeback_owner_added: %s", e)
         return {"ok": True, "added": added, "owner_pattern": pat}
 
     @app.delete("/api/chargeback/centers/{center_id}/owners/{owner_pattern:path}")
@@ -7579,6 +7670,16 @@ def create_app(db, config, analytics=None, ad_lookup=None, email_notifier=None,
         # ``:path`` lets the pattern contain backslashes / slashes from the
         # owner field (e.g. ``CONTOSO\jdoe``) without double-encoding.
         deleted = _chargeback_report().remove_owner(center_id, owner_pattern)
+        # R-6: only audit a real deletion (idempotent no-op writes no row).
+        if deleted:
+            try:
+                db.insert_audit_event_simple(
+                    source_id=None, event_type="chargeback_owner_removed",
+                    username="admin", file_path=None,
+                    details=f"center_id={center_id};owner_pattern={owner_pattern}",
+                )
+            except Exception as e:  # pragma: no cover - audit is best-effort
+                logger.warning("audit emit failed for chargeback_owner_removed: %s", e)
         return {"ok": True, "deleted": deleted}
 
     @app.get("/api/chargeback/{source_id}")


### PR DESCRIPTION
## Why (EPIC #225, R-6)

R-6 is the audit-backlog flush of the `A_AUDIT_ALLOWLIST` (Rule 4: every mutating endpoint emits an audit event). Wave 1 (#276) and wave 2 (#280) drained 46→31. **This wave drains the 8 remaining real-mutation candidates → 23.**

## What

8 mutating endpoints now call `db.insert_audit_event_simple` on the success path — snake_case `event_type`, **status-guarded** so idempotent no-op paths write no fake row, `try/except` so an audit outage never rolls back the mutation:

| Endpoint | event_type | Notes |
|---|---|---|
| `run_scan` | `scan_started` | `already_running` early-return is a no-op, not audited |
| `run_archive` | `archive_run` | includes `dry_run` flag; "no files" path not audited |
| `drilldown_archive` | `drilldown_archive_run` | live archive, no dry_run param |
| `chargeback_add_center` | `chargeback_center_added` | |
| `chargeback_update_center` | `chargeback_center_updated` | guarded on `ok` (real update only) |
| `chargeback_remove_center` | `chargeback_center_removed` | guarded on `deleted` |
| `chargeback_add_owner` | `chargeback_owner_added` | guarded on `added` (re-add is no-op) |
| `chargeback_remove_owner` | `chargeback_owner_removed` | guarded on `deleted` |

- **Chargeback config is global** (not per-source) → `source_id=None`, matching the #276 convention for non-source-scoped admin actions. Every `ChargebackReport` mutation method returns a `bool`/id, so the status-guards are exact.
- The two archive endpoints emit an **endpoint-level summary** (matched/archived/failed/total_size) **in addition to** the engine's per-file audits — same shape as `archive_selective_run` (#280).

## Verification

- `python scripts/ci_guards.py` → **12/12**; `A-AUDIT` allowlist **31 → 23** (8 drained, no offenders).
- `python -m py_compile src/dashboard/api.py scripts/ci_guards.py` → OK.
- `pytest tests/test_audit_chain*.py` → **15 passed**. (fastapi-gated endpoint tests run in CI — fastapi absent in the dev sandbox.)
- Pre-existing local-only failure `test_ci_guards.py::test_s_shape_respects_noqa_marker` (UnicodeDecodeError, Windows cp1252) reproduces on pristine master — unrelated to this change.

## Remaining allowlist (23) — all justified

`approvals_*` (audited by ApprovalRegistry._audit — don't double-emit) · analytics-compute (`*_recompute`, `*_compute`, `pii_scan`) · self-test/connectivity (`*_test`, `test_source`) · export-only (`audit_export`, `start_export`) · dry-run/preview · `open_folder` (no DB write) · `db_optimize`. Plus `create_snapshot`, `duplicates_delete`, `duplicates_quarantine`, `notify_users_run_now`, `notifications_send_to` — candidates for a later pass.

Refs #225.

---
_Generated by [Claude Code](https://claude.ai/code)_