### PR TITLE
fix(growth): back-fill scan_runs.total_size/total_files in compute_scan_summary (#291)

### DIFF
--- a/src/storage/database.py
+++ b/src/storage/database.py
@@ -3708,10 +3708,21 @@ class Database:
         # would silently lose summary_json for that scan (audit C1-3).
         now = now_dt.strftime("%Y-%m-%d %H:%M:%S")
         payload = json.dumps(summary, ensure_ascii=False, separators=(",", ":"))
+        # #291 — back-fill the scan_runs.total_files / total_size COLUMNS from
+        # the authoritative post-enrich totals computed above. complete_scan_run
+        # sets these columns right after the MFT walk, which runs BEFORE the
+        # size-enrich pass, so total_size lands as 0 (sizes still unknown) and is
+        # never updated again. Growth analysis reads MAX(total_size) from these
+        # columns (src/storage/database.py::get_growth_stats + the DuckDB twin),
+        # so without this back-fill the size series is flat-zero even though
+        # summary_json carries the real total. Written in the same retried UPDATE
+        # as summary_json so the column and the JSON can never disagree.
         self._execute_write_with_retry(
             "compute_scan_summary.UPDATE",
-            "UPDATE scan_runs SET summary_json=?, summary_computed_at=? WHERE id=?",
-            (payload, now, scan_id),
+            "UPDATE scan_runs SET summary_json=?, summary_computed_at=?, "
+            "total_files=?, total_size=? WHERE id=?",
+            (payload, now, summary.get("total_files", 0),
+             summary.get("total_size", 0), scan_id),
         )
 
         summary["scan_id"] = scan_id

--- a/tests/test_growth_total_size_backfill.py
+++ b/tests/test_growth_total_size_backfill.py
@@ -1,0 +1,87 @@
+"""Regression test for issue #291: growth analysis empty / flat size series.
+
+Root cause (confirmed on the customer's 31 GB / 2.9M-file box): `complete_scan_run`
+writes the `scan_runs.total_files` / `total_size` COLUMNS right after the MFT walk
+— which runs BEFORE the size-enrich pass — so `total_size` lands as 0 and is never
+updated. `get_growth_stats` reads `MAX(total_size)` from those columns, so the
+growth size series was flat-zero even though `summary_json` carried the real total
+(17.8 TB on the box).
+
+Fix: `compute_scan_summary` now back-fills the columns from the authoritative
+post-enrich totals it already computes, in the same UPDATE that persists
+`summary_json`. These tests pin that behaviour. No fastapi needed.
+"""
+
+from __future__ import annotations
+
+from src.storage.database import Database
+
+
+def _seed(db, sizes, *, started_at="2026-05-26 21:11:17"):
+    """One source + one completed scan + scanned_files with the given sizes.
+
+    Simulates the bug by forcing the scan_runs.total_size column to 0 (as
+    complete_scan_run would when sizes are still un-enriched at walk time).
+    Returns the scan_id.
+    """
+    with db.get_cursor() as cur:
+        cur.execute("INSERT INTO sources(name, unc_path) VALUES('e', 'x')")
+    scan_id = db.create_scan_run(1)
+    with db.get_cursor() as cur:
+        cur.execute(
+            "UPDATE scan_runs SET status='completed', started_at=?, "
+            "total_files=?, total_size=0 WHERE id=?",
+            (started_at, len(sizes), scan_id),
+        )
+        cur.executemany(
+            "INSERT INTO scanned_files"
+            "(source_id, scan_id, file_name, file_path, relative_path, "
+            " extension, file_size, last_access_time) "
+            "VALUES (1, ?, ?, ?, ?, 'dat', ?, '2026-05-01 00:00:00')",
+            [(scan_id, f"f{i}.dat", f"f{i}.dat", f"f{i}.dat", s)
+             for i, s in enumerate(sizes)],
+        )
+    return scan_id
+
+
+def test_compute_scan_summary_backfills_total_size(tmp_path):
+    db = Database({"path": str(tmp_path / "g.db")})
+    db.connect()
+    scan_id = _seed(db, [1000, 2000, 3000])
+
+    # Precondition: the column is the buggy 0 even though rows have real sizes.
+    with db.get_read_cursor() as cur:
+        before = cur.execute(
+            "SELECT total_files, total_size FROM scan_runs WHERE id=?", (scan_id,)
+        ).fetchone()
+    assert before["total_size"] == 0
+
+    summary = db.compute_scan_summary(scan_id)
+    assert summary["total_size"] == 6000  # SUM of the row sizes
+
+    # The column is now back-filled to match summary_json (the fix).
+    with db.get_read_cursor() as cur:
+        after = cur.execute(
+            "SELECT total_files, total_size FROM scan_runs WHERE id=?", (scan_id,)
+        ).fetchone()
+    assert after["total_size"] == 6000
+    assert after["total_files"] == 3
+    db.close()
+
+
+def test_growth_stats_size_series_nonzero_after_summary(tmp_path):
+    """End-to-end: after compute_scan_summary, get_growth_stats reports the real
+    total_size instead of 0 (the customer-visible symptom)."""
+    db = Database({"path": str(tmp_path / "g2.db")})
+    db.connect()
+    scan_id = _seed(db, [10, 20, 70])  # total 100
+    db.compute_scan_summary(scan_id)
+
+    g = db.get_growth_stats(1)
+    assert g["total_scans"] == 1
+    # The daily bucket for the scan day must carry the real size, not 0.
+    daily = g["daily"]
+    assert daily, "expected at least one daily growth point"
+    assert daily[-1]["total_size"] == 100
+    assert daily[-1]["total_files"] == 3
+    db.close()


### PR DESCRIPTION
Closes #291.

## On-box diagnosis (bridge, burculogo — 31 GB / 2.9M-file E:\ box, master `cae2aa3`)
`scan_runs` for the source: 3 completed scans, `total_files` column populated (~2.88M) but **`total_size` column = 0 for all 3**, while `summary_json.total_size` = **17.8 TB**. `get_growth_stats` reads `MAX(total_size)` from the column → size series flat-zero → growth page looks empty. (The original "<2 scans" hypothesis was **refuted** on-box — there are 3.)

## Root cause
`complete_scan_run` sets the `total_files`/`total_size` columns right after the MFT walk, which runs **before** the size-enrich pass — so `total_size` is summed from still-zero file sizes and is never updated again. `summary_json` is computed later (post-enrich) with the real total; the columns are not.

## Fix
`compute_scan_summary` now back-fills `scan_runs.total_files`/`total_size` from the authoritative post-enrich totals it already computes, in the **same retried UPDATE** that persists `summary_json` (so column and JSON can never disagree). Future scans self-heal; existing scans heal on the next `compute_scan_summary` run, or via a one-time on-box `UPDATE ... = json_extract(summary_json,...)`.

## Validation
- `tests/test_growth_total_size_backfill.py` (2 cases): column back-fill + growth size series non-zero end-to-end. **2/2 pass** (pytest 9.0.3). No fastapi needed → runs in CI.
- `test_scan_summary_v2` + summary suite: no regression (fastapi-absent endpoint tests aside).
- `py_compile`, `ci_guards` **12/12**.

## Follow-up (not in this PR)
- One-time on-box back-fill of the 3 existing scans (their `summary_json` already has the right total).
- Optional frontend empty-state hint for the genuine <2-completed-scans case (deferred to keep this a clean DB-only change; tracked in #291).

---
_Generated by [Claude Code](https://claude.ai/code)_