### PR TITLE
feat(pii): add dashboard "PII Tara" trigger + background scan mode (#292)

### DIFF
--- a/src/dashboard/api.py
+++ b/src/dashboard/api.py
@@ -6769,11 +6769,26 @@ def create_app(db, config, analytics=None, ad_lookup=None, email_notifier=None,
         app.state.retention_engine = engine
         return engine
 
+    # #292 — track in-flight background PII scans per source so the UI button
+    # can't launch duplicates. Module-ish closure state, same pattern as the
+    # scanner's _scan_threads.
+    _pii_scan_threads: dict = {}
+
     @app.post("/api/compliance/pii/scan/{source_id}")
     async def pii_scan(source_id: int,
                        max_files: Optional[int] = None,
-                       overwrite_existing: bool = False):
-        """Run PiiEngine.scan_source against the latest scan of source_id."""
+                       overwrite_existing: bool = False,
+                       background: bool = False):
+        """Run PiiEngine.scan_source against the latest scan of source_id.
+
+        #292 — ``background=true`` spawns a daemon thread and returns
+        immediately (``{"status": "started"}``). A full content scan on a
+        multi-million-file share runs for minutes/hours; blocking the HTTP
+        request would hang the dashboard's "PII Tara" button. scan_source
+        writes findings incrementally, so the PII page surfaces them growing
+        on refresh. Default (``false``) keeps the original blocking behaviour
+        used by the API and the test-suite.
+        """
         engine = _get_pii_engine()
         src = _get_source(db, source_id)
         import asyncio
@@ -6784,6 +6799,24 @@ def create_app(db, config, analytics=None, ad_lookup=None, email_notifier=None,
                 max_files=max_files,
                 overwrite_existing=overwrite_existing,
             )
+
+        if background:
+            existing = _pii_scan_threads.get(src.id)
+            if existing is not None and existing.is_alive():
+                return {"status": "already_running", "source_id": src.id}
+
+            def _bg():
+                try:
+                    _run()
+                except Exception as e:  # pragma: no cover - defensive
+                    logger.warning(
+                        "background PII scan failed for source %s: %s", src.id, e
+                    )
+
+            t = threading.Thread(target=_bg, daemon=True)
+            _pii_scan_threads[src.id] = t
+            t.start()
+            return {"status": "started", "source_id": src.id}
 
         result = await asyncio.get_event_loop().run_in_executor(None, _run)
         result["source_id"] = src.id

--- a/src/dashboard/static/index.html
+++ b/src/dashboard/static/index.html
@@ -1241,6 +1241,7 @@ body.sidebar-open { overflow: hidden; }
             <select id="pii-pattern-filter" onchange="loadPii()" style="width:160px">
                 <option value="">Tum pattern'ler</option>
             </select>
+            <button class="btn" id="pii-scan-btn" onclick="runPiiScan()" style="display:none">PII Tara</button>
             <button class="btn btn-outline" onclick="openPiiSubjectModal()">Subject Export (GDPR)</button>
         </div>
     </div>
@@ -7294,11 +7295,16 @@ async function loadPii() {
     const listEl = document.getElementById('pii-list-container');
     if (!listEl) return;
     const banner = document.getElementById('pii-disabled-banner');
+    const scanBtn = document.getElementById('pii-scan-btn');
 
-    // Rule 8: surface the exact config key when the feature is off.
+    // Rule 8: surface the exact config key when the feature is off, and only
+    // expose the "PII Tara" trigger when the feature is actually enabled
+    // (the scan endpoint would refuse otherwise). #292
     try {
         const cfg = await api('/compliance/config', { silent: true });
-        if (banner) banner.style.display = (cfg && cfg.pii && cfg.pii.enabled) ? 'none' : 'block';
+        const enabled = !!(cfg && cfg.pii && cfg.pii.enabled);
+        if (banner) banner.style.display = enabled ? 'none' : 'block';
+        if (scanBtn) scanBtn.style.display = enabled ? '' : 'none';
     } catch (e) { /* banner stays hidden if the flag fetch fails */ }
 
     const sourceId = document.getElementById('pii-source')?.value || '';
@@ -7336,6 +7342,27 @@ async function loadPii() {
                 <tbody>${body}</tbody>
             </table>
         </div>`);
+}
+
+// #292 — kick off a PII content scan from the dashboard. Previously the page
+// told operators to "run a scan first" but offered no way to; the scan was
+// API-only. Runs in the background (large shares take minutes/hours) and
+// surfaces findings incrementally on refresh.
+async function runPiiScan() {
+    const sid = document.getElementById('pii-source')?.value || '';
+    if (!sid) { notify('Once bir kaynak secin — PII taramasi kaynak bazlidir', 'warning'); return; }
+    if (!confirm('PII taramasi dosya iceriklerini okur ve buyuk paylasimlarda uzun surebilir.\nArka planda baslatilsin mi? Bulgular islendikce listede gorunur.')) return;
+    try {
+        const r = await api(`/compliance/pii/scan/${encodeURIComponent(sid)}?background=true`, { method: 'POST' });
+        if (r && r.status === 'already_running') {
+            notify('Bu kaynak icin PII taramasi zaten calisiyor', 'info');
+        } else {
+            notify('PII taramasi arka planda baslatildi — bulgular islendikce gorunecek', 'success');
+        }
+        setTimeout(loadPii, 6000);
+    } catch (e) {
+        notify('PII taramasi baslatilamadi: ' + (e.message || 'hata'), 'error');
+    }
 }
 
 function loadRetention() {


### PR DESCRIPTION
Closes #292.

## On-box diagnosis (bridge, burculogo)
`compliance.pii.enabled = false`, `pii_findings = 0`, no `PII scan_source` line in the log → the feature is **off** and no PII scan was ever run. The page already renders the Rule-8 "feature off" banner + a "Bulgu yok… once bir tarama calistirin" message — but there was **no way to launch a PII scan from the dashboard**. The only trigger (`POST /api/compliance/pii/scan/{id}`) was API-only, and it **blocks** until the whole content scan finishes (hours on a 2.9M-file share), so it couldn't be wired to a simple button.

## What
- **Frontend** — a **"PII Tara"** button on the PII page, shown only when `compliance.pii.enabled` is true (toggled off the same `/compliance/config` fetch as the banner). `runPiiScan()` POSTs the scan for the selected source (per-source — prompts to pick one), warns that content-scanning a large share is slow, then refreshes to surface incremental findings.
- **Backend** — `pii_scan` gains `background=true`: spawns a daemon thread and returns `{"status":"started"}` immediately (with an `already_running` guard), mirroring the scanner's `run_scan` pattern. `scan_source` writes findings **incrementally**, so they appear on refresh. The default blocking path is unchanged for the API and tests.

## Note (operational)
This makes the feature **usable from the UI**; actually getting findings still requires the operator to **enable `compliance.pii.enabled`** (a privacy/perf decision — content scan of 2.9M files) and run it. On the box the feature is currently off by design.

## Validation
- **node --check** on `index.html` → OK; **py_compile**; **ci_guards 12/12** (A-AWAIT + A-AUDIT green; `pii_scan` stays allowlisted).
- `scan_source` (the work the thread does) is covered by `tests/test_pii_engine.py`. The added background branch is a thin thread wrapper over it (same pattern as `run_scan`).

## Possible follow-up (not here)
PII content scanning is privacy-sensitive; consider emitting an audit event on scan start (currently `pii_scan` is allowlisted as analytics-compute).

---
_Generated by [Claude Code](https://claude.ai/code)_