### PR TITLE
feat(treemap): per-extension "wasted %" (stale-bytes share) — punch-list #3

### DIFF
--- a/src/analyzer/type_analyzer.py
+++ b/src/analyzer/type_analyzer.py
@@ -26,6 +26,13 @@ class TypeAnalyzer:
             r["avg_size_formatted"] = format_size(r["avg_size"])
             r["min_size_formatted"] = format_size(r["min_size"])
             r["max_size_formatted"] = format_size(r["max_size"])
+            # Treemap "wasted %": stale (1yr+ unaccessed) bytes as a share of
+            # this extension's total. Guard div-by-zero for zero-size types.
+            stale = r.get("stale_size") or 0
+            total = r.get("total_size") or 0
+            r["stale_size"] = stale
+            r["stale_size_formatted"] = format_size(stale)
+            r["wasted_pct"] = round(stale / total * 100, 1) if total else 0.0
 
         logger.info("Dosya türü analizi tamamlandı: %d uzantı", len(results))
         return results

--- a/src/dashboard/static/index.html
+++ b/src/dashboard/static/index.html
@@ -832,6 +832,7 @@ body.sidebar-open { overflow: hidden; }
                 <option value="extension">Dosya Turu</option>
                 <option value="age">Yas (Erisim)</option>
                 <option value="size">Boyut</option>
+                <option value="wasted">Israf % (eski)</option>
             </select>
             <label style="margin-left:12px">Boyut:</label>
             <select id="treemap-size" onchange="renderTreemap()" style="width:130px">
@@ -4247,6 +4248,10 @@ async function loadTreemap() {
                     count: d.count || 0,
                     size: d.size_bytes || 0,
                     avg: d.count ? Math.round((d.size_bytes || 0) / d.count) : 0,
+                    // Partial summary has no per-dir stale breakdown; wasted %
+                    // populates on the full post-scan load.
+                    wastedPct: 0,
+                    stale: 0,
                 })),
             };
             treemapZoomPath = null;
@@ -4285,6 +4290,8 @@ function buildTreeFromTypes(types, summary) {
         count: t.file_count,
         size: t.total_size || 0,
         avg: t.avg_size || 0,
+        wastedPct: t.wasted_pct || 0,
+        stale: t.stale_size || 0,
     }));
     return { name: 'Root', children };
 }
@@ -4329,7 +4336,9 @@ function renderTreemap() {
         ? d3.scaleOrdinal(d3.schemeTableau10)
         : colorMode === 'age'
             ? d3.scaleSequential(d3.interpolateYlOrRd).domain([0, root.leaves().length])
-            : d3.scaleSequential(d3.interpolateBlues).domain([0, d3.max(root.leaves(), d => d.value)]);
+            : colorMode === 'wasted'
+                ? d3.scaleSequential(d3.interpolateReds).domain([0, 100])
+                : d3.scaleSequential(d3.interpolateBlues).domain([0, d3.max(root.leaves(), d => d.value)]);
 
     const tooltip = document.getElementById('treemap-tooltip');
 
@@ -4338,7 +4347,7 @@ function renderTreemap() {
     leaf.append('rect')
         .attr('width', d => Math.max(0, d.x1 - d.x0))
         .attr('height', d => Math.max(0, d.y1 - d.y0))
-        .attr('fill', (d, i) => colorMode === 'extension' ? colorScale(d.data.extension || d.data.name) : colorMode === 'size' ? colorScale(d.value) : colorScale(i))
+        .attr('fill', (d, i) => colorMode === 'extension' ? colorScale(d.data.extension || d.data.name) : colorMode === 'size' ? colorScale(d.value) : colorMode === 'wasted' ? colorScale(d.data.wastedPct || 0) : colorScale(i))
         .attr('rx', 2).attr('opacity', 0.85)
         .style('cursor', 'pointer')
         .on('mousemove', (event, d) => {
@@ -4348,7 +4357,8 @@ function renderTreemap() {
             tooltip.innerHTML = `<div class="tt-name">${escapeHtml(d.data.name)}</div>
                 <div class="tt-row"><span>Dosya Sayisi</span><span>${formatNum(d.data.count)}</span></div>
                 <div class="tt-row"><span>Toplam Boyut</span><span>${formatSize(d.data.size)}</span></div>
-                <div class="tt-row"><span>Ortalama</span><span>${formatSize(d.data.avg)}</span></div>`;
+                <div class="tt-row"><span>Ortalama</span><span>${formatSize(d.data.avg)}</span></div>
+                <div class="tt-row"><span>Bosa Giden (eski)</span><span>%${(d.data.wastedPct || 0).toFixed(1)} (${formatSize(d.data.stale || 0)})</span></div>`;
         })
         .on('mouseleave', () => { tooltip.style.display = 'none'; });
 

--- a/src/storage/database.py
+++ b/src/storage/database.py
@@ -1762,7 +1762,16 @@ class Database:
         return results
 
     def get_type_analysis(self, source_id: int, scan_id: int) -> list:
-        """Dosya turu analizi."""
+        """Dosya turu analizi.
+
+        Includes ``stale_size`` per extension — bytes whose
+        ``last_access_time`` is 1+ year old — so the treemap can surface a
+        per-type "wasted %" (stale data is the archive-candidate proxy). Uses
+        the SAME 365-day cutoff as ``compute_scan_summary`` so the treemap's
+        wasted figure and the Overview "stale" KPI agree.
+        """
+        from datetime import datetime, timedelta
+        stale_cutoff = (datetime.now() - timedelta(days=365)).strftime('%Y-%m-%d')
         with self.get_cursor() as cur:
             cur.execute("""
                 SELECT
@@ -1773,12 +1782,15 @@ class Database:
                     MIN(file_size) as min_size,
                     MAX(file_size) as max_size,
                     MIN(creation_time) as oldest,
-                    MAX(creation_time) as newest
+                    MAX(creation_time) as newest,
+                    COALESCE(SUM(CASE WHEN last_access_time IS NOT NULL
+                        AND last_access_time <= ? THEN file_size ELSE 0 END), 0)
+                        as stale_size
                 FROM scanned_files
                 WHERE source_id = ? AND scan_id = ?
                 GROUP BY extension
                 ORDER BY total_size DESC
-            """, (source_id, scan_id))
+            """, (stale_cutoff, source_id, scan_id))
             return cur.fetchall()
 
     def get_size_analysis(self, source_id: int, scan_id: int, buckets: dict) -> list:

--- a/tests/test_treemap_wasted_pct.py
+++ b/tests/test_treemap_wasted_pct.py
@@ -1,0 +1,105 @@
+"""Tests for the treemap per-extension "wasted %" feature (punch-list #3).
+
+``get_type_analysis`` gained a ``stale_size`` aggregate (bytes whose
+``last_access_time`` is 1+ year old, the same 365-day cutoff the Overview
+"stale" KPI uses) and ``TypeAnalyzer.analyze`` derives ``wasted_pct`` from it.
+The treemap colours/labels each extension node by that percentage.
+
+These tests need no fastapi — they exercise the storage + analyzer layers
+directly, so they run everywhere the suite runs.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+
+import pytest
+
+from src.storage.database import Database
+from src.analyzer.type_analyzer import TypeAnalyzer
+
+
+def _ymd(days_ago: int) -> str:
+    """A ``YYYY-MM-DD HH:MM:SS`` string ``days_ago`` days in the past."""
+    return (datetime.now() - timedelta(days=days_ago)).strftime("%Y-%m-%d %H:%M:%S")
+
+
+@pytest.fixture
+def seeded(tmp_path):
+    """DB with one source, one scan, and a hand-picked file mix.
+
+    docx: one stale (400d) + one fresh (10d)  -> wasted is partial.
+    pdf : two stale (800d, 400d), one zero-size stale -> wasted 100% of bytes.
+    tmp : one with NULL last_access_time -> never counts as stale.
+    """
+    db = Database({"path": str(tmp_path / "wasted.db")})
+    db.connect()
+    with db.get_cursor() as cur:
+        cur.execute("INSERT INTO sources(name, unc_path) VALUES('s1', 'x')")
+        scan_id = db.create_scan_run(1)
+        rows = [
+            # source, scan, name, path, rel, ext, size, last_access
+            (1, scan_id, "a.docx", "a.docx", "a.docx", "docx", 1000, _ymd(400)),
+            (1, scan_id, "b.docx", "b.docx", "b.docx", "docx", 500, _ymd(10)),
+            (1, scan_id, "c.pdf", "c.pdf", "c.pdf", "pdf", 2000, _ymd(800)),
+            (1, scan_id, "d.pdf", "d.pdf", "d.pdf", "pdf", 0, _ymd(400)),
+            (1, scan_id, "e.tmp", "e.tmp", "e.tmp", "tmp", 100, None),
+        ]
+        cur.executemany(
+            "INSERT INTO scanned_files"
+            "(source_id, scan_id, file_name, file_path, relative_path, "
+            " extension, file_size, last_access_time) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            rows,
+        )
+    yield db, scan_id
+    db.close()
+
+
+def test_get_type_analysis_includes_stale_size(seeded):
+    db, scan_id = seeded
+    by = {r["extension"]: r for r in db.get_type_analysis(1, scan_id)}
+    # docx: only the 400-day file (1000 B) is stale; the 10-day one is fresh.
+    assert by["docx"]["total_size"] == 1500
+    assert by["docx"]["stale_size"] == 1000
+    # pdf: both files are 1+ year old; bytes = 2000 (+0 for the zero-size one).
+    assert by["pdf"]["total_size"] == 2000
+    assert by["pdf"]["stale_size"] == 2000
+
+
+def test_null_last_access_is_not_stale(seeded):
+    db, scan_id = seeded
+    by = {r["extension"]: r for r in db.get_type_analysis(1, scan_id)}
+    # A NULL last_access_time must NOT be counted as stale (it's "unknown",
+    # not "old") — mirrors compute_scan_summary's `IS NOT NULL` guard.
+    assert by["tmp"]["stale_size"] == 0
+
+
+def test_wasted_pct_derivation(seeded):
+    db, scan_id = seeded
+    by = {r["extension"]: r for r in TypeAnalyzer(db).analyze(1, scan_id)}
+    assert by["docx"]["wasted_pct"] == pytest.approx(round(1000 / 1500 * 100, 1))
+    assert by["pdf"]["wasted_pct"] == 100.0
+    assert by["tmp"]["wasted_pct"] == 0.0
+    # Formatted helper is present for the (unused-by-treemap-but-handy) UI.
+    assert by["docx"]["stale_size_formatted"]
+
+
+def test_wasted_pct_zero_when_no_bytes(tmp_path):
+    """A type whose total_size is 0 must not divide-by-zero -> wasted 0.0."""
+    db = Database({"path": str(tmp_path / "z.db")})
+    db.connect()
+    with db.get_cursor() as cur:
+        cur.execute("INSERT INTO sources(name, unc_path) VALUES('s1', 'x')")
+        scan_id = db.create_scan_run(1)
+        cur.execute(
+            "INSERT INTO scanned_files"
+            "(source_id, scan_id, file_name, file_path, relative_path, "
+            " extension, file_size, last_access_time) "
+            "VALUES (1, ?, 'z.log', 'z.log', 'z.log', 'log', 0, ?)",
+            (scan_id, _ymd(800)),
+        )
+    by = {r["extension"]: r for r in TypeAnalyzer(db).analyze(1, scan_id)}
+    assert by["log"]["total_size"] == 0
+    assert by["log"]["wasted_pct"] == 0.0
+    db.close()


### PR DESCRIPTION
## Why (deep-research punch-list #3)

The treemap showed size/count per file type but gave no signal about how much of that space is *dead weight*. This adds a **"wasted %"** per extension — the share of bytes that are **stale (1+ year since last access)**, the natural archive-candidate proxy. So at a glance an operator sees which file types are mostly cold and worth archiving.

"Wasted" is defined as **stale only**, reusing the **same 365-day cutoff** as `compute_scan_summary`, so the treemap figure agrees with the Overview "stale" KPI (no second, conflicting definition).

## What

**Backend**
- `get_type_analysis()` adds a per-extension `stale_size` aggregate: `SUM(CASE WHEN last_access_time IS NOT NULL AND last_access_time <= cutoff THEN file_size ELSE 0 END)`. A NULL access time is "unknown", not stale — mirrors the summary's `IS NOT NULL` guard.
- `TypeAnalyzer.analyze()` derives `wasted_pct = stale/total*100` (div-by-zero guarded for zero-byte types) + `stale_size_formatted`.

**Frontend (treemap)**
- New **"Israf % (eski)"** colour mode → red heatmap keyed on `wasted_pct` (0–100).
- Tooltip gains a **"Bosa Giden (eski)"** row: `%NN.N (<stale size>)`.
- Nodes carry `wastedPct`/`stale`; partial-scan (`by_directory`) nodes default to 0 (the partial summary has no per-dir stale breakdown; populates on the full post-scan load).

## Validation

- **`tests/test_treemap_wasted_pct.py`** (new, 4 cases): stale aggregate, NULL-not-stale, `wasted_pct` derivation, zero-byte div-by-zero. No fastapi needed → runs in the Docker Linux job. **4/4 pass** locally (pytest 9.0.3).
- **node --check** on the extracted `index.html` script → OK (mandatory per repo discipline).
- **ci_guards 12/12**, HTML-BUDGET unchanged (131/140 — no new innerHTML write; the existing stored-ref tooltip assignment is only extended).
- `py_compile` on the two changed Python files → OK.

Net-new, additive feature — no behaviour change to existing colour modes or other reports.

---
_Generated by [Claude Code](https://claude.ai/code)_