### PR TITLE
build(deps-dev): bump pytest floor to >=9.0.3 (clears GHSA-6w46-j5rx-g56g)

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -10,8 +10,13 @@
 # and don't pull pytest + plugins into the runtime image.
 #
 # ──────────────────────────────────────────────────────────────────────
-# Test runner. Pinned to a recent 8.x; compatible with Python 3.10-3.12.
-pytest>=8.0,<9
+# Test runner. Floor raised to 9.0.3 to clear GHSA-6w46-j5rx-g56g (pytest
+# vulnerable tmpdir handling, MODERATE; fixed in 9.0.3). The `<10` cap keeps
+# the major-version pin convention so an unvetted pytest 10 can't silently
+# break CI. Compatible with Python 3.9+. Suite verified under 9.0.3: a
+# differential run (8.4.2 vs 9.0.3) showed identical pass/fail, i.e. no
+# pytest-9 regressions.
+pytest>=9.0.3,<10
 
 # Optional: handy when iterating locally to print captured stdout on
 # failure with nicer formatting. Not required by the suite itself.


### PR DESCRIPTION
## Why

**GHSA-6w46-j5rx-g56g** — pytest "vulnerable tmpdir handling" (MODERATE, vulnerable `<9.0.3`, fixed in **9.0.3**). It's the **only outstanding OSV/Dependabot advisory** on master (the "1 moderate" line printed on every `git push`). The dev-only test runner was capped at `pytest>=8.0,<9`, so it could never reach the fix.

## What

`requirements-dev.txt`: `pytest>=8.0,<9` → `pytest>=9.0.3,<10`. The `<10` cap keeps the established major-version-pin convention so an unvetted pytest 10 can't silently break CI later. Dev-dep only — production `requirements*.txt` untouched. `docker/Dockerfile.test` and the Windows CI job both `pip install -r requirements-dev.txt`, so the floor flows through with no other edits.

## Validation — major bump introduces no test regressions

CI can't fully vet this on its own (the Linux Docker pytest job flakes at `apt-get` build time; the Windows job runs only 2 files; both are `continue-on-error`). So I validated locally with a **differential run**:

- Ran `tests/` (minus elasticsearch + bench, `--continue-on-collection-errors` to skip fastapi-absent modules) under **pytest 8.4.2** and **pytest 9.0.3** in the same env (Python 3.14).
- **Identical result both times: 620 passed, 42 failed, 43 skipped.** `comm` diff of the failed-test sets is **empty in both directions** → no test fails *specifically* under pytest 9. The 42 failures are pre-existing env-only issues (Python 3.14 + missing optional deps like fastapi/imagehash), not pytest-version-dependent.

So the floor raise is safe w.r.t. pytest compatibility.

---
_Generated by [Claude Code](https://claude.ai/code)_